### PR TITLE
Pull out common code between Add Trips & Reroute.

### DIFF
--- a/configurations/default/messages.yml
+++ b/configurations/default/messages.yml
@@ -35,6 +35,9 @@ scenario:
   editTitle: Edit scenario
   route: Route
 transitEditor:
+  startEdit: Edit route geometry
+  stopEdit: Stop editing
+  bidirectional: Bidirectional
   followRoad: Follow streets
   makeStop: make stop
   makeControlPoint: make control point

--- a/lib/components/modification/__tests__/__snapshots__/add-trip-pattern.js.snap
+++ b/lib/components/modification/__tests__/__snapshots__/add-trip-pattern.js.snap
@@ -1,57 +1,81 @@
 exports[`Component > Modification > AddTripPattern renders correctly 1`] = `
 <div>
-  <a
-    className="btn btn-warning btn-block"
-    href="#"
-    onClick={[Function]}
-    target={undefined}>
-    <i
-      className="fa fa-times-circle fa-fw " />
-     Stop editing
-  </a>
-  <div
-    className="checkbox">
-    <label>
-      <input
-        defaultChecked={true}
-        onChange={[Function]}
-        type="checkbox" />
+  <div>
+    <a
+      className="btn btn-warning btn-block"
+      href="#"
+      onClick={[Function]}
+      target={undefined}>
+      <i
+        className="fa fa-times-circle fa-fw " />
        
-      Extend from end
-    </label>
-  </div>
-  <div
-    className="checkbox">
-    <label>
-      <input
-        defaultChecked={true}
-        onChange={[Function]}
-        type="checkbox" />
-       
-      Follow streets
-    </label>
-  </div>
-  <div
-    className="checkbox">
-    <label>
-      <input
-        defaultChecked={false}
-        onChange={[Function]}
-        type="checkbox" />
-       
-      Create stops automatically
-    </label>
-  </div>
-  <div
-    className="checkbox">
-    <label>
-      <input
-        checked={false}
-        onChange={[Function]}
-        type="checkbox" />
-       
-      Bidirectional
-    </label>
+      Stop editing
+    </a>
+    <div
+      className="checkbox">
+      <label>
+        <input
+          defaultChecked={true}
+          onChange={[Function]}
+          type="checkbox" />
+         
+        Create stops automatically
+      </label>
+    </div>
+    <div
+      className="form-group">
+      <label>
+        Stop spacing
+      </label>
+      <div
+        className="InputWithUnits">
+        <input
+          className="form-control"
+          min={0}
+          name={undefined}
+          onChange={[Function]}
+          placeholder="meters"
+          type="number"
+          value={400} />
+        <span
+          className="InputUnits">
+          meters
+        </span>
+      </div>
+    </div>
+    <div
+      className="checkbox">
+      <label>
+        <input
+          defaultChecked={true}
+          onChange={[Function]}
+          type="checkbox" />
+         
+        Extend from end
+      </label>
+    </div>
+    <div
+      className="checkbox">
+      <label>
+        <input
+          defaultChecked={true}
+          onChange={[Function]}
+          type="checkbox" />
+         
+        Follow streets
+      </label>
+    </div>
+    <div
+      className="checkbox">
+      <label>
+        <input
+          checked={false}
+          onChange={[Function]}
+          type="checkbox" />
+         
+        Bidirectional
+      </label>
+    </div>
   </div>
   <div>
     <section

--- a/lib/components/modification/__tests__/__snapshots__/add-trip-pattern.js.snap
+++ b/lib/components/modification/__tests__/__snapshots__/add-trip-pattern.js.snap
@@ -7,7 +7,7 @@ exports[`Component > Modification > AddTripPattern renders correctly 1`] = `
       onClick={[Function]}
       target={undefined}>
       <i
-        className="fa fa-times-circle fa-fw " />
+        className="fa fa-stop-circle fa-fw " />
        
       Stop editing
     </a>
@@ -47,6 +47,17 @@ exports[`Component > Modification > AddTripPattern renders correctly 1`] = `
       className="checkbox">
       <label>
         <input
+          checked={false}
+          onChange={[Function]}
+          type="checkbox" />
+         
+        Bidirectional
+      </label>
+    </div>
+    <div
+      className="checkbox">
+      <label>
+        <input
           defaultChecked={true}
           onChange={[Function]}
           type="checkbox" />
@@ -63,17 +74,6 @@ exports[`Component > Modification > AddTripPattern renders correctly 1`] = `
           type="checkbox" />
          
         Follow streets
-      </label>
-    </div>
-    <div
-      className="checkbox">
-      <label>
-        <input
-          checked={false}
-          onChange={[Function]}
-          type="checkbox" />
-         
-        Bidirectional
       </label>
     </div>
   </div>

--- a/lib/components/modification/__tests__/__snapshots__/edit-alignment.js.snap
+++ b/lib/components/modification/__tests__/__snapshots__/edit-alignment.js.snap
@@ -6,7 +6,7 @@ exports[`Component > Modification > Edit Alignment renders correctly 1`] = `
     onClick={[Function]}
     target={undefined}>
     <i
-      className="fa fa-times-circle fa-fw " />
+      className="fa fa-stop-circle fa-fw " />
      
     Stop editing
   </a>
@@ -46,7 +46,18 @@ exports[`Component > Modification > Edit Alignment renders correctly 1`] = `
     className="checkbox">
     <label>
       <input
-        defaultChecked={true}
+        checked={false}
+        onChange={[Function]}
+        type="checkbox" />
+       
+      Bidirectional
+    </label>
+  </div>
+  <div
+    className="checkbox">
+    <label>
+      <input
+        defaultChecked={undefined}
         onChange={[Function]}
         type="checkbox" />
        
@@ -62,17 +73,6 @@ exports[`Component > Modification > Edit Alignment renders correctly 1`] = `
         type="checkbox" />
        
       Follow streets
-    </label>
-  </div>
-  <div
-    className="checkbox">
-    <label>
-      <input
-        checked={false}
-        onChange={[Function]}
-        type="checkbox" />
-       
-      Bidirectional
     </label>
   </div>
 </div>

--- a/lib/components/modification/__tests__/__snapshots__/edit-alignment.js.snap
+++ b/lib/components/modification/__tests__/__snapshots__/edit-alignment.js.snap
@@ -1,0 +1,79 @@
+exports[`Component > Modification > Edit Alignment renders correctly 1`] = `
+<div>
+  <a
+    className="btn btn-warning btn-block"
+    href="#"
+    onClick={[Function]}
+    target={undefined}>
+    <i
+      className="fa fa-times-circle fa-fw " />
+     
+    Stop editing
+  </a>
+  <div
+    className="checkbox">
+    <label>
+      <input
+        defaultChecked={true}
+        onChange={[Function]}
+        type="checkbox" />
+       
+      Create stops automatically
+    </label>
+  </div>
+  <div
+    className="form-group">
+    <label>
+      Stop spacing
+    </label>
+    <div
+      className="InputWithUnits">
+      <input
+        className="form-control"
+        min={0}
+        name={undefined}
+        onChange={[Function]}
+        placeholder="meters"
+        type="number"
+        value={400} />
+      <span
+        className="InputUnits">
+        meters
+      </span>
+    </div>
+  </div>
+  <div
+    className="checkbox">
+    <label>
+      <input
+        defaultChecked={true}
+        onChange={[Function]}
+        type="checkbox" />
+       
+      Extend from end
+    </label>
+  </div>
+  <div
+    className="checkbox">
+    <label>
+      <input
+        defaultChecked={undefined}
+        onChange={[Function]}
+        type="checkbox" />
+       
+      Follow streets
+    </label>
+  </div>
+  <div
+    className="checkbox">
+    <label>
+      <input
+        checked={false}
+        onChange={[Function]}
+        type="checkbox" />
+       
+      Bidirectional
+    </label>
+  </div>
+</div>
+`;

--- a/lib/components/modification/__tests__/__snapshots__/editor.js.snap
+++ b/lib/components/modification/__tests__/__snapshots__/editor.js.snap
@@ -27,7 +27,7 @@ exports[`Component > Modification > ModificationEditor renders correctly 1`] = `
             onClick={[Function]}
             target={undefined}>
             <i
-              className="fa fa-times-circle fa-fw " />
+              className="fa fa-stop-circle fa-fw " />
              
             Stop editing
           </a>
@@ -67,6 +67,17 @@ exports[`Component > Modification > ModificationEditor renders correctly 1`] = `
             className="checkbox">
             <label>
               <input
+                checked={false}
+                onChange={[Function]}
+                type="checkbox" />
+               
+              Bidirectional
+            </label>
+          </div>
+          <div
+            className="checkbox">
+            <label>
+              <input
                 defaultChecked={true}
                 onChange={[Function]}
                 type="checkbox" />
@@ -83,17 +94,6 @@ exports[`Component > Modification > ModificationEditor renders correctly 1`] = `
                 type="checkbox" />
                
               Follow streets
-            </label>
-          </div>
-          <div
-            className="checkbox">
-            <label>
-              <input
-                checked={false}
-                onChange={[Function]}
-                type="checkbox" />
-               
-              Bidirectional
             </label>
           </div>
         </div>

--- a/lib/components/modification/__tests__/__snapshots__/editor.js.snap
+++ b/lib/components/modification/__tests__/__snapshots__/editor.js.snap
@@ -20,58 +20,82 @@ exports[`Component > Modification > ModificationEditor renders correctly 1`] = `
           value="Test Modification" />
       </div>
       <div>
-        <a
-          className="btn btn-warning btn-block"
-          href="#"
-          onClick={[Function]}
-          target={undefined}>
-          <i
-            className="fa fa-times-circle fa-fw " />
-           Stop editing
-        </a>
-        <div
-          className="checkbox">
-          <label>
-            <input
-              defaultChecked={true}
-              onChange={[Function]}
-              type="checkbox" />
+        <div>
+          <a
+            className="btn btn-warning btn-block"
+            href="#"
+            onClick={[Function]}
+            target={undefined}>
+            <i
+              className="fa fa-times-circle fa-fw " />
              
-            Extend from end
-          </label>
-        </div>
-        <div
-          className="checkbox">
-          <label>
-            <input
-              defaultChecked={true}
-              onChange={[Function]}
-              type="checkbox" />
-             
-            Follow streets
-          </label>
-        </div>
-        <div
-          className="checkbox">
-          <label>
-            <input
-              defaultChecked={false}
-              onChange={[Function]}
-              type="checkbox" />
-             
-            Create stops automatically
-          </label>
-        </div>
-        <div
-          className="checkbox">
-          <label>
-            <input
-              checked={false}
-              onChange={[Function]}
-              type="checkbox" />
-             
-            Bidirectional
-          </label>
+            Stop editing
+          </a>
+          <div
+            className="checkbox">
+            <label>
+              <input
+                defaultChecked={true}
+                onChange={[Function]}
+                type="checkbox" />
+               
+              Create stops automatically
+            </label>
+          </div>
+          <div
+            className="form-group">
+            <label>
+              Stop spacing
+            </label>
+            <div
+              className="InputWithUnits">
+              <input
+                className="form-control"
+                min={0}
+                name={undefined}
+                onChange={[Function]}
+                placeholder="meters"
+                type="number"
+                value={400} />
+              <span
+                className="InputUnits">
+                meters
+              </span>
+            </div>
+          </div>
+          <div
+            className="checkbox">
+            <label>
+              <input
+                defaultChecked={true}
+                onChange={[Function]}
+                type="checkbox" />
+               
+              Extend from end
+            </label>
+          </div>
+          <div
+            className="checkbox">
+            <label>
+              <input
+                defaultChecked={true}
+                onChange={[Function]}
+                type="checkbox" />
+               
+              Follow streets
+            </label>
+          </div>
+          <div
+            className="checkbox">
+            <label>
+              <input
+                checked={false}
+                onChange={[Function]}
+                type="checkbox" />
+               
+              Bidirectional
+            </label>
+          </div>
         </div>
         <div>
           <section

--- a/lib/components/modification/__tests__/__snapshots__/reroute.js.snap
+++ b/lib/components/modification/__tests__/__snapshots__/reroute.js.snap
@@ -35,39 +35,82 @@ exports[`Component > Modification > Reroute renders correctly 1`] = `
       </div>
     </div>
   </div>
-  <a
-    className="btn btn-warning btn-block"
-    href="#"
-    onClick={[Function]}
-    target={undefined}>
-    <i
-      className="fa fa-pencil fa-fw " />
-     Edit alignment
-  </a>
-  <div
-    className="checkbox">
-    <label>
-      <input
-        checked={true}
-        onChange={[Function]}
-        type="checkbox" />
+  <div>
+    <a
+      className="btn btn-warning btn-block"
+      href="#"
+      onClick={[Function]}
+      target={undefined}>
+      <i
+        className="fa fa-times-circle fa-fw " />
        
-      Create stops automatically
-    </label>
-  </div>
-  <div
-    className="form-group">
-    <label>
-      Stop spacing
-    </label>
-    <input
-      className="form-control"
-      min={0}
-      name={undefined}
-      onChange={[Function]}
-      placeholder="Stop spacing"
-      type="number"
-      value={400} />
+      Stop editing
+    </a>
+    <div
+      className="checkbox">
+      <label>
+        <input
+          defaultChecked={true}
+          onChange={[Function]}
+          type="checkbox" />
+         
+        Create stops automatically
+      </label>
+    </div>
+    <div
+      className="form-group">
+      <label>
+        Stop spacing
+      </label>
+      <div
+        className="InputWithUnits">
+        <input
+          className="form-control"
+          min={0}
+          name={undefined}
+          onChange={[Function]}
+          placeholder="meters"
+          type="number"
+          value={400} />
+        <span
+          className="InputUnits">
+          meters
+        </span>
+      </div>
+    </div>
+    <div
+      className="checkbox">
+      <label>
+        <input
+          defaultChecked={true}
+          onChange={[Function]}
+          type="checkbox" />
+         
+        Extend from end
+      </label>
+    </div>
+    <div
+      className="checkbox">
+      <label>
+        <input
+          defaultChecked={undefined}
+          onChange={[Function]}
+          type="checkbox" />
+         
+        Follow streets
+      </label>
+    </div>
+    <div
+      className="checkbox">
+      <label>
+        <input
+          checked={undefined}
+          onChange={[Function]}
+          type="checkbox" />
+         
+        Bidirectional
+      </label>
+    </div>
   </div>
   <div>
     <div

--- a/lib/components/modification/__tests__/__snapshots__/reroute.js.snap
+++ b/lib/components/modification/__tests__/__snapshots__/reroute.js.snap
@@ -42,7 +42,7 @@ exports[`Component > Modification > Reroute renders correctly 1`] = `
       onClick={[Function]}
       target={undefined}>
       <i
-        className="fa fa-times-circle fa-fw " />
+        className="fa fa-stop-circle fa-fw " />
        
       Stop editing
     </a>
@@ -82,6 +82,17 @@ exports[`Component > Modification > Reroute renders correctly 1`] = `
       className="checkbox">
       <label>
         <input
+          checked={undefined}
+          onChange={[Function]}
+          type="checkbox" />
+         
+        Bidirectional
+      </label>
+    </div>
+    <div
+      className="checkbox">
+      <label>
+        <input
           defaultChecked={true}
           onChange={[Function]}
           type="checkbox" />
@@ -98,17 +109,6 @@ exports[`Component > Modification > Reroute renders correctly 1`] = `
           type="checkbox" />
          
         Follow streets
-      </label>
-    </div>
-    <div
-      className="checkbox">
-      <label>
-        <input
-          checked={undefined}
-          onChange={[Function]}
-          type="checkbox" />
-         
-        Bidirectional
       </label>
     </div>
   </div>

--- a/lib/components/modification/__tests__/edit-alignment.js
+++ b/lib/components/modification/__tests__/edit-alignment.js
@@ -1,0 +1,27 @@
+/* global describe, expect, it, jest */
+
+import renderer from 'react-test-renderer'
+import React from 'react'
+
+import {mockModification} from '../../../utils/mock-data'
+
+import EditAlignment from '../edit-alignment'
+
+describe('Component > Modification > Edit Alignment', function () {
+  it('renders correctly', function () {
+    const props = {
+      mapState: {
+        modificationId: mockModification.id
+      },
+      modification: mockModification,
+      setMapState: jest.fn(),
+      update: jest.fn()
+    }
+
+    const tree = renderer.create(
+      <EditAlignment {...props} />
+    ).toJSON()
+
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/lib/components/modification/add-trip-pattern.js
+++ b/lib/components/modification/add-trip-pattern.js
@@ -24,6 +24,7 @@ export default class AddTripPattern extends DeepEqual {
     return (
       <div>
         <EditAlignment
+          extendFromEnd={mapState && mapState.modificationId === modification.id ? mapState.extendFromEnd : true}
           mapState={mapState}
           modification={modification}
           setMapState={setMapState}

--- a/lib/components/modification/add-trip-pattern.js
+++ b/lib/components/modification/add-trip-pattern.js
@@ -2,14 +2,10 @@
 
 import React, {PropTypes} from 'react'
 
-import {DEFAULT_STOP_SPACING_METERS} from '../../constants'
-import {Button} from '../buttons'
 import DeepEqual from '../deep-equal'
-import Icon from '../icon'
-import {Checkbox, Number} from '../input'
+
+import EditAlignment from './edit-alignment'
 import Timetables from './timetables'
-import {ADD_TRIP_PATTERN} from '../../utils/modification-types'
-import messages from '../../utils/messages'
 
 export default class AddTripPattern extends DeepEqual {
   static propTypes = {
@@ -23,139 +19,15 @@ export default class AddTripPattern extends DeepEqual {
     update: PropTypes.func.isRequired
   }
 
-  state = getStateFromProps(this.props)
-
-  componentWillReceiveProps (newProps) {
-    this.setState({
-      ...this.state,
-      ...getStateFromProps(newProps)
-    })
-  }
-
-  /** edit this modification on the map */
-  editOnMap = () => {
-    const {modification, setMapState} = this.props
-    const {extendFromEnd, followRoad, spacing} = this.state
-    setMapState({
-      allowExtend: true,
-      extendFromEnd,
-      followRoad,
-      modificationId: modification.id,
-      spacing,
-      state: ADD_TRIP_PATTERN
-    })
-  }
-
-  stopEditingOnMap = () => {
-    this.props.setMapState({
-      modificationId: null,
-      state: null
-    })
-  }
-
-  _updateMapState (props) {
-    const {mapState, setMapState} = this.props
-    if (mapState.state === ADD_TRIP_PATTERN) {
-      setMapState({
-        ...mapState,
-        ...props
-      })
-    }
-  }
-
-  onExtendFromEndChange = (e) => {
-    this._updateMapState({extendFromEnd: e.target.checked})
-  }
-
-  onFollowRoadChange = (e) => {
-    this._updateMapState({followRoad: e.target.checked})
-  }
-
-  /** toggle whether a pattern is bidirectional */
-  onBidirectionalChange = (e) => {
-    this.props.update({bidirectional: e.target.checked})
-  }
-
-  /** toggle whether stops should be created automatically */
-  onAutoCreateStopsChange = (e) => {
-    const {modification, update} = this.props
-    const spacing = e.target.checked ? DEFAULT_STOP_SPACING_METERS : 0
-
-    this._updateMapState({spacing})
-
-    update({
-      segments: modification.segments.map((segment) => ({...segment, spacing}))
-    })
-  }
-
-  /** set stop spacing */
-  onStopSpacingChange = (e) => {
-    const {modification, update} = this.props
-    const {segments} = modification
-    const spacing = parseInt(e.target.value, 10)
-
-    this._updateMapState({spacing})
-
-    if (spacing !== null && !isNaN(spacing) && spacing >= 50) {
-      // only set stop spacing if current spacing is not zero
-      if (segments.length > 0 && segments[0].spacing > 0) {
-        update({segments: segments.map((segment) => ({...segment, spacing}))})
-      }
-    }
-  }
-
   render () {
-    const {modification, mapState, numberOfStops, segmentDistances, update} = this.props
-    const {createStopsAutomatically, extendFromEnd, followRoad, spacing} = this.state
-    const isEditing = mapState.modificationId === modification.id
+    const {modification, mapState, numberOfStops, segmentDistances, setMapState, update} = this.props
     return (
       <div>
-        {!isEditing
-          ? <Button
-            block
-            onClick={this.editOnMap}
-            style='warning'
-            ><Icon type='pencil' /> Edit route geometry
-          </Button>
-          : <Button
-            block
-            onClick={this.stopEditingOnMap}
-            style='warning'
-            ><Icon type='times-circle' /> Stop editing
-          </Button>}
-
-        {isEditing &&
-          <Checkbox
-            defaultChecked={extendFromEnd}
-            label={messages.transitEditor.extendFromEnd}
-            onChange={this.onExtendFromEndChange}
-            />}
-
-        {isEditing &&
-          <Checkbox
-            defaultChecked={followRoad}
-            label={messages.transitEditor.followRoad}
-            onChange={this.onFollowRoadChange}
-            />}
-
-        <Checkbox
-          defaultChecked={createStopsAutomatically}
-          label={messages.transitEditor.autoCreateStops}
-          onChange={this.onAutoCreateStopsChange}
-          />
-
-        {createStopsAutomatically &&
-          <Number
-            value={spacing}
-            label={messages.transitEditor.stopSpacingMeters}
-            onChange={this.onStopSpacingChange}
-            units='meters'
-            />}
-
-        <Checkbox
-          checked={modification.bidirectional}
-          label='Bidirectional'
-          onChange={this.onBidirectionalChange}
+        <EditAlignment
+          mapState={mapState}
+          modification={modification}
+          setMapState={setMapState}
+          update={update}
           />
 
         <Timetables
@@ -166,18 +38,5 @@ export default class AddTripPattern extends DeepEqual {
           />
       </div>
     )
-  }
-}
-
-function getStateFromProps ({
-  mapState,
-  modification
-}) {
-  const spacing = modification.segments.length > 0 ? modification.segments[0].spacing : 0
-  return {
-    createStopsAutomatically: spacing > 0,
-    extendFromEnd: mapState && mapState.modificationId === modification.id ? mapState.extendFromEnd : true,
-    followRoad: mapState.followRoad,
-    spacing
   }
 }

--- a/lib/components/modification/edit-alignment.js
+++ b/lib/components/modification/edit-alignment.js
@@ -14,6 +14,7 @@ import {Checkbox, Number} from '../input'
 
 export default class EditAlignment extends DeepEqual {
   static propTypes = {
+    extendFromEnd: PropTypes.bool.isRequired,
     mapState: PropTypes.object.isRequired,
     modification: PropTypes.object.isRequired,
 
@@ -35,8 +36,8 @@ export default class EditAlignment extends DeepEqual {
    * Edit this modification on the map
    */
   _editOnMap = () => {
-    const {modification, setMapState} = this.props
-    const {allowExtend, extendFromEnd, followRoad, spacing} = this.state
+    const {extendFromEnd, modification, setMapState} = this.props
+    const {allowExtend, followRoad, spacing} = this.state
     setMapState({
       allowExtend,
       extendFromEnd,
@@ -112,8 +113,8 @@ export default class EditAlignment extends DeepEqual {
   }
 
   render () {
-    const {modification} = this.props
-    const {createStopsAutomatically, extendFromEnd, followRoad, isEditing, spacing} = this.state
+    const {extendFromEnd, modification} = this.props
+    const {createStopsAutomatically, followRoad, isEditing, spacing} = this.state
 
     return (
       <div>
@@ -183,7 +184,6 @@ function getStateFromProps ({
   return {
     allowExtend: modification.toStop == null || modification.fromStop == null,
     createStopsAutomatically: spacing > 0,
-    extendFromEnd: isEditingAlignment ? modification.toStop == null && mapState.extendFromEnd : false,
     followRoad: mapState.followRoad,
     isEditing: mapState.modificationId === modification.id,
     isEditingAlignment,

--- a/lib/components/modification/edit-alignment.js
+++ b/lib/components/modification/edit-alignment.js
@@ -1,0 +1,192 @@
+import React, {PropTypes} from 'react'
+
+import {
+  DEFAULT_STOP_SPACING_METERS,
+  MAP_STATE_TRANSIT_EDITOR,
+  REROUTE
+} from '../../constants'
+import messages from '../../utils/messages'
+
+import {Button} from '../buttons'
+import DeepEqual from '../deep-equal'
+import Icon from '../icon'
+import {Checkbox, Number} from '../input'
+
+export default class EditAlignment extends DeepEqual {
+  static propTypes = {
+    mapState: PropTypes.object.isRequired,
+    modification: PropTypes.object.isRequired,
+
+    // actions
+    setMapState: PropTypes.func.isRequired,
+    update: PropTypes.func.isRequired
+  }
+
+  state = getStateFromProps(this.props)
+
+  componentWillReceiveProps (newProps) {
+    this.setState({
+      ...this.state,
+      ...getStateFromProps(newProps)
+    })
+  }
+
+  /**
+   * Edit this modification on the map
+   */
+  _editOnMap = () => {
+    const {modification, setMapState} = this.props
+    const {allowExtend, extendFromEnd, followRoad, spacing} = this.state
+    setMapState({
+      allowExtend,
+      extendFromEnd,
+      followRoad,
+      modificationId: modification.id,
+      spacing,
+      state: MAP_STATE_TRANSIT_EDITOR
+    })
+  }
+
+  _stopEditingOnMap = () => {
+    this.props.setMapState({
+      modificationId: null,
+      state: null
+    })
+  }
+
+  _updateMapState (props) {
+    const {mapState, setMapState} = this.props
+    if (mapState.state === MAP_STATE_TRANSIT_EDITOR) {
+      setMapState({
+        ...mapState,
+        ...props
+      })
+    }
+  }
+
+  _onExtendFromEndChange = (e) => {
+    this._updateMapState({extendFromEnd: e.target.checked})
+  }
+
+  _onFollowRoadChange = (e) => {
+    this._updateMapState({followRoad: e.target.checked})
+  }
+
+  /**
+   * Toggle whether a pattern is bidirectional.
+   */
+  _onBidirectionalChange = (e) => {
+    this.props.update({bidirectional: e.target.checked})
+  }
+
+  /**
+   * Toggle whether stops should be created automatically.
+   */
+  _onAutoCreateStopsChange = (e) => {
+    const {modification, update} = this.props
+    const spacing = e.target.checked ? DEFAULT_STOP_SPACING_METERS : 0
+
+    this._updateMapState({spacing})
+
+    update({
+      segments: modification.segments.map((segment) => ({...segment, spacing}))
+    })
+  }
+
+  /**
+   * Set stop spacing
+   */
+  _onStopSpacingChange = (e) => {
+    const {modification, update} = this.props
+    const {segments} = modification
+    const spacing = parseInt(e.target.value, 10)
+
+    this._updateMapState({spacing})
+
+    if (spacing !== null && !isNaN(spacing) && spacing >= 50) {
+      // only set stop spacing if current spacing is not zero
+      if (segments.length > 0 && segments[0].spacing > 0) {
+        update({segments: segments.map((segment) => ({...segment, spacing}))})
+      }
+    }
+  }
+
+  render () {
+    const {modification} = this.props
+    const {createStopsAutomatically, extendFromEnd, followRoad, isEditing, spacing} = this.state
+
+    return (
+      <div>
+        {!isEditing
+          ? <Button
+            block
+            onClick={this._editOnMap}
+            style='warning'
+            ><Icon type='pencil' /> {messages.transitEditor.startEdit}
+          </Button>
+          : <Button
+            block
+            onClick={this._stopEditingOnMap}
+            style='warning'
+            ><Icon type='times-circle' /> {messages.transitEditor.stopEdit}
+          </Button>}
+
+        <Checkbox
+          defaultChecked={createStopsAutomatically}
+          label={messages.transitEditor.autoCreateStops}
+          onChange={this._onAutoCreateStopsChange}
+          />
+
+        {createStopsAutomatically &&
+          <Number
+            value={spacing}
+            label={messages.transitEditor.stopSpacingMeters}
+            onChange={this._onStopSpacingChange}
+            units='meters'
+            />}
+
+        {modification.type !== REROUTE && isEditing &&
+          <Checkbox
+            defaultChecked={extendFromEnd}
+            label={messages.transitEditor.extendFromEnd}
+            onChange={this._onExtendFromEndChange}
+            />}
+
+        {isEditing &&
+          <Checkbox
+            defaultChecked={followRoad}
+            label={messages.transitEditor.followRoad}
+            onChange={this._onFollowRoadChange}
+            />}
+
+        {modification.type !== REROUTE &&
+          <Checkbox
+            checked={modification.bidirectional}
+            label={messages.transitEditor.bidirectional}
+            onChange={this._onBidirectionalChange}
+            />}
+      </div>
+    )
+  }
+}
+
+/**
+  * Extract current stop spacing from a modification
+  */
+function getStateFromProps ({
+  mapState,
+  modification
+}) {
+  const isEditingAlignment = mapState && mapState.modificationId === modification.id && mapState.state === MAP_STATE_TRANSIT_EDITOR
+  const spacing = modification.segments.length > 0 ? modification.segments[0].spacing : DEFAULT_STOP_SPACING_METERS
+
+  return {
+    allowExtend: modification.toStop == null || modification.fromStop == null,
+    createStopsAutomatically: spacing > 0,
+    extendFromEnd: isEditingAlignment ? modification.toStop === null && mapState.extendFromEnd : true,
+    followRoad: mapState.followRoad,
+    isEditing: mapState.modificationId === modification.id,
+    isEditingAlignment,
+    spacing
+  }
+}

--- a/lib/components/modification/edit-alignment.js
+++ b/lib/components/modification/edit-alignment.js
@@ -183,7 +183,7 @@ function getStateFromProps ({
   return {
     allowExtend: modification.toStop == null || modification.fromStop == null,
     createStopsAutomatically: spacing > 0,
-    extendFromEnd: isEditingAlignment ? modification.toStop === null && mapState.extendFromEnd : true,
+    extendFromEnd: isEditingAlignment ? modification.toStop == null && mapState.extendFromEnd : false,
     followRoad: mapState.followRoad,
     isEditing: mapState.modificationId === modification.id,
     isEditingAlignment,

--- a/lib/components/modification/edit-alignment.js
+++ b/lib/components/modification/edit-alignment.js
@@ -128,7 +128,7 @@ export default class EditAlignment extends DeepEqual {
             block
             onClick={this._stopEditingOnMap}
             style='warning'
-            ><Icon type='times-circle' /> {messages.transitEditor.stopEdit}
+            ><Icon type='stop-circle' /> {messages.transitEditor.stopEdit}
           </Button>}
 
         <Checkbox
@@ -145,6 +145,13 @@ export default class EditAlignment extends DeepEqual {
             units='meters'
             />}
 
+        {modification.type !== REROUTE &&
+          <Checkbox
+            checked={modification.bidirectional}
+            label={messages.transitEditor.bidirectional}
+            onChange={this._onBidirectionalChange}
+            />}
+
         {modification.type !== REROUTE && isEditing &&
           <Checkbox
             defaultChecked={extendFromEnd}
@@ -157,13 +164,6 @@ export default class EditAlignment extends DeepEqual {
             defaultChecked={followRoad}
             label={messages.transitEditor.followRoad}
             onChange={this._onFollowRoadChange}
-            />}
-
-        {modification.type !== REROUTE &&
-          <Checkbox
-            checked={modification.bidirectional}
-            label={messages.transitEditor.bidirectional}
-            onChange={this._onBidirectionalChange}
             />}
       </div>
     )

--- a/lib/components/modification/reroute.js
+++ b/lib/components/modification/reroute.js
@@ -23,7 +23,7 @@ export default class Reroute extends Component {
     update: PropTypes.func.isRequired
   }
 
-  onSelectorChange = ({feed, routes, trips}) => {
+  _onSelectorChange = ({feed, routes, trips}) => {
     const {update} = this.props
     update({
       feed,
@@ -32,7 +32,7 @@ export default class Reroute extends Component {
     })
   }
 
-  selectFromStop = (e) => {
+  _selectFromStop = (e) => {
     this.props.setMapState({
       state: SINGLE_STOP_SELECTION,
       modification: this.props.modification,
@@ -40,7 +40,7 @@ export default class Reroute extends Component {
     })
   }
 
-  selectToStop = (e) => {
+  _selectToStop = (e) => {
     this.props.setMapState({
       state: SINGLE_STOP_SELECTION,
       modification: this.props.modification,
@@ -51,24 +51,37 @@ export default class Reroute extends Component {
   render () {
     const {feeds, feedsById, mapState, modification, segmentDistances, setMapState, stops, update} = this.props
     const selectedFeed = feedsById[modification.feed]
+    const hasFeedAndRoutes = selectedFeed && modification.routes
+    const fromStopLabel = `From stop: ${modification.fromStop ? selectedFeed.stopsById[modification.fromStop].stop_name : '(none)'}`
+    const toStopLabel = `To stop: ${modification.toStop ? selectedFeed.stopsById[modification.toStop].stop_name : '(none)'}`
 
     let numberOfStops = stops.length
     // don't include dwells at first and last stops
     if (modification.fromStop) numberOfStops--
     if (modification.toStop) numberOfStops--
+
     return (
       <div>
         <SelectFeedRouteAndPatterns
           feeds={feeds}
-          onChange={this.onSelectorChange}
+          onChange={this._onSelectorChange}
           routes={modification.routes}
           selectedFeed={selectedFeed}
           trips={modification.trips}
           />
 
-        {this.renderStops()}
+        {hasFeedAndRoutes &&
+          <div>
+            <Group label={fromStopLabel}>
+              <Button block onClick={this._selectFromStop} style='info'><Icon type='crosshairs' /> Select</Button>
+            </Group>
+            <Group label={toStopLabel}>
+              <Button block onClick={this._selectToStop} style='info'><Icon type='crosshairs' /> Select</Button>
+            </Group>
+          </div>}
 
         <EditAlignment
+          extendFromEnd={modification.toStop == null}
           mapState={mapState}
           modification={modification}
           setMapState={setMapState}
@@ -85,25 +98,5 @@ export default class Reroute extends Component {
 
       </div>
     )
-  }
-
-  renderStops () {
-    const {feedsById, modification} = this.props
-    const selectedFeed = feedsById[modification.feed]
-    const hasFeedAndRoutes = selectedFeed && modification.routes
-    if (hasFeedAndRoutes) {
-      const fromStopLabel = `From stop: ${modification.fromStop ? selectedFeed.stopsById[modification.fromStop].stop_name : '(none)'}`
-      const toStopLabel = `To stop: ${modification.toStop ? selectedFeed.stopsById[modification.toStop].stop_name : '(none)'}`
-      return (
-        <div>
-          <Group label={fromStopLabel}>
-            <Button block onClick={this.selectFromStop} style='info'><Icon type='crosshairs' /> Select</Button>
-          </Group>
-          <Group label={toStopLabel}>
-            <Button block onClick={this.selectToStop} style='info'><Icon type='crosshairs' /> Select</Button>
-          </Group>
-        </div>
-      )
-    }
   }
 }

--- a/lib/components/modification/reroute.js
+++ b/lib/components/modification/reroute.js
@@ -4,11 +4,12 @@ import React, {Component, PropTypes} from 'react'
 
 import {Button} from '../buttons'
 import Icon from '../icon'
-import {Group, Number, Checkbox} from '../input'
+import {Group} from '../input'
+import {SINGLE_STOP_SELECTION} from '../scenario-map/state'
+
+import EditAlignment from './edit-alignment'
 import SelectFeedRouteAndPatterns from './select-feed-route-and-patterns'
 import SegmentSpeeds from './segment-speeds'
-import messages from '../../utils/messages'
-import {ADD_STOPS, SINGLE_STOP_SELECTION} from '../scenario-map/state'
 
 export default class Reroute extends Component {
   static propTypes = {
@@ -20,12 +21,6 @@ export default class Reroute extends Component {
     setMapState: PropTypes.func.isRequired,
     stops: PropTypes.array.isRequired,
     update: PropTypes.func.isRequired
-  }
-
-  state = getStateFromProps(this.props)
-
-  componentWillReceiveProps (newProps) {
-    this.setState(getStateFromProps(newProps))
   }
 
   onSelectorChange = ({feed, routes, trips}) => {
@@ -53,70 +48,14 @@ export default class Reroute extends Component {
     })
   }
 
-  editAlignment = (e) => {
-    this.props.setMapState({
-      state: ADD_STOPS,
-      modificationId: this.props.modification.id,
-      extendFromEnd: this.props.modification.toStop == null,
-      followRoad: this.state.followRoad,
-      // if one or the other end is free, allow extending the modification
-      allowExtend: this.props.modification.toStop == null || this.props.modification.fromStop == null
-    })
-  }
-
-  onFollowRoadChange = (e) => {
-    this.props.setMapState({
-      state: ADD_STOPS,
-      modificationId: this.props.modification.id,
-      extendFromEnd: this.props.modification.toStop == null,
-      followRoad: e.target.checked,
-      // if one or the other end is free, allow extending the modification
-      allowExtend: this.props.modification.toStop == null || this.props.modification.fromStop == null
-    })
-  }
-
-  stopEditingAlignment = (e) => {
-    this.props.setMapState({
-      state: null,
-      modificationId: null
-    })
-  }
-
-  /** toggle whether stops should be created automatically */
-  onAutoCreateStopsChange = (e) => {
-    const spacing = e.target.checked ? 400 : 0
-    this.setState({...this.state, spacing})
-
-    const {modification, update} = this.props
-    update({segments: modification.segments.map((s) => ({...s, spacing}))})
-  }
-
-  /** set stop spacing */
-  onStopSpacingChange = (e) => {
-    const spacing = parseInt(e.target.value, 10)
-    this.setState({...this.state, spacing})
-    const spacingIsValid = spacing !== null && isNaN(spacing) && spacing >= 50
-    if (spacingIsValid) { // user likely still typing
-      const {modification, update} = this.props
-      const {segments} = modification
-      const currentSpacingIsNotZero = segments.length > 0 && segments[0].spacing > 0
-      if (currentSpacingIsNotZero) {
-        update({segments: segments.map((segment) => ({...segment, spacing}))})
-      }
-    }
-  }
-
   render () {
-    const {feeds, modification, segmentDistances, stops, update} = this.props
-    const {followRoad, isEditingAlignment, selectedFeed, spacing} = this.state
+    const {feeds, feedsById, mapState, modification, segmentDistances, setMapState, stops, update} = this.props
+    const selectedFeed = feedsById[modification.feed]
 
     let numberOfStops = stops.length
     // don't include dwells at first and last stops
     if (modification.fromStop) numberOfStops--
     if (modification.toStop) numberOfStops--
-
-    // not using state here as otherwise checkbox would toggle on and off as you're editing the stop spacing
-    const autoCreateStops = modification.segments.length > 0 ? modification.segments[0].spacing > 0 : true
     return (
       <div>
         <SelectFeedRouteAndPatterns
@@ -129,43 +68,12 @@ export default class Reroute extends Component {
 
         {this.renderStops()}
 
-        {isEditingAlignment &&
-          <div>
-            <Button
-              block
-              onClick={this.stopEditingAlignment}
-              style='warning'
-              ><Icon type='pencil' /> Stop editing alignment
-            </Button>
-            <Checkbox
-              checked={followRoad}
-              label={messages.transitEditor.followRoad}
-              onChange={this.onFollowRoadChange}
-              />
-          </div>
-        }
-        {!isEditingAlignment &&
-          <Button
-            block
-            onClick={this.editAlignment}
-            style='warning'
-            ><Icon type='pencil' /> Edit alignment
-          </Button>
-        }
-
-        <Checkbox
-          checked={autoCreateStops}
-          label={messages.transitEditor.autoCreateStops}
-          onChange={this.onAutoCreateStopsChange}
+        <EditAlignment
+          mapState={mapState}
+          modification={modification}
+          setMapState={setMapState}
+          update={update}
           />
-
-        {autoCreateStops &&
-          <Number
-            value={spacing}
-            label={messages.transitEditor.stopSpacingMeters}
-            onChange={this.onStopSpacingChange}
-            />
-        }
 
         <SegmentSpeeds
           dwellTime={modification.dwellTime}
@@ -180,8 +88,8 @@ export default class Reroute extends Component {
   }
 
   renderStops () {
-    const {modification} = this.props
-    const {selectedFeed} = this.state
+    const {feedsById, modification} = this.props
+    const selectedFeed = feedsById[modification.feed]
     const hasFeedAndRoutes = selectedFeed && modification.routes
     if (hasFeedAndRoutes) {
       const fromStopLabel = `From stop: ${modification.fromStop ? selectedFeed.stopsById[modification.fromStop].stop_name : '(none)'}`
@@ -197,17 +105,5 @@ export default class Reroute extends Component {
         </div>
       )
     }
-  }
-}
-
-/** extract current stop spacing from a modification */
-function getStateFromProps (props) {
-  const {feedsById, mapState, modification} = props
-
-  return {
-    followRoad: mapState.followRoad,
-    isEditingAlignment: mapState && mapState.modificationId === modification.id && mapState.state === ADD_STOPS,
-    selectedFeed: feedsById[modification.feed],
-    spacing: modification.segments.length > 0 ? modification.segments[0].spacing : 400
   }
 }

--- a/lib/components/scenario-map/index.js
+++ b/lib/components/scenario-map/index.js
@@ -4,11 +4,13 @@ import React, {Component, PropTypes} from 'react'
 import {FeatureGroup} from 'react-leaflet'
 import {connect} from 'react-redux'
 
+import {MAP_STATE_TRANSIT_EDITOR} from '../../constants'
+import colors from '../../constants/colors'
+
 import {setMapState} from '../../actions'
 import {setAndRetrieveData as replaceModification} from '../../actions/modifications'
 import updateAddStopsTerminus from '../../utils/update-add-stops-terminus'
 import AddTripPatternLayer from './add-trip-pattern-layer'
-import colors from '../../constants/colors'
 import AdjustSpeedLayer from './adjust-speed-layer'
 import HopSelectPolygon from './hop-select-polygon'
 import * as modType from '../../utils/modification-types'
@@ -174,8 +176,7 @@ class ScenarioMap extends Component {
           replaceModification={(modification) => replaceModification({bundleId, modification})}
           setMapState={setMapState}
           />
-      case mapStateType.ADD_STOPS:
-      case mapStateType.ADD_TRIP_PATTERN:
+      case MAP_STATE_TRANSIT_EDITOR:
         const m = modificationsById[mapState.modificationId]
         if (m) {
           return <TransitEditor

--- a/lib/constants/index.js
+++ b/lib/constants/index.js
@@ -1,3 +1,15 @@
+/**
+ * Modification types
+ */
+export const ADD_TRIP_PATTERN = 'add-trip-pattern'
+export const ADJUST_DWELL_TIME = 'adjust-dwell-time'
+export const ADJUST_SPEED = 'adjust-speed'
+export const CONVERT_TO_FREQUENCY = 'convert-to-frequency'
+export const REMOVE_STOPS = 'remove-stops'
+export const REMOVE_TRIPS = 'remove-trips'
+export const REROUTE = 'reroute'
 
 export const DEFAULT_STOP_SPACING_METERS = 400
 export const MINIMUM_SNAP_STOP_ZOOM_LEVEL = 12
+
+export const MAP_STATE_TRANSIT_EDITOR = 'map-state-transit-editor'


### PR DESCRIPTION
The form and functionality required to begin editing the alignments of Add Trips & Reroute modifications is almost identical and therefore an appropriate place to pull out into a common component.