### PR TITLE
Remove internal authenticated fetch

### DIFF
--- a/__mocks__/isomorphic-fetch.js
+++ b/__mocks__/isomorphic-fetch.js
@@ -1,0 +1,5 @@
+const ifetch = require('isomorphic-fetch')
+
+module.exports = (url, opts) => url[0] === '/'
+  ? ifetch(`http://mockhost.com${url}`, opts)
+  : ifetch(url, opts)

--- a/lib/actions/__tests__/__snapshots__/get-feeds-routes-and-stops.js.snap
+++ b/lib/actions/__tests__/__snapshots__/get-feeds-routes-and-stops.js.snap
@@ -1,3 +1,34 @@
+exports[`actions > getFeedsRoutesAndStops should lock ui when no bundles are returned 1`] = `
+Object {
+  "payload": Object {
+    "next": [Function],
+    "url": "/api/graphql?query=%0Aquery%20routeQuery(%24bundleId%3A%20String%2C%20%24routeIds%3A%20%5BString%5D)%20%7B%0A%20%20bundle%20(bundle_id%3A%20%5B%24bundleId%5D)%20%7B%0A%20%20%20%20feeds%20%7B%0A%20%20%20%20%20%20feed_id%2C%0A%20%20%20%20%20%20routes(route_id%3A%20%24routeIds)%20%7B%0A%20%20%20%20%20%20%20%20route_id%0A%20%20%20%20%20%20%20%20route_short_name%0A%20%20%20%20%20%20%20%20route_long_name%0A%20%20%20%20%20%20%20%20patterns%20%7B%0A%20%20%20%20%20%20%20%20%20%20name%2C%0A%20%20%20%20%20%20%20%20%20%20pattern_id%2C%0A%20%20%20%20%20%20%20%20%20%20geometry%2C%0A%20%20%20%20%20%20%20%20%20%20trips%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20trip_id%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20trip_short_name%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20trip_headsign%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20start_time%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20duration%0A%20%20%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%20%20%20%20stops%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20stop_id%0A%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D&variables=%7B%22bundleId%22%3A1%2C%22routeIds%22%3A%5B%222%22%5D%7D",
+  },
+  "type": "fetch",
+}
+`;
+
+exports[`actions > getFeedsRoutesAndStops should lock ui when no bundles are returned 2`] = `
+Array [
+  Object {
+    "type": "increment outstanding fetches",
+  },
+  Promise {},
+]
+`;
+
+exports[`actions > getFeedsRoutesAndStops should lock ui when no bundles are returned 3`] = `
+Array [
+  Object {
+    "type": "decrement outstanding fetches",
+  },
+  Object {
+    "payload": "No bundles were returned.",
+    "type": "lock ui with error",
+  },
+]
+`;
+
 exports[`actions > getFeedsRoutesAndStops should work when fetching via getAllRoutesAndStops 1`] = `
 Object {
   "payload": Object {
@@ -33,12 +64,22 @@ Array [
             "route_id": "1",
             "route_short_name": "1",
           },
+          Object {
+            "label": "2 ",
+            "route_id": "2",
+            "route_short_name": "2",
+          },
         ],
         "routesById": Object {
           "1": Object {
             "label": "1 ",
             "route_id": "1",
             "route_short_name": "1",
+          },
+          "2": Object {
+            "label": "2 ",
+            "route_id": "2",
+            "route_short_name": "2",
           },
         },
         "stops": Array [
@@ -93,12 +134,22 @@ Array [
             "route_id": "1",
             "route_short_name": "1",
           },
+          Object {
+            "label": "2 ",
+            "route_id": "2",
+            "route_short_name": "2",
+          },
         ],
         "routesById": Object {
           "1": Object {
             "label": "1 ",
             "route_id": "1",
             "route_short_name": "1",
+          },
+          "2": Object {
+            "label": "2 ",
+            "route_id": "2",
+            "route_short_name": "2",
           },
         },
         "stops": Array [

--- a/lib/actions/__tests__/__snapshots__/get-feeds-routes-and-stops.js.snap
+++ b/lib/actions/__tests__/__snapshots__/get-feeds-routes-and-stops.js.snap
@@ -1,83 +1,119 @@
-exports[`actions > getFeedsRoutesAndStops should work when fetching via getAllRoutesAndStops and then getUnfetchedRoutes 1`] = `
+exports[`actions > getFeedsRoutesAndStops should work when fetching via getAllRoutesAndStops 1`] = `
 Object {
-  "type": "increment outstanding requests",
+  "payload": Object {
+    "next": [Function],
+    "url": "/api/graphql?query=%0Aquery%20dataQuery(%24bundleId%3A%20String%2C%20%24routeIds%3A%20%5BString%5D)%20%7B%0A%20%20bundle%20(bundle_id%3A%20%5B%24bundleId%5D)%20%7B%0A%20%20%20%20feeds%20%7B%0A%20%20%20%20%20%20feed_id%2C%0A%20%20%20%20%20%20checksum%2C%0A%20%20%20%20%20%20routes%20%7B%0A%20%20%20%20%20%20%20%20route_id%0A%20%20%20%20%20%20%20%20route_short_name%0A%20%20%20%20%20%20%20%20route_long_name%0A%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20detailRoutes%3A%20routes(route_id%3A%20%24routeIds)%20%7B%0A%20%20%20%20%20%20%20%20route_id%0A%20%20%20%20%20%20%20%20route_short_name%0A%20%20%20%20%20%20%20%20route_long_name%0A%20%20%20%20%20%20%20%20patterns%20%7B%0A%20%20%20%20%20%20%20%20%20%20name%2C%0A%20%20%20%20%20%20%20%20%20%20pattern_id%2C%0A%20%20%20%20%20%20%20%20%20%20geometry%2C%0A%20%20%20%20%20%20%20%20%20%20trips%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20trip_id%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20trip_short_name%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20trip_headsign%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20start_time%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20direction_id%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20duration%0A%20%20%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%20%20%20%20stops%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20stop_id%0A%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20stops%20%7B%0A%20%20%20%20%20%20%20%20stop_id%2C%0A%20%20%20%20%20%20%20%20stop_name%2C%0A%20%20%20%20%20%20%20%20stop_lat%2C%0A%20%20%20%20%20%20%20%20stop_lon%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&variables=%7B%22bundleId%22%3A1%2C%22routeIds%22%3A%5B%5D%7D",
+  },
+  "type": "fetch",
 }
 `;
 
-exports[`actions > getFeedsRoutesAndStops should work when fetching via getAllRoutesAndStops and then getUnfetchedRoutes 2`] = `
+exports[`actions > getFeedsRoutesAndStops should work when fetching via getAllRoutesAndStops 2`] = `
+Array [
+  Object {
+    "type": "increment outstanding fetches",
+  },
+  Promise {},
+]
+`;
+
+exports[`actions > getFeedsRoutesAndStops should work when fetching via getAllRoutesAndStops 3`] = `
+Array [
+  Object {
+    "type": "decrement outstanding fetches",
+  },
+  Object {
+    "payload": Array [
+      Object {
+        "checksum": "abcd",
+        "id": "1",
+        "routes": Array [
+          Object {
+            "label": "1 ",
+            "route_id": "1",
+            "route_short_name": "1",
+          },
+        ],
+        "routesById": Object {
+          "1": Object {
+            "label": "1 ",
+            "route_id": "1",
+            "route_short_name": "1",
+          },
+        },
+        "stops": Array [
+          Object {
+            "stop_id": "1",
+          },
+        ],
+        "stopsById": Object {
+          "1": Object {
+            "stop_id": "1",
+          },
+        },
+      },
+    ],
+    "type": "set feeds",
+  },
+]
+`;
+
+exports[`actions > getFeedsRoutesAndStops should work when fetching with getUnfetchedRoutes 1`] = `
 Object {
-  "type": "decrement outstanding requests",
+  "payload": Object {
+    "next": [Function],
+    "url": "/api/graphql?query=%0Aquery%20routeQuery(%24bundleId%3A%20String%2C%20%24routeIds%3A%20%5BString%5D)%20%7B%0A%20%20bundle%20(bundle_id%3A%20%5B%24bundleId%5D)%20%7B%0A%20%20%20%20feeds%20%7B%0A%20%20%20%20%20%20feed_id%2C%0A%20%20%20%20%20%20routes(route_id%3A%20%24routeIds)%20%7B%0A%20%20%20%20%20%20%20%20route_id%0A%20%20%20%20%20%20%20%20route_short_name%0A%20%20%20%20%20%20%20%20route_long_name%0A%20%20%20%20%20%20%20%20patterns%20%7B%0A%20%20%20%20%20%20%20%20%20%20name%2C%0A%20%20%20%20%20%20%20%20%20%20pattern_id%2C%0A%20%20%20%20%20%20%20%20%20%20geometry%2C%0A%20%20%20%20%20%20%20%20%20%20trips%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20trip_id%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20trip_short_name%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20trip_headsign%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20start_time%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20duration%0A%20%20%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%20%20%20%20stops%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20stop_id%0A%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D&variables=%7B%22bundleId%22%3A1%2C%22routeIds%22%3A%5B%222%22%5D%7D",
+  },
+  "type": "fetch",
 }
 `;
 
-exports[`actions > getFeedsRoutesAndStops should work when fetching via getAllRoutesAndStops and then getUnfetchedRoutes 3`] = `
-Object {
-  "payload": Array [
-    Object {
-      "checksum": "abcd",
-      "id": "1",
-      "routes": Array [
-        Object {
-          "label": "1 ",
-          "route_id": "1",
-          "route_short_name": "1",
-        },
-      ],
-      "routesById": Object {
-        "1": Object {
-          "label": "1 ",
-          "route_id": "1",
-          "route_short_name": "1",
-        },
-      },
-      "stops": Array [
-        Object {
-          "stop_id": "1",
-        },
-      ],
-      "stopsById": Object {
-        "1": Object {
-          "stop_id": "1",
-        },
-      },
-    },
-  ],
-  "type": "set feeds",
-}
+exports[`actions > getFeedsRoutesAndStops should work when fetching with getUnfetchedRoutes 2`] = `
+Array [
+  Object {
+    "type": "increment outstanding fetches",
+  },
+  Promise {},
+]
 `;
 
-exports[`actions > getFeedsRoutesAndStops should work when fetching via getAllRoutesAndStops and then getUnfetchedRoutes 4`] = `
-Object {
-  "payload": Array [
-    Object {
-      "checksum": "abcd",
-      "id": "1",
-      "routes": Array [
-        Object {
-          "label": "1 ",
-          "route_id": "1",
-          "route_short_name": "1",
+exports[`actions > getFeedsRoutesAndStops should work when fetching with getUnfetchedRoutes 3`] = `
+Array [
+  Object {
+    "type": "decrement outstanding fetches",
+  },
+  Object {
+    "payload": Array [
+      Object {
+        "checksum": "abcd",
+        "id": "1",
+        "routes": Array [
+          Object {
+            "label": "1 ",
+            "route_id": "1",
+            "route_short_name": "1",
+          },
+        ],
+        "routesById": Object {
+          "1": Object {
+            "label": "1 ",
+            "route_id": "1",
+            "route_short_name": "1",
+          },
         },
-      ],
-      "routesById": Object {
-        "1": Object {
-          "label": "1 ",
-          "route_id": "1",
-          "route_short_name": "1",
+        "stops": Array [
+          Object {
+            "stop_id": "1",
+          },
+        ],
+        "stopsById": Object {
+          "1": Object {
+            "stop_id": "1",
+          },
         },
       },
-      "stops": Array [
-        Object {
-          "stop_id": "1",
-        },
-      ],
-      "stopsById": Object {
-        "1": Object {
-          "stop_id": "1",
-        },
-      },
-    },
-  ],
-  "type": "set feeds",
-}
+    ],
+    "type": "set feeds",
+  },
+]
 `;

--- a/lib/actions/__tests__/__snapshots__/index.js.snap
+++ b/lib/actions/__tests__/__snapshots__/index.js.snap
@@ -5,46 +5,95 @@ Object {
 `;
 
 exports[`actions > index > bundle deleteBundle should work 1`] = `
-Object {
-  "payload": 1,
-  "type": "delete bundle",
-}
+Array [
+  Object {
+    "payload": 1,
+    "type": "delete bundle",
+  },
+  Object {
+    "payload": Object {
+      "next": [Function],
+      "options": Object {
+        "method": "delete",
+      },
+      "url": "/api/bundle/1",
+    },
+    "type": "fetch",
+  },
+]
 `;
 
 exports[`actions > index > bundle deleteBundle should work 2`] = `
-Object {
-  "type": "increment outstanding requests",
-}
+Array [
+  Object {
+    "payload": 1,
+    "type": "delete bundle",
+  },
+  Array [
+    Object {
+      "type": "increment outstanding fetches",
+    },
+    Promise {},
+  ],
+]
 `;
 
 exports[`actions > index > bundle deleteBundle should work 3`] = `
 Array [
   Object {
-    "type": "decrement outstanding requests",
+    "type": "increment outstanding fetches",
   },
+  Promise {},
 ]
 `;
 
 exports[`actions > index > bundle saveBundle should work 1`] = `
-Object {
-  "payload": Object {
-    "id": 1,
+Array [
+  Object {
+    "payload": Object {
+      "id": 1,
+    },
+    "type": "set bundle",
   },
-  "type": "set bundle",
-}
+  Object {
+    "payload": Object {
+      "next": [Function],
+      "options": Object {
+        "body": Object {
+          "id": 1,
+        },
+        "method": "put",
+      },
+      "url": "/api/bundle/1",
+    },
+    "type": "fetch",
+  },
+]
 `;
 
 exports[`actions > index > bundle saveBundle should work 2`] = `
-Object {
-  "type": "increment outstanding requests",
-}
+Array [
+  Object {
+    "payload": Object {
+      "id": 1,
+    },
+    "type": "set bundle",
+  },
+  Array [
+    Object {
+      "type": "increment outstanding fetches",
+    },
+    Promise {},
+  ],
+]
 `;
 
 exports[`actions > index > bundle saveBundle should work 3`] = `
 Array [
   Object {
-    "type": "decrement outstanding requests",
+    "type": "increment outstanding fetches",
   },
+  Promise {},
 ]
 `;
 

--- a/lib/actions/__tests__/__snapshots__/modifications.js.snap
+++ b/lib/actions/__tests__/__snapshots__/modifications.js.snap
@@ -1,83 +1,363 @@
 exports[`actions > modifications copyFromScenario should work 1`] = `
 Object {
-  "type": "increment outstanding requests",
+  "payload": Object {
+    "next": [Function],
+    "url": "/api/scenario/1/modifications",
+  },
+  "type": "fetch",
 }
 `;
 
 exports[`actions > modifications copyFromScenario should work 2`] = `
-Object {
-  "type": "decrement outstanding requests",
-}
-`;
-
-exports[`actions > modifications copyFromScenario should work 3`] = `
-Object {
-  "payload": Object {
-    "bidirectional": false,
-    "entries": Array [],
-    "feed": "1",
-    "name": "Test Modification",
-    "routes": Array [
-      "route1",
-    ],
-    "scenario": 2,
-    "segments": Array [],
-    "showOnMap": false,
-    "timetables": Array [
-      Object {
-        "dwellTime": 10,
-        "endTime": 57600,
-        "friday": true,
-        "headwaySecs": 900,
-        "monday": true,
-        "name": "Test timetable",
-        "patternTrips": Array [
-          "abcd",
-        ],
-        "saturday": false,
-        "segmentSpeeds": Array [],
-        "sourceTrip": "abcd",
-        "startTime": 28800,
-        "sunday": false,
-        "thursday": true,
-        "tuesday": true,
-        "wednesday": true,
-      },
-    ],
-    "trips": Array [
-      "abcd",
-    ],
-    "type": "add-trip-pattern",
-    "variants": Array [
-      0,
-    ],
-  },
-  "type": "set modification",
-}
-`;
-
-exports[`actions > modifications copyFromScenario should work 4`] = `
 Array [
   Object {
-    "type": "increment outstanding requests",
+    "type": "increment outstanding fetches",
   },
   Promise {},
 ]
 `;
 
+exports[`actions > modifications copyFromScenario should work 3`] = `
+Array [
+  Object {
+    "type": "decrement outstanding fetches",
+  },
+  Array [
+    Array [
+      Object {
+        "payload": Object {
+          "bidirectional": false,
+          "entries": Array [],
+          "feed": "1",
+          "id": "2e456370-f559-4300-a5a1-5d3cfd871ab0",
+          "name": "Test Modification",
+          "routes": Array [
+            "route1",
+          ],
+          "scenario": 2,
+          "segments": Array [],
+          "showOnMap": false,
+          "timetables": Array [
+            Object {
+              "dwellTime": 10,
+              "endTime": 57600,
+              "friday": true,
+              "headwaySecs": 900,
+              "monday": true,
+              "name": "Test timetable",
+              "patternTrips": Array [
+                "abcd",
+              ],
+              "saturday": false,
+              "segmentSpeeds": Array [],
+              "sourceTrip": "abcd",
+              "startTime": 28800,
+              "sunday": false,
+              "thursday": true,
+              "tuesday": true,
+              "wednesday": true,
+            },
+          ],
+          "trips": Array [
+            "abcd",
+          ],
+          "type": "add-trip-pattern",
+          "variants": Array [
+            0,
+          ],
+        },
+        "type": "set modification",
+      },
+      Array [
+        Object {
+          "type": "increment outstanding fetches",
+        },
+        Promise {},
+      ],
+    ],
+  ],
+]
+`;
+
 exports[`actions > modifications create should work 1`] = `
 Object {
-  "type": "increment outstanding requests",
+  "payload": Object {
+    "next": [Function],
+    "options": Object {
+      "body": "{\"expanded\":false,\"id\":\"216799fb-8904-4685-a165-2526cc48a71e\",\"name\":\"Add Trip Pattern\",\"scenario\":\"1\",\"showOnMap\":true,\"type\":\"add-trip-pattern\",\"variants\":[],\"segments\":[],\"timetables\":[]}",
+      "method": "post",
+    },
+    "url": "/api/modification",
+  },
+  "type": "fetch",
 }
 `;
 
 exports[`actions > modifications create should work 2`] = `
-Object {
-  "type": "decrement outstanding requests",
-}
+Array [
+  Object {
+    "type": "increment outstanding fetches",
+  },
+  Promise {},
+]
 `;
 
 exports[`actions > modifications create should work 3`] = `
+Array [
+  Object {
+    "type": "decrement outstanding fetches",
+  },
+  Array [
+    Object {
+      "payload": Object {
+        "bidirectional": false,
+        "entries": Array [],
+        "feed": "1",
+        "id": "1234",
+        "name": "Test Modification",
+        "routes": Array [
+          "route1",
+        ],
+        "segments": Array [],
+        "showOnMap": false,
+        "timetables": Array [
+          Object {
+            "dwellTime": 10,
+            "endTime": 57600,
+            "friday": true,
+            "headwaySecs": 900,
+            "monday": true,
+            "name": "Test timetable",
+            "patternTrips": Array [
+              "abcd",
+            ],
+            "saturday": false,
+            "segmentSpeeds": Array [],
+            "sourceTrip": "abcd",
+            "startTime": 28800,
+            "sunday": false,
+            "thursday": true,
+            "tuesday": true,
+            "wednesday": true,
+          },
+        ],
+        "trips": Array [
+          "abcd",
+        ],
+        "type": "add-trip-pattern",
+        "variants": Array [
+          0,
+        ],
+      },
+      "type": "set modification",
+    },
+    Object {
+      "payload": Object {
+        "args": Array [
+          "/projects/1/scenarios/1/modifications/1234",
+        ],
+        "method": "push",
+      },
+      "type": "@@router/CALL_HISTORY_METHOD",
+    },
+  ],
+]
+`;
+
+exports[`actions > modifications deleteModification should work 1`] = `
+Array [
+  Object {
+    "payload": "1",
+    "type": "delete modification",
+  },
+  Object {
+    "payload": Object {
+      "next": [Function],
+      "options": Object {
+        "method": "delete",
+      },
+      "url": "/api/modification/1",
+    },
+    "type": "fetch",
+  },
+]
+`;
+
+exports[`actions > modifications deleteModification should work 2`] = `
+Array [
+  Object {
+    "payload": "1",
+    "type": "delete modification",
+  },
+  Array [
+    Object {
+      "type": "increment outstanding fetches",
+    },
+    Promise {},
+  ],
+]
+`;
+
+exports[`actions > modifications deleteModification should work 3`] = `
+Array [
+  Object {
+    "type": "increment outstanding fetches",
+  },
+  Promise {},
+]
+`;
+
+exports[`actions > modifications getForScenario should work 1`] = `
+Object {
+  "payload": Object {
+    "next": [Function],
+    "url": "/api/scenario/1/modifications",
+  },
+  "type": "fetch",
+}
+`;
+
+exports[`actions > modifications getForScenario should work 2`] = `
+Array [
+  Object {
+    "type": "increment outstanding fetches",
+  },
+  Promise {},
+]
+`;
+
+exports[`actions > modifications getForScenario should work 3`] = `
+Array [
+  Object {
+    "type": "decrement outstanding fetches",
+  },
+  Array [
+    Object {
+      "payload": Array [
+        Object {
+          "bidirectional": false,
+          "entries": Array [],
+          "feed": "1",
+          "id": "1234",
+          "name": "Test Modification",
+          "routes": Array [
+            "route1",
+          ],
+          "segments": Array [],
+          "showOnMap": false,
+          "timetables": Array [
+            Object {
+              "dwellTime": 10,
+              "endTime": 57600,
+              "friday": true,
+              "headwaySecs": 900,
+              "monday": true,
+              "name": "Test timetable",
+              "patternTrips": Array [
+                "abcd",
+              ],
+              "saturday": false,
+              "segmentSpeeds": Array [],
+              "sourceTrip": "abcd",
+              "startTime": 28800,
+              "sunday": false,
+              "thursday": true,
+              "tuesday": true,
+              "wednesday": true,
+            },
+          ],
+          "trips": Array [
+            "abcd",
+          ],
+          "type": "add-trip-pattern",
+          "variants": Array [
+            0,
+          ],
+        },
+      ],
+      "type": "set modifications",
+    },
+    Array [
+      Object {
+        "type": "increment outstanding fetches",
+      },
+      Promise {},
+    ],
+  ],
+]
+`;
+
+exports[`actions > modifications saveToServer should work 1`] = `
+Object {
+  "payload": Object {
+    "next": [Function],
+    "options": Object {
+      "body": Object {
+        "bidirectional": false,
+        "entries": Array [],
+        "feed": "1",
+        "id": "1234",
+        "name": "Test Modification",
+        "routes": Array [
+          "route1",
+        ],
+        "segments": Array [],
+        "showOnMap": false,
+        "timetables": Array [
+          Object {
+            "dwellTime": 10,
+            "endTime": 57600,
+            "friday": true,
+            "headwaySecs": 900,
+            "monday": true,
+            "name": "Test timetable",
+            "patternTrips": Array [
+              "abcd",
+            ],
+            "saturday": false,
+            "segmentSpeeds": Array [],
+            "sourceTrip": "abcd",
+            "startTime": 28800,
+            "sunday": false,
+            "thursday": true,
+            "tuesday": true,
+            "wednesday": true,
+          },
+        ],
+        "trips": Array [
+          "abcd",
+        ],
+        "type": "add-trip-pattern",
+        "variants": Array [
+          0,
+        ],
+      },
+      "method": "put",
+    },
+    "url": "/api/modification/1234",
+  },
+  "type": "fetch",
+}
+`;
+
+exports[`actions > modifications saveToServer should work 2`] = `
+Array [
+  Object {
+    "type": "increment outstanding fetches",
+  },
+  Promise {},
+]
+`;
+
+exports[`actions > modifications saveToServer should work 3`] = `
+Array [
+  Object {
+    "type": "decrement outstanding fetches",
+  },
+]
+`;
+
+exports[`actions > modifications set should work 1`] = `
 Array [
   Object {
     "payload": Object {
@@ -124,180 +404,58 @@ Array [
   },
   Object {
     "payload": Object {
-      "args": Array [
-        "/projects/1/scenarios/1/modifications/1234",
-      ],
-      "method": "push",
-    },
-    "type": "@@router/CALL_HISTORY_METHOD",
-  },
-]
-`;
-
-exports[`actions > modifications deleteModification should work 1`] = `
-Object {
-  "payload": "1",
-  "type": "delete modification",
-}
-`;
-
-exports[`actions > modifications deleteModification should work 2`] = `
-Object {
-  "type": "increment outstanding requests",
-}
-`;
-
-exports[`actions > modifications deleteModification should work 3`] = `
-Array [
-  Object {
-    "type": "decrement outstanding requests",
-  },
-]
-`;
-
-exports[`actions > modifications getForScenario should work 1`] = `
-Object {
-  "type": "increment outstanding requests",
-}
-`;
-
-exports[`actions > modifications getForScenario should work 2`] = `
-Object {
-  "type": "decrement outstanding requests",
-}
-`;
-
-exports[`actions > modifications getForScenario should work 3`] = `
-Object {
-  "payload": Array [
-    Object {
-      "bidirectional": false,
-      "entries": Array [],
-      "feed": "1",
-      "id": "1234",
-      "name": "Test Modification",
-      "routes": Array [
-        "route1",
-      ],
-      "segments": Array [],
-      "showOnMap": false,
-      "timetables": Array [
-        Object {
-          "dwellTime": 10,
-          "endTime": 57600,
-          "friday": true,
-          "headwaySecs": 900,
-          "monday": true,
-          "name": "Test timetable",
-          "patternTrips": Array [
+      "next": [Function],
+      "options": Object {
+        "body": Object {
+          "bidirectional": false,
+          "entries": Array [],
+          "feed": "1",
+          "id": "1234",
+          "name": "Test Modification",
+          "routes": Array [
+            "route1",
+          ],
+          "segments": Array [],
+          "showOnMap": false,
+          "timetables": Array [
+            Object {
+              "dwellTime": 10,
+              "endTime": 57600,
+              "friday": true,
+              "headwaySecs": 900,
+              "monday": true,
+              "name": "Test timetable",
+              "patternTrips": Array [
+                "abcd",
+              ],
+              "saturday": false,
+              "segmentSpeeds": Array [],
+              "sourceTrip": "abcd",
+              "startTime": 28800,
+              "sunday": false,
+              "thursday": true,
+              "tuesday": true,
+              "wednesday": true,
+            },
+          ],
+          "trips": Array [
             "abcd",
           ],
-          "saturday": false,
-          "segmentSpeeds": Array [],
-          "sourceTrip": "abcd",
-          "startTime": 28800,
-          "sunday": false,
-          "thursday": true,
-          "tuesday": true,
-          "wednesday": true,
+          "type": "add-trip-pattern",
+          "variants": Array [
+            0,
+          ],
         },
-      ],
-      "trips": Array [
-        "abcd",
-      ],
-      "type": "add-trip-pattern",
-      "variants": Array [
-        0,
-      ],
-    },
-  ],
-  "type": "set modifications",
-}
-`;
-
-exports[`actions > modifications getForScenario should work 4`] = `
-Array [
-  Object {
-    "type": "increment outstanding requests",
-  },
-  Promise {},
-]
-`;
-
-exports[`actions > modifications saveToServer should work 1`] = `
-Object {
-  "type": "increment outstanding requests",
-}
-`;
-
-exports[`actions > modifications saveToServer should work 2`] = `
-Object {
-  "type": "decrement outstanding requests",
-}
-`;
-
-exports[`actions > modifications set should work 1`] = `
-Object {
-  "payload": Object {
-    "bidirectional": false,
-    "entries": Array [],
-    "feed": "1",
-    "id": "1234",
-    "name": "Test Modification",
-    "routes": Array [
-      "route1",
-    ],
-    "segments": Array [],
-    "showOnMap": false,
-    "timetables": Array [
-      Object {
-        "dwellTime": 10,
-        "endTime": 57600,
-        "friday": true,
-        "headwaySecs": 900,
-        "monday": true,
-        "name": "Test timetable",
-        "patternTrips": Array [
-          "abcd",
-        ],
-        "saturday": false,
-        "segmentSpeeds": Array [],
-        "sourceTrip": "abcd",
-        "startTime": 28800,
-        "sunday": false,
-        "thursday": true,
-        "tuesday": true,
-        "wednesday": true,
+        "method": "put",
       },
-    ],
-    "trips": Array [
-      "abcd",
-    ],
-    "type": "add-trip-pattern",
-    "variants": Array [
-      0,
-    ],
+      "url": "/api/modification/1234",
+    },
+    "type": "fetch",
   },
-  "type": "set modification",
-}
+]
 `;
 
 exports[`actions > modifications set should work 2`] = `
-Array [
-  Object {
-    "type": "increment outstanding requests",
-  },
-  Promise {},
-]
-`;
-
-exports[`actions > modifications setActive should work 1`] = `
-Object {
-  "type": "set active modification",
-}
-`;
-
-exports[`actions > modifications setAndRetrieveData should work 1`] = `
 Array [
   Object {
     "payload": Object {
@@ -344,19 +502,132 @@ Array [
   },
   Array [
     Object {
-      "type": "increment outstanding requests",
+      "type": "increment outstanding fetches",
     },
     Promise {},
   ],
 ]
 `;
 
-exports[`actions > modifications setAndRetrieveData should work 2`] = `
+exports[`actions > modifications set should work 3`] = `
 Array [
   Object {
-    "type": "increment outstanding requests",
+    "type": "increment outstanding fetches",
   },
   Promise {},
+]
+`;
+
+exports[`actions > modifications setActive should work 1`] = `
+Object {
+  "type": "set active modification",
+}
+`;
+
+exports[`actions > modifications setAndRetrieveData should work 1`] = `
+Array [
+  Array [
+    Object {
+      "payload": Object {
+        "bidirectional": false,
+        "entries": Array [],
+        "feed": "1",
+        "id": "1234",
+        "name": "Test Modification",
+        "routes": Array [
+          "route1",
+        ],
+        "segments": Array [],
+        "showOnMap": false,
+        "timetables": Array [
+          Object {
+            "dwellTime": 10,
+            "endTime": 57600,
+            "friday": true,
+            "headwaySecs": 900,
+            "monday": true,
+            "name": "Test timetable",
+            "patternTrips": Array [
+              "abcd",
+            ],
+            "saturday": false,
+            "segmentSpeeds": Array [],
+            "sourceTrip": "abcd",
+            "startTime": 28800,
+            "sunday": false,
+            "thursday": true,
+            "tuesday": true,
+            "wednesday": true,
+          },
+        ],
+        "trips": Array [
+          "abcd",
+        ],
+        "type": "add-trip-pattern",
+        "variants": Array [
+          0,
+        ],
+      },
+      "type": "set modification",
+    },
+    Object {
+      "payload": Object {
+        "next": [Function],
+        "options": Object {
+          "body": Object {
+            "bidirectional": false,
+            "entries": Array [],
+            "feed": "1",
+            "id": "1234",
+            "name": "Test Modification",
+            "routes": Array [
+              "route1",
+            ],
+            "segments": Array [],
+            "showOnMap": false,
+            "timetables": Array [
+              Object {
+                "dwellTime": 10,
+                "endTime": 57600,
+                "friday": true,
+                "headwaySecs": 900,
+                "monday": true,
+                "name": "Test timetable",
+                "patternTrips": Array [
+                  "abcd",
+                ],
+                "saturday": false,
+                "segmentSpeeds": Array [],
+                "sourceTrip": "abcd",
+                "startTime": 28800,
+                "sunday": false,
+                "thursday": true,
+                "tuesday": true,
+                "wednesday": true,
+              },
+            ],
+            "trips": Array [
+              "abcd",
+            ],
+            "type": "add-trip-pattern",
+            "variants": Array [
+              0,
+            ],
+          },
+          "method": "put",
+        },
+        "url": "/api/modification/1234",
+      },
+      "type": "fetch",
+    },
+  ],
+  Object {
+    "payload": Object {
+      "next": [Function],
+      "url": "/api/graphql?query=%0Aquery%20dataQuery(%24bundleId%3A%20String%2C%20%24routeIds%3A%20%5BString%5D)%20%7B%0A%20%20bundle%20(bundle_id%3A%20%5B%24bundleId%5D)%20%7B%0A%20%20%20%20feeds%20%7B%0A%20%20%20%20%20%20feed_id%2C%0A%20%20%20%20%20%20checksum%2C%0A%20%20%20%20%20%20routes%20%7B%0A%20%20%20%20%20%20%20%20route_id%0A%20%20%20%20%20%20%20%20route_short_name%0A%20%20%20%20%20%20%20%20route_long_name%0A%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20detailRoutes%3A%20routes(route_id%3A%20%24routeIds)%20%7B%0A%20%20%20%20%20%20%20%20route_id%0A%20%20%20%20%20%20%20%20route_short_name%0A%20%20%20%20%20%20%20%20route_long_name%0A%20%20%20%20%20%20%20%20patterns%20%7B%0A%20%20%20%20%20%20%20%20%20%20name%2C%0A%20%20%20%20%20%20%20%20%20%20pattern_id%2C%0A%20%20%20%20%20%20%20%20%20%20geometry%2C%0A%20%20%20%20%20%20%20%20%20%20trips%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20trip_id%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20trip_short_name%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20trip_headsign%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20start_time%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20direction_id%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20duration%0A%20%20%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%20%20%20%20stops%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20stop_id%0A%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%0A%20%20%20%20%20%20stops%20%7B%0A%20%20%20%20%20%20%20%20stop_id%2C%0A%20%20%20%20%20%20%20%20stop_name%2C%0A%20%20%20%20%20%20%20%20stop_lat%2C%0A%20%20%20%20%20%20%20%20stop_lon%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&variables=%7B%22bundleId%22%3A1%2C%22routeIds%22%3A%5B%5D%7D",
+    },
+    "type": "fetch",
+  },
 ]
 `;
 

--- a/lib/actions/__tests__/__snapshots__/modifications.js.snap
+++ b/lib/actions/__tests__/__snapshots__/modifications.js.snap
@@ -1,4 +1,4 @@
-exports[`actions > modifications copyFromScenario should work 1`] = `
+exports[`actions > modifications > copyFromScenario should work 1`] = `
 Object {
   "payload": Object {
     "next": [Function],
@@ -8,7 +8,7 @@ Object {
 }
 `;
 
-exports[`actions > modifications copyFromScenario should work 2`] = `
+exports[`actions > modifications > copyFromScenario should work 2`] = `
 Array [
   Object {
     "type": "increment outstanding fetches",
@@ -17,7 +17,7 @@ Array [
 ]
 `;
 
-exports[`actions > modifications copyFromScenario should work 3`] = `
+exports[`actions > modifications > copyFromScenario should work 3`] = `
 Array [
   Object {
     "type": "decrement outstanding fetches",
@@ -29,7 +29,6 @@ Array [
           "bidirectional": false,
           "entries": Array [],
           "feed": "1",
-          "id": "2e456370-f559-4300-a5a1-5d3cfd871ab0",
           "name": "Test Modification",
           "routes": Array [
             "route1",
@@ -79,12 +78,22 @@ Array [
 ]
 `;
 
-exports[`actions > modifications create should work 1`] = `
+exports[`actions > modifications > create should work 1`] = `
 Object {
   "payload": Object {
     "next": [Function],
     "options": Object {
-      "body": "{\"expanded\":false,\"id\":\"216799fb-8904-4685-a165-2526cc48a71e\",\"name\":\"Add Trip Pattern\",\"scenario\":\"1\",\"showOnMap\":true,\"type\":\"add-trip-pattern\",\"variants\":[],\"segments\":[],\"timetables\":[]}",
+      "body": Object {
+        "expanded": false,
+        "id": 1,
+        "name": "Add Trip Pattern",
+        "scenario": "1",
+        "segments": Array [],
+        "showOnMap": true,
+        "timetables": Array [],
+        "type": "add-trip-pattern",
+        "variants": Array [],
+      },
       "method": "post",
     },
     "url": "/api/modification",
@@ -93,7 +102,7 @@ Object {
 }
 `;
 
-exports[`actions > modifications create should work 2`] = `
+exports[`actions > modifications > create should work 2`] = `
 Array [
   Object {
     "type": "increment outstanding fetches",
@@ -102,7 +111,7 @@ Array [
 ]
 `;
 
-exports[`actions > modifications create should work 3`] = `
+exports[`actions > modifications > create should work 3`] = `
 Array [
   Object {
     "type": "decrement outstanding fetches",
@@ -164,7 +173,7 @@ Array [
 ]
 `;
 
-exports[`actions > modifications deleteModification should work 1`] = `
+exports[`actions > modifications > deleteModification should work 1`] = `
 Array [
   Object {
     "payload": "1",
@@ -183,7 +192,7 @@ Array [
 ]
 `;
 
-exports[`actions > modifications deleteModification should work 2`] = `
+exports[`actions > modifications > deleteModification should work 2`] = `
 Array [
   Object {
     "payload": "1",
@@ -198,7 +207,7 @@ Array [
 ]
 `;
 
-exports[`actions > modifications deleteModification should work 3`] = `
+exports[`actions > modifications > deleteModification should work 3`] = `
 Array [
   Object {
     "type": "increment outstanding fetches",
@@ -207,7 +216,7 @@ Array [
 ]
 `;
 
-exports[`actions > modifications getForScenario should work 1`] = `
+exports[`actions > modifications > getForScenario should work 1`] = `
 Object {
   "payload": Object {
     "next": [Function],
@@ -217,7 +226,7 @@ Object {
 }
 `;
 
-exports[`actions > modifications getForScenario should work 2`] = `
+exports[`actions > modifications > getForScenario should work 2`] = `
 Array [
   Object {
     "type": "increment outstanding fetches",
@@ -226,7 +235,7 @@ Array [
 ]
 `;
 
-exports[`actions > modifications getForScenario should work 3`] = `
+exports[`actions > modifications > getForScenario should work 3`] = `
 Array [
   Object {
     "type": "decrement outstanding fetches",
@@ -287,7 +296,7 @@ Array [
 ]
 `;
 
-exports[`actions > modifications saveToServer should work 1`] = `
+exports[`actions > modifications > saveToServer should work 1`] = `
 Object {
   "payload": Object {
     "next": [Function],
@@ -340,7 +349,7 @@ Object {
 }
 `;
 
-exports[`actions > modifications saveToServer should work 2`] = `
+exports[`actions > modifications > saveToServer should work 2`] = `
 Array [
   Object {
     "type": "increment outstanding fetches",
@@ -349,7 +358,7 @@ Array [
 ]
 `;
 
-exports[`actions > modifications saveToServer should work 3`] = `
+exports[`actions > modifications > saveToServer should work 3`] = `
 Array [
   Object {
     "type": "decrement outstanding fetches",
@@ -357,7 +366,7 @@ Array [
 ]
 `;
 
-exports[`actions > modifications set should work 1`] = `
+exports[`actions > modifications > set should work 1`] = `
 Array [
   Object {
     "payload": Object {
@@ -455,7 +464,7 @@ Array [
 ]
 `;
 
-exports[`actions > modifications set should work 2`] = `
+exports[`actions > modifications > set should work 2`] = `
 Array [
   Object {
     "payload": Object {
@@ -509,7 +518,7 @@ Array [
 ]
 `;
 
-exports[`actions > modifications set should work 3`] = `
+exports[`actions > modifications > set should work 3`] = `
 Array [
   Object {
     "type": "increment outstanding fetches",
@@ -518,13 +527,13 @@ Array [
 ]
 `;
 
-exports[`actions > modifications setActive should work 1`] = `
+exports[`actions > modifications > setActive should work 1`] = `
 Object {
   "type": "set active modification",
 }
 `;
 
-exports[`actions > modifications setAndRetrieveData should work 1`] = `
+exports[`actions > modifications > setAndRetrieveData should work 1`] = `
 Array [
   Array [
     Object {
@@ -631,7 +640,7 @@ Array [
 ]
 `;
 
-exports[`actions > modifications setLocally should work 1`] = `
+exports[`actions > modifications > setLocally should work 1`] = `
 Object {
   "type": "set modification",
 }

--- a/lib/actions/__tests__/__snapshots__/project.js.snap
+++ b/lib/actions/__tests__/__snapshots__/project.js.snap
@@ -11,7 +11,7 @@ Object {
           "west": -77,
         },
         "description": "Project description",
-        "id": "e1bd2af4-ddcb-48fd-ba9f-e73631eb8bcc",
+        "id": 1,
         "name": "Mock Project",
       },
       "method": "post",
@@ -46,7 +46,7 @@ Array [
           "west": -77,
         },
         "description": "Project description",
-        "id": "e1bd2af4-ddcb-48fd-ba9f-e73631eb8bcc",
+        "id": 1,
         "name": "Mock Project",
       },
       "type": "set project",
@@ -54,7 +54,7 @@ Array [
     Object {
       "payload": Object {
         "args": Array [
-          "/projects/e1bd2af4-ddcb-48fd-ba9f-e73631eb8bcc",
+          "/projects/1",
         ],
         "method": "push",
       },

--- a/lib/actions/__tests__/__snapshots__/project.js.snap
+++ b/lib/actions/__tests__/__snapshots__/project.js.snap
@@ -1,117 +1,249 @@
+exports[`actions > project create should work 1`] = `
+Object {
+  "payload": Object {
+    "next": [Function],
+    "options": Object {
+      "body": Object {
+        "bounds": Object {
+          "east": -76,
+          "north": 39,
+          "south": 38,
+          "west": -77,
+        },
+        "description": "Project description",
+        "id": "e1bd2af4-ddcb-48fd-ba9f-e73631eb8bcc",
+        "name": "Mock Project",
+      },
+      "method": "post",
+    },
+    "url": "/api/project",
+  },
+  "type": "fetch",
+}
+`;
+
+exports[`actions > project create should work 2`] = `
+Array [
+  Object {
+    "type": "increment outstanding fetches",
+  },
+  Promise {},
+]
+`;
+
+exports[`actions > project create should work 3`] = `
+Array [
+  Object {
+    "type": "decrement outstanding fetches",
+  },
+  Array [
+    Object {
+      "payload": Object {
+        "bounds": Object {
+          "east": -76,
+          "north": 39,
+          "south": 38,
+          "west": -77,
+        },
+        "description": "Project description",
+        "id": "e1bd2af4-ddcb-48fd-ba9f-e73631eb8bcc",
+        "name": "Mock Project",
+      },
+      "type": "set project",
+    },
+    Object {
+      "payload": Object {
+        "args": Array [
+          "/projects/e1bd2af4-ddcb-48fd-ba9f-e73631eb8bcc",
+        ],
+        "method": "push",
+      },
+      "type": "@@router/CALL_HISTORY_METHOD",
+    },
+  ],
+]
+`;
+
 exports[`actions > project deleteProject should work 1`] = `
 Object {
-  "type": "increment outstanding requests",
+  "payload": Object {
+    "next": [Function],
+    "options": Object {
+      "method": "delete",
+    },
+    "url": "/api/project/1",
+  },
+  "type": "fetch",
 }
 `;
 
 exports[`actions > project deleteProject should work 2`] = `
-Object {
-  "type": "decrement outstanding requests",
-}
+Array [
+  Object {
+    "type": "increment outstanding fetches",
+  },
+  Promise {},
+]
 `;
 
 exports[`actions > project deleteProject should work 3`] = `
 Array [
   Object {
-    "payload": "1",
-    "type": "delete project",
+    "type": "decrement outstanding fetches",
   },
-  Object {
-    "payload": Object {
-      "args": Array [
-        "/",
-      ],
-      "method": "push",
+  Array [
+    Object {
+      "payload": "1",
+      "type": "delete project",
     },
-    "type": "@@router/CALL_HISTORY_METHOD",
-  },
+    Object {
+      "payload": Object {
+        "args": Array [
+          "/",
+        ],
+        "method": "push",
+      },
+      "type": "@@router/CALL_HISTORY_METHOD",
+    },
+  ],
 ]
 `;
 
 exports[`actions > project load should work 1`] = `
 Object {
-  "type": "increment outstanding requests",
+  "payload": Object {
+    "next": [Function],
+    "url": "/api/project/1",
+  },
+  "type": "fetch",
 }
 `;
 
 exports[`actions > project load should work 2`] = `
-Object {
-  "type": "decrement outstanding requests",
-}
+Array [
+  Object {
+    "type": "increment outstanding fetches",
+  },
+  Promise {},
+]
 `;
 
 exports[`actions > project load should work 3`] = `
 Array [
   Object {
-    "payload": Object {
-      "bounds": Object {
-        "east": -76.81503295898438,
-        "north": 39.02345139405932,
-        "south": 38.777640223073355,
-        "west": -77.25723266601562,
+    "type": "decrement outstanding fetches",
+  },
+  Array [
+    Object {
+      "payload": Object {
+        "bounds": Object {
+          "east": -76.81503295898438,
+          "north": 39.02345139405932,
+          "south": 38.777640223073355,
+          "west": -77.25723266601562,
+        },
+        "bundles": Array [],
+        "description": "Project description",
+        "name": "Project name",
+        "scenarios": Array [],
       },
-      "bundles": Array [],
-      "description": "Project description",
-      "name": "Project name",
-      "scenarios": Array [],
+      "type": "set project",
     },
-    "type": "set project",
-  },
-  Object {
-    "payload": Object {
-      "lat": 38.900545808566335,
-      "lon": -77.0361328125,
+    Object {
+      "payload": Object {
+        "lat": 38.900545808566335,
+        "lon": -77.0361328125,
+      },
+      "type": "set map center",
     },
-    "type": "set map center",
-  },
-  Object {
-    "type": "set bundles",
-  },
-  Object {
-    "type": "set scenarios",
-  },
+    Object {
+      "type": "set bundles",
+    },
+    Object {
+      "type": "set scenarios",
+    },
+  ],
 ]
 `;
 
 exports[`actions > project loadAll should work 1`] = `
 Object {
-  "type": "increment outstanding requests",
+  "payload": Object {
+    "next": [Function],
+    "url": "/api/project",
+  },
+  "type": "fetch",
 }
 `;
 
 exports[`actions > project loadAll should work 2`] = `
-Object {
-  "type": "decrement outstanding requests",
-}
+Array [
+  Object {
+    "type": "increment outstanding fetches",
+  },
+  Promise {},
+]
 `;
 
 exports[`actions > project loadAll should work 3`] = `
-Object {
-  "payload": Array [],
-  "type": "set all projects",
-}
+Array [
+  Object {
+    "type": "decrement outstanding fetches",
+  },
+  Object {
+    "payload": Array [],
+    "type": "set all projects",
+  },
+]
 `;
 
 exports[`actions > project save should work 1`] = `
-Object {
-  "payload": Object {
-    "id": "1",
+Array [
+  Object {
+    "payload": Object {
+      "id": "1",
+    },
+    "type": "set project",
   },
-  "type": "set project",
-}
+  Object {
+    "payload": Object {
+      "next": [Function],
+      "options": Object {
+        "body": Object {
+          "id": "1",
+        },
+        "method": "put",
+      },
+      "url": "/api/project/1",
+    },
+    "type": "fetch",
+  },
+]
 `;
 
 exports[`actions > project save should work 2`] = `
-Object {
-  "type": "increment outstanding requests",
-}
+Array [
+  Object {
+    "payload": Object {
+      "id": "1",
+    },
+    "type": "set project",
+  },
+  Array [
+    Object {
+      "type": "increment outstanding fetches",
+    },
+    Promise {},
+  ],
+]
 `;
 
 exports[`actions > project save should work 3`] = `
 Array [
   Object {
-    "type": "decrement outstanding requests",
+    "type": "increment outstanding fetches",
   },
+  Promise {},
 ]
 `;
 

--- a/lib/actions/__tests__/__snapshots__/scenario.js.snap
+++ b/lib/actions/__tests__/__snapshots__/scenario.js.snap
@@ -1,32 +1,55 @@
 exports[`actions > scenario create should work 1`] = `
 Object {
-  "type": "increment outstanding requests",
+  "payload": Object {
+    "next": [Function],
+    "options": Object {
+      "body": Object {
+        "bundleId": "1",
+        "name": "test",
+        "projectId": "1",
+        "variants": Array [
+          "Default",
+        ],
+      },
+      "method": "post",
+    },
+    "url": "/api/scenario",
+  },
+  "type": "fetch",
 }
 `;
 
 exports[`actions > scenario create should work 2`] = `
-Object {
-  "type": "decrement outstanding requests",
-}
+Array [
+  Object {
+    "type": "increment outstanding fetches",
+  },
+  Promise {},
+]
 `;
 
 exports[`actions > scenario create should work 3`] = `
 Array [
   Object {
-    "payload": Object {
-      "id": "1",
-    },
-    "type": "add scenario",
+    "type": "decrement outstanding fetches",
   },
-  Object {
-    "payload": Object {
-      "args": Array [
-        "/projects/1/scenarios/1",
-      ],
-      "method": "push",
+  Array [
+    Object {
+      "payload": Object {
+        "id": "1",
+      },
+      "type": "add scenario",
     },
-    "type": "@@router/CALL_HISTORY_METHOD",
-  },
+    Object {
+      "payload": Object {
+        "args": Array [
+          "/projects/1/scenarios/1",
+        ],
+        "method": "push",
+      },
+      "type": "@@router/CALL_HISTORY_METHOD",
+    },
+  ],
 ]
 `;
 
@@ -38,83 +61,128 @@ Object {
 
 exports[`actions > scenario deleteScenario should work 1`] = `
 Object {
-  "type": "increment outstanding requests",
+  "payload": Object {
+    "next": [Function],
+    "options": Object {
+      "method": "delete",
+    },
+    "url": "/api/scenario/1",
+  },
+  "type": "fetch",
 }
 `;
 
 exports[`actions > scenario deleteScenario should work 2`] = `
-Object {
-  "type": "decrement outstanding requests",
-}
+Array [
+  Object {
+    "type": "increment outstanding fetches",
+  },
+  Promise {},
+]
 `;
 
 exports[`actions > scenario deleteScenario should work 3`] = `
 Array [
   Object {
-    "payload": "1",
-    "type": "delete scenario",
+    "type": "decrement outstanding fetches",
   },
-  Object {
-    "payload": Object {
-      "args": Array [
-        "/projects/1",
-      ],
-      "method": "push",
+  Array [
+    Object {
+      "payload": "1",
+      "type": "delete scenario",
     },
-    "type": "@@router/CALL_HISTORY_METHOD",
-  },
+    Object {
+      "payload": Object {
+        "args": Array [
+          "/projects/1",
+        ],
+        "method": "push",
+      },
+      "type": "@@router/CALL_HISTORY_METHOD",
+    },
+  ],
 ]
 `;
 
 exports[`actions > scenario load should work 1`] = `
 Object {
-  "type": "increment outstanding requests",
+  "payload": Object {
+    "next": [Function],
+    "url": "/api/scenario/1",
+  },
+  "type": "fetch",
 }
 `;
 
 exports[`actions > scenario load should work 2`] = `
-Object {
-  "type": "decrement outstanding requests",
-}
+Array [
+  Object {
+    "type": "increment outstanding fetches",
+  },
+  Promise {},
+]
 `;
 
 exports[`actions > scenario load should work 3`] = `
 Array [
   Object {
-    "payload": Object {
-      "bundleId": "1",
-      "id": "1",
-    },
-    "type": "set scenario",
+    "type": "decrement outstanding fetches",
   },
   Array [
     Object {
-      "type": "increment outstanding requests",
+      "payload": Object {
+        "bundleId": "1",
+        "id": "1",
+      },
+      "type": "set scenario",
     },
-    Promise {},
+    Array [
+      Object {
+        "type": "increment outstanding fetches",
+      },
+      Promise {},
+    ],
   ],
 ]
 `;
 
 exports[`actions > scenario saveToServer should work 1`] = `
 Object {
-  "type": "increment outstanding requests",
+  "payload": Object {
+    "next": [Function],
+    "options": Object {
+      "body": Object {
+        "id": "1",
+      },
+      "method": "put",
+    },
+    "url": "/api/scenario/1",
+  },
+  "type": "fetch",
 }
 `;
 
 exports[`actions > scenario saveToServer should work 2`] = `
-Object {
-  "type": "decrement outstanding requests",
-}
+Array [
+  Object {
+    "type": "increment outstanding fetches",
+  },
+  Promise {},
+]
 `;
 
 exports[`actions > scenario saveToServer should work 3`] = `
-Object {
-  "payload": Object {
-    "id": "1",
+Array [
+  Object {
+    "type": "decrement outstanding fetches",
   },
-  "type": "set scenario",
-}
+  Object {
+    "payload": Object {
+      "id": "1",
+    },
+    "type": "set scenario",
+  },
+]
 `;
 
 exports[`actions > scenario set should work 1`] = `
@@ -138,12 +206,40 @@ Array [
     },
     "type": "set scenario",
   },
+  Object {
+    "payload": Object {
+      "next": [Function],
+      "url": "/api/scenario/1/modifications",
+    },
+    "type": "fetch",
+  },
+]
+`;
+
+exports[`actions > scenario setAndLoadModifications should work 2`] = `
+Array [
+  Object {
+    "payload": Object {
+      "bundleId": "1",
+      "id": "1",
+    },
+    "type": "set scenario",
+  },
   Array [
     Object {
-      "type": "increment outstanding requests",
+      "type": "increment outstanding fetches",
     },
     Promise {},
   ],
+]
+`;
+
+exports[`actions > scenario setAndLoadModifications should work 3`] = `
+Array [
+  Object {
+    "type": "increment outstanding fetches",
+  },
+  Promise {},
 ]
 `;
 

--- a/lib/actions/__tests__/get-feeds-routes-and-stops.js
+++ b/lib/actions/__tests__/get-feeds-routes-and-stops.js
@@ -3,57 +3,53 @@
 describe('actions > getFeedsRoutesAndStops', () => {
   const nock = require('nock')
   const getFeedsRoutesAndStops = require('../get-feeds-routes-and-stops')
+  const {makeMockStore} = require('../../utils/mock-data')
 
-  it('should work when fetching via getAllRoutesAndStops and then getUnfetchedRoutes', async () => {
-    const mockRoutes = [
+  const mockRoutes = [
+    {
+      route_id: '1',
+      route_short_name: '1'
+    }
+  ]
+
+  const mockResponse = {
+    bundle: [
       {
-        route_id: '1',
-        route_short_name: '1'
+        feeds: [
+          {
+            checksum: 'abcd',
+            detailRoutes: mockRoutes,
+            feed_id: '1',
+            routes: mockRoutes,
+            stops: [
+              {
+                stop_id: '1'
+              }
+            ]
+          }
+        ]
       }
     ]
-    const mockResponse = {
-      bundle: [
-        {
-          feeds: [
-            {
-              checksum: 'abcd',
-              detailRoutes: mockRoutes,
-              feed_id: '1',
-              routes: mockRoutes,
-              stops: [
-                {
-                  stop_id: '1'
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
+  }
 
-    const nockHost = nock('http://mockhost.com/')
-    nockHost.get(/^\/api\/graphql/)
+  it('should work when fetching via getAllRoutesAndStops', async () => {
+    nock('http://mockhost.com/')
+      .get(/^\/api\/graphql/)
       .reply(200, mockResponse)
 
-    const getResult = getFeedsRoutesAndStops({ bundleId: 1 })
-
-    // expect to receive increment action while making request
-    expect(getResult[0]).toMatchSnapshot()
-
-    // perform request
+    const store = makeMockStore()
+    const get = getFeedsRoutesAndStops({ bundleId: 1 })
+    expect(get).toMatchSnapshot()
+    const getResult = store.dispatch(get)
+    expect(getResult).toMatchSnapshot()
     const fetchResult = await getResult[1]
+    expect(fetchResult).toMatchSnapshot()
+  })
 
-    // expect to receive decrement action upon fulfillment of request
-    expect(fetchResult[0]).toMatchSnapshot()
-
-    // parse response
-    const parseResult = await fetchResult[1]
-
-    // expect parse result to be what we desired
-    expect(parseResult).toMatchSnapshot()
-
+  it('should work when fetching with getUnfetchedRoutes', async () => {
     // make request again, forcing fetching via getUnfetchedRoutes
-    nockHost.get(/^\/api\/graphql/)
+    nock('http://mockhost.com/')
+      .get(/^\/api\/graphql/)
       .reply(200, mockResponse)
 
     const actionParams = {
@@ -65,15 +61,13 @@ describe('actions > getFeedsRoutesAndStops', () => {
         }
       ]
     }
-    const getResult2 = getFeedsRoutesAndStops(actionParams)
 
-    // perform request
-    const fetchResult2 = await getResult2[1]
-
-    // parse response
-    const parseResult2 = await fetchResult2[1]
-
-    // expect parse result to be what we desired
-    expect(parseResult2).toMatchSnapshot()
+    const store = makeMockStore()
+    const get = getFeedsRoutesAndStops(actionParams)
+    expect(get).toMatchSnapshot()
+    const getResult = store.dispatch(get)
+    expect(getResult).toMatchSnapshot()
+    const fetchResult = await getResult[1]
+    expect(fetchResult).toMatchSnapshot()
   })
 })

--- a/lib/actions/__tests__/get-feeds-routes-and-stops.js
+++ b/lib/actions/__tests__/get-feeds-routes-and-stops.js
@@ -9,6 +9,10 @@ describe('actions > getFeedsRoutesAndStops', () => {
     {
       route_id: '1',
       route_short_name: '1'
+    },
+    {
+      route_id: '2',
+      route_short_name: '2'
     }
   ]
 
@@ -68,6 +72,32 @@ describe('actions > getFeedsRoutesAndStops', () => {
     const getResult = store.dispatch(get)
     expect(getResult).toMatchSnapshot()
     const fetchResult = await getResult[1]
+    expect(fetchResult).toMatchSnapshot()
+  })
+
+  it('should lock ui when no bundles are returned', async () => {
+    // make request again, forcing fetching via getUnfetchedRoutes
+    nock('http://mockhost.com/')
+      .get(/^\/api\/graphql/)
+      .reply(200, {bundle: []})
+
+    const actionParams = {
+      bundleId: 1,
+      modifications: [
+        {
+          type: 'reroute',
+          routes: ['2']
+        }
+      ]
+    }
+
+    const store = makeMockStore()
+    const get = getFeedsRoutesAndStops(actionParams)
+    const getResult = store.dispatch(get)
+    const fetchResult = await getResult[1]
+
+    expect(get).toMatchSnapshot()
+    expect(getResult).toMatchSnapshot()
     expect(fetchResult).toMatchSnapshot()
   })
 })

--- a/lib/actions/__tests__/index.js
+++ b/lib/actions/__tests__/index.js
@@ -3,6 +3,7 @@
 describe('actions > index', () => {
   const nock = require('nock')
   const actions = require('../')
+  const {makeMockStore} = require('../../utils/mock-data')
 
   describe('> bundle', () => {
     it('addBundle should work', () => {
@@ -14,19 +15,13 @@ describe('actions > index', () => {
         .delete('/api/bundle/1')
         .reply(200, 'deleted')
 
-      const deleteResult = actions.deleteBundle(1)
-
-      // expect to receive delete bundle locally action
-      expect(deleteResult[0]).toMatchSnapshot()
-
-      // expect to receive increment action while making delete request
-      expect(deleteResult[1][0]).toMatchSnapshot()
-
-      // perform deletion
-      const deleteRequestResult = await deleteResult[1][1]
-
-      // expect to receive decrement action upon fulfillment of delete request
-      expect(deleteRequestResult).toMatchSnapshot()
+      const store = makeMockStore()
+      const del = actions.deleteBundle(1)
+      expect(del).toMatchSnapshot()
+      const deleteResult = store.dispatch(del)
+      expect(deleteResult).toMatchSnapshot()
+      const fetchResult = await deleteResult[1]
+      expect(fetchResult).toMatchSnapshot()
     })
 
     it('saveBundle should work', async () => {
@@ -34,19 +29,13 @@ describe('actions > index', () => {
         .put('/api/bundle/1')
         .reply(200, 'saved')
 
-      const saveResult = actions.saveBundle({ id: 1 })
-
-      // expect to receive save bundle locally action
-      expect(saveResult[0]).toMatchSnapshot()
-
-      // expect to receive increment action while making save request
-      expect(saveResult[1][0]).toMatchSnapshot()
-
-      // perform request
-      const requestResult = await saveResult[1][1]
-
-      // expect to receive decrement action upon fulfillment of save request
-      expect(requestResult).toMatchSnapshot()
+      const store = makeMockStore()
+      const save = actions.saveBundle({ id: 1 })
+      expect(save).toMatchSnapshot()
+      const saveResult = store.dispatch(save)
+      expect(saveResult).toMatchSnapshot()
+      const fetchResult = await saveResult[1]
+      expect(fetchResult).toMatchSnapshot()
     })
 
     it('setBundle should work', () => {

--- a/lib/actions/__tests__/modifications.js
+++ b/lib/actions/__tests__/modifications.js
@@ -1,15 +1,6 @@
 /* global describe, expect, it */
 
-/* const mockModification = {
-  feed: { id: '1' },
-  id: '1',
-  routes: [{ id: '1' }],
-  stops: [{ id: '1' }],
-  trips: [{ id: '1' }],
-  variants: ['2']
-} */
-
-describe('actions > modifications', () => {
+describe('actions > modifications >', () => {
   const nock = require('nock')
   const modifications = require('../modifications')
   const {makeMockStore, mockModification} = require('../../utils/mock-data')
@@ -27,10 +18,12 @@ describe('actions > modifications', () => {
       toScenarioId: 2,
       variants: [1]
     })
-    expect(copy).toMatchSnapshot()
     const copyResult = store.dispatch(copy)
-    expect(copyResult).toMatchSnapshot()
     const fetchResult = await copyResult[1]
+
+    expect(copy).toMatchSnapshot()
+    expect(copyResult).toMatchSnapshot()
+    delete fetchResult[1][0][0].payload.id
     expect(fetchResult).toMatchSnapshot()
   })
 
@@ -47,10 +40,12 @@ describe('actions > modifications', () => {
       type: 'add-trip-pattern',
       variants: []
     })
-    expect(create).toMatchSnapshot()
+    create.payload.options.body.id = 1
     const createResult = store.dispatch(create)
-    expect(createResult).toMatchSnapshot()
     const fetchResult = await createResult[1]
+
+    expect(create).toMatchSnapshot()
+    expect(createResult).toMatchSnapshot()
     expect(fetchResult).toMatchSnapshot()
   })
 

--- a/lib/actions/__tests__/modifications.js
+++ b/lib/actions/__tests__/modifications.js
@@ -12,7 +12,7 @@
 describe('actions > modifications', () => {
   const nock = require('nock')
   const modifications = require('../modifications')
-  const {mockModification} = require('../../utils/mock-data')
+  const {makeMockStore, mockModification} = require('../../utils/mock-data')
 
   it('copyFromScenario should work', async () => {
     nock('http://mockHost.com/')
@@ -21,40 +21,17 @@ describe('actions > modifications', () => {
       .put(/^\/api\/modification/)
       .reply(200, 'saved')
 
-    const copyResult = modifications.copyFromScenario({
+    const store = makeMockStore()
+    const copy = modifications.copyFromScenario({
       fromScenarioId: 1,
       toScenarioId: 2,
       variants: [1]
     })
-
-    // expect to receive increment action while making request
-    expect(copyResult[0]).toMatchSnapshot()
-
-    // perform request
+    expect(copy).toMatchSnapshot()
+    const copyResult = store.dispatch(copy)
+    expect(copyResult).toMatchSnapshot()
     const fetchResult = await copyResult[1]
-
-    // expect to receive decrement action upon fulfillment of request
-    expect(fetchResult[0]).toMatchSnapshot()
-
-    // parse response
-    const parseResult = await fetchResult[1]
-
-    // should receive an array of arrays
-    expect(parseResult.length).toBe(1)
-    expect(parseResult[0].length).toBe(2)
-
-    // assert existance of uuid then delete it for snapshot
-    expect(parseResult[0][0].payload.id).toMatch(/[-\w]*/)
-    delete parseResult[0][0].payload.id
-
-    // expect parse result to be the result of the set action
-    expect(parseResult[0][0]).toMatchSnapshot()
-
-    // expect a set action
-    expect(parseResult[0][1]).toMatchSnapshot()
-
-    // don't bother to perform save request
-    // since it is tested in another test case in this file
+    expect(fetchResult).toMatchSnapshot()
   })
 
   it('create should work', async () => {
@@ -62,29 +39,19 @@ describe('actions > modifications', () => {
       .post('/api/modification')
       .reply(200, mockModification)
 
-    const createResult = modifications.create({
+    const store = makeMockStore()
+    const create = modifications.create({
       feedId: '1',
       projectId: '1',
       scenarioId: '1',
       type: 'add-trip-pattern',
       variants: []
     })
-
-    // expect to receive increment action while making request
-    expect(createResult[0]).toMatchSnapshot()
-
-    // perform request
+    expect(create).toMatchSnapshot()
+    const createResult = store.dispatch(create)
+    expect(createResult).toMatchSnapshot()
     const fetchResult = await createResult[1]
-
-    // expect to receive decrement action upon fulfillment of request
-    expect(fetchResult[0]).toMatchSnapshot()
-
-    // parse response
-    const parseResult = await fetchResult[1]
-
-    // expect parseResult to have server response and
-    // react route push action
-    expect(parseResult).toMatchSnapshot()
+    expect(fetchResult).toMatchSnapshot()
   })
 
   it('deleteModification should work', async () => {
@@ -92,22 +59,13 @@ describe('actions > modifications', () => {
       .delete('/api/modification/1')
       .reply(200, 'deleted')
 
-    const deleteResult = modifications.deleteModification('1')
-
-    // expect to receive delete locally action
-    expect(deleteResult[0]).toMatchSnapshot()
-
-    // perform request
+    const store = makeMockStore()
+    const del = modifications.deleteModification('1')
+    expect(del).toMatchSnapshot()
+    const deleteResult = store.dispatch(del)
+    expect(deleteResult).toMatchSnapshot()
     const fetchResult = await deleteResult[1]
-
-    // expect to receive increment action while making request
-    expect(fetchResult[0]).toMatchSnapshot()
-
-    // parse response
-    const parseResult = await fetchResult[1]
-
-    // expect to receive decrement action upon fulfillment of request
-    expect(parseResult).toMatchSnapshot()
+    expect(fetchResult).toMatchSnapshot()
   })
 
   it('getForScenario should work', async () => {
@@ -117,31 +75,16 @@ describe('actions > modifications', () => {
       .get(/^\/api\/graphql/)
       .reply(200)
 
-    const getResult = modifications.getForScenario({
+    const store = makeMockStore()
+    const get = modifications.getForScenario({
       bundleId: '1',
       scenarioId: '1'
     })
-
-    // expect to receive increment action while making request
-    expect(getResult[0]).toMatchSnapshot()
-
-    // perform request
+    expect(get).toMatchSnapshot()
+    const getResult = store.dispatch(get)
+    expect(getResult).toMatchSnapshot()
     const fetchResult = await getResult[1]
-
-    // expect to receive decrement action upon fulfillment of request
-    expect(fetchResult[0]).toMatchSnapshot()
-
-    // parse response
-    const parseResult = await fetchResult[1]
-
-    // expect to receive an array with first result being a setAll action
-    expect(parseResult[0]).toMatchSnapshot()
-
-    // expect second result being a request to getFeedsRoutesAndStops
-    expect(parseResult[1]).toMatchSnapshot()
-
-    // don't bother testing result of getFeedsRoutesAndStops
-    // since it is tested in the get-feeds-routes-and-stops file
+    expect(fetchResult).toMatchSnapshot()
   })
 
   it('saveToServer should work', async () => {
@@ -149,17 +92,13 @@ describe('actions > modifications', () => {
       .put('/api/modification/1234')
       .reply(200, 'saved')
 
-    const saveResult = modifications.saveToServer(mockModification)
-
-    // expect to receive increment action while making request
-    expect(saveResult[0]).toMatchSnapshot()
-
-    // perform request
+    const store = makeMockStore()
+    const save = modifications.saveToServer(mockModification)
+    expect(save).toMatchSnapshot()
+    const saveResult = store.dispatch(save)
+    expect(saveResult).toMatchSnapshot()
     const fetchResult = await saveResult[1]
-
-    // expect to receive only decrement action upon fulfillment of request
-    expect(fetchResult.length).toBe(1)
-    expect(fetchResult[0]).toMatchSnapshot()
+    expect(fetchResult).toMatchSnapshot()
   })
 
   it('set should work', async () => {
@@ -167,19 +106,13 @@ describe('actions > modifications', () => {
       .put('/api/modification/1234')
       .reply(200, 'saved')
 
-    const setResult = modifications.set(mockModification)
-
-    // should receive an array of arrays
-    expect(setResult.length).toBe(2)
-
-    // expect a setLocally action
-    expect(setResult[0]).toMatchSnapshot()
-
-    // expect saveToServer action
-    expect(setResult[1]).toMatchSnapshot()
-
-    // don't bother testing result of saveToServer
-    // since it is tested in another test case in this file
+    const store = makeMockStore()
+    const set = modifications.set(mockModification)
+    expect(set).toMatchSnapshot()
+    const setResult = store.dispatch(set)
+    expect(setResult).toMatchSnapshot()
+    const fetchResult = await setResult[1]
+    expect(fetchResult).toMatchSnapshot()
   })
 
   it('setActive should work', () => {
@@ -187,29 +120,12 @@ describe('actions > modifications', () => {
   })
 
   it('setAndRetrieveData should work', async () => {
-    nock('http://mockHost.com/')
-      .put('/api/modification/1')
-      .reply(200, 'saved')
-      .get(/^\/api\/graphql/)
-      .reply(200)
-
     const setResult = modifications.setAndRetrieveData({
       bundleId: 1,
       modification: mockModification
     })
 
-    // should receive an array
-    expect(setResult.length).toBe(2)
-
-    // expect a set action (array of setLocally and saveToServer)
-    expect(setResult[0]).toMatchSnapshot()
-
-    // expect a getFeedsRoutesAndStops action
-    expect(setResult[1]).toMatchSnapshot()
-
-    // don't bother testing result of getFeedsRoutesAndStops or saveToServer
-    // getFeedsRoutesAndStops is tested in the get-feeds-routes-and-stops file
-    // saveToServer is tested in another test case in this file
+    expect(setResult).toMatchSnapshot()
   })
 
   it('setLocally should work', () => {

--- a/lib/actions/__tests__/project.js
+++ b/lib/actions/__tests__/project.js
@@ -12,10 +12,12 @@ describe('actions > project', () => {
 
     const store = makeMockStore()
     const create = project.create(mockProject)
-    expect(create).toMatchSnapshot()
+    create.payload.options.body.id = 1
     const createResult = store.dispatch(create)
-    expect(createResult).toMatchSnapshot()
     const fetchResult = await createResult[1]
+
+    expect(create).toMatchSnapshot()
+    expect(createResult).toMatchSnapshot()
     expect(fetchResult).toMatchSnapshot()
   })
 

--- a/lib/actions/__tests__/project.js
+++ b/lib/actions/__tests__/project.js
@@ -3,19 +3,20 @@
 describe('actions > project', () => {
   const nock = require('nock')
   const project = require('../project')
-  const {mockProject} = require('../../utils/mock-data')
+  const {makeMockStore, mockProject} = require('../../utils/mock-data')
 
-  it('create should work', () => {
-    const postNock = nock('http://mockhost.com/')
+  it('create should work', async () => {
+    nock('http://mockhost.com/')
       .post('/api/project')
       .reply(200)
 
-    const createResult = project.create(mockProject)
-    const fetchAction = createResult[1]
-    return fetchAction
-      .then((actions) => {
-        expect(postNock.isDone()).toBeTruthy()
-      })
+    const store = makeMockStore()
+    const create = project.create(mockProject)
+    expect(create).toMatchSnapshot()
+    const createResult = store.dispatch(create)
+    expect(createResult).toMatchSnapshot()
+    const fetchResult = await createResult[1]
+    expect(fetchResult).toMatchSnapshot()
   })
 
   it('deleteProject should work', async () => {
@@ -23,24 +24,13 @@ describe('actions > project', () => {
       .delete('/api/project/1')
       .reply(200)
 
-    const deleteResult = project.deleteProject('1')
-
-    // expect to receive increment action while making request
-    expect(deleteResult[0]).toMatchSnapshot()
-
-    // perform request
-    const fetchResult = await deleteResult[1]
-
-    // expect to receive decrement action upon fulfillment of request
-    expect(fetchResult[0]).toMatchSnapshot()
-
-    // parse response
-    const parseResult = await fetchResult[1]
-
-    // should receive an array of actions
-    // - delete project
-    // - react router action to go to home
-    expect(parseResult).toMatchSnapshot()
+    const store = makeMockStore()
+    const action = project.deleteProject('1')
+    expect(action).toMatchSnapshot()
+    const actionResult = store.dispatch(action)
+    expect(actionResult).toMatchSnapshot()
+    const fetchResult = await actionResult[1]
+    expect(fetchResult).toMatchSnapshot()
   })
 
   it('load should work', async () => {
@@ -59,26 +49,13 @@ describe('actions > project', () => {
       .get('/api/project/1')
       .reply(200, mockProject)
 
-    const loadResult = project.load('1')
-
-    // expect to receive increment action while making request
-    expect(loadResult[0]).toMatchSnapshot()
-
-    // perform request
-    const fetchResult = await loadResult[1]
-
-    // expect to receive decrement action upon fulfillment of request
-    expect(fetchResult[0]).toMatchSnapshot()
-
-    // parse response
-    const parseResult = await fetchResult[1]
-
-    // should receive an array of actions
-    // - setLocally
-    // - map.setCenter
-    // - index.setBundles
-    // - scenario.setScenarios
-    expect(parseResult).toMatchSnapshot()
+    const store = makeMockStore()
+    const action = project.load('1')
+    expect(action).toMatchSnapshot()
+    const actionResult = store.dispatch(action)
+    expect(actionResult).toMatchSnapshot()
+    const fetchResult = await actionResult[1]
+    expect(fetchResult).toMatchSnapshot()
   })
 
   it('loadAll should work', async () => {
@@ -86,22 +63,13 @@ describe('actions > project', () => {
       .get('/api/project')
       .reply(200, [])
 
-    const loadResult = project.loadAll()
-
-    // expect to receive increment action while making request
-    expect(loadResult[0]).toMatchSnapshot()
-
-    // perform request
-    const fetchResult = await loadResult[1]
-
-    // expect to receive decrement action upon fulfillment of request
-    expect(fetchResult[0]).toMatchSnapshot()
-
-    // parse response
-    const parseResult = await fetchResult[1]
-
-    // should receive an setAll action
-    expect(parseResult).toMatchSnapshot()
+    const store = makeMockStore()
+    const action = project.loadAll()
+    expect(action).toMatchSnapshot()
+    const actionResult = store.dispatch(action)
+    expect(actionResult).toMatchSnapshot()
+    const fetchResult = await actionResult[1]
+    expect(fetchResult).toMatchSnapshot()
   })
 
   it('save should work', async () => {
@@ -109,18 +77,12 @@ describe('actions > project', () => {
       .put('/api/project/1')
       .reply(200, 'saved')
 
-    const saveResult = project.save({ id: '1' })
-
-    // expect setLocally action
-    expect(saveResult[0]).toMatchSnapshot()
-
-    // expect to receive increment action while making request
-    expect(saveResult[1][0]).toMatchSnapshot()
-
-    // perform request
-    const fetchResult = await saveResult[1][1]
-
-    // expect to receive a single decrement action upon fulfillment of request
+    const store = makeMockStore()
+    const action = project.save({ id: '1' })
+    expect(action).toMatchSnapshot()
+    const actionResult = store.dispatch(action)
+    expect(actionResult).toMatchSnapshot()
+    const fetchResult = await actionResult[1]
     expect(fetchResult).toMatchSnapshot()
   })
 

--- a/lib/actions/__tests__/scenario.js
+++ b/lib/actions/__tests__/scenario.js
@@ -3,34 +3,26 @@
 describe('actions > scenario', () => {
   const nock = require('nock')
   const scenario = require('../scenario')
+  const {makeMockStore} = require('../../utils/mock-data')
 
   it('create should work', async () => {
     nock('http://mockHost.com/')
       .post('/api/scenario')
       .reply(200, { id: '1' })
 
-    const createResult = scenario.create({
+    const action = scenario.create({
       bundleId: '1',
       name: 'test',
       projectId: '1'
     })
+    const store = makeMockStore()
+    const actionResult = store.dispatch(action)
+    const fetchResult = await actionResult[1]
 
-    // expect to receive increment action while making request
-    expect(createResult[0]).toMatchSnapshot()
-
-    // perform request
-    const fetchResult = await createResult[1]
-
-    // expect to receive decrement action upon fulfillment of request
-    expect(fetchResult[0]).toMatchSnapshot()
-
-    // parse response
-    const parseResult = await fetchResult[1]
-
-    // should receive an array of actions
-    // - addScenario
-    // - react router action to go to new scenario
-    expect(parseResult).toMatchSnapshot()
+    delete action.payload.options.body.id
+    expect(action).toMatchSnapshot()
+    expect(actionResult).toMatchSnapshot()
+    expect(fetchResult).toMatchSnapshot()
   })
 
   it('deleteScenario should work', async () => {
@@ -38,27 +30,16 @@ describe('actions > scenario', () => {
       .delete('/api/scenario/1')
       .reply(200, 'deleted')
 
-    const deleteResult = scenario.deleteScenario({
+    const action = scenario.deleteScenario({
       projectId: '1',
       scenarioId: '1'
     })
-
-    // expect to receive increment action while making request
-    expect(deleteResult[0]).toMatchSnapshot()
-
-    // perform request
-    const fetchResult = await deleteResult[1]
-
-    // expect to receive decrement action upon fulfillment of request
-    expect(fetchResult[0]).toMatchSnapshot()
-
-    // parse response
-    const parseResult = await fetchResult[1]
-
-    // should receive an array of actions
-    // - deleteLocally
-    // - react router action to go to certain project
-    expect(parseResult).toMatchSnapshot()
+    const store = makeMockStore()
+    expect(action).toMatchSnapshot()
+    const actionResult = store.dispatch(action)
+    expect(actionResult).toMatchSnapshot()
+    const fetchResult = await actionResult[1]
+    expect(fetchResult).toMatchSnapshot()
   })
 
   it('load should work', async () => {
@@ -68,27 +49,13 @@ describe('actions > scenario', () => {
       .get('/api/scenario/1/modifications')
       .reply(200)
 
-    const loadResult = scenario.load('1')
-
-    // expect to receive increment action while making request
-    expect(loadResult[0]).toMatchSnapshot()
-
-    // perform request
-    const fetchResult = await loadResult[1]
-
-    // expect to receive decrement action upon fulfillment of request
-    expect(fetchResult[0]).toMatchSnapshot()
-
-    // parse response
-    const parseResult = await fetchResult[1]
-
-    // should receive an array of actions
-    // - set
-    // - modifications.getForScenario
-    expect(parseResult).toMatchSnapshot()
-
-    // don't bother to test getForScenario
-    // since it is tested in the modifications file
+    const action = scenario.load('1')
+    const store = makeMockStore()
+    expect(action).toMatchSnapshot()
+    const actionResult = store.dispatch(action)
+    expect(actionResult).toMatchSnapshot()
+    const fetchResult = await actionResult[1]
+    expect(fetchResult).toMatchSnapshot()
   })
 
   it('saveToServer should work', async () => {
@@ -96,22 +63,13 @@ describe('actions > scenario', () => {
       .put('/api/scenario/1')
       .reply(200, { id: '1' })
 
-    const saveResult = scenario.saveToServer({ id: '1' })
-
-    // expect to receive increment action while making request
-    expect(saveResult[0]).toMatchSnapshot()
-
-    // perform request
-    const fetchResult = await saveResult[1]
-
-    // expect to receive decrement action upon fulfillment of request
-    expect(fetchResult[0]).toMatchSnapshot()
-
-    // parse response
-    const parseResult = await fetchResult[1]
-
-    // should receive only a set action
-    expect(parseResult).toMatchSnapshot()
+    const action = scenario.saveToServer({ id: '1' })
+    const store = makeMockStore()
+    expect(action).toMatchSnapshot()
+    const actionResult = store.dispatch(action)
+    expect(actionResult).toMatchSnapshot()
+    const fetchResult = await actionResult[1]
+    expect(fetchResult).toMatchSnapshot()
   })
 
   it('set should work', () => {
@@ -127,15 +85,14 @@ describe('actions > scenario', () => {
       .get('/api/scenario/1/modifications')
       .reply(200)
 
-    const loadResult = scenario.setAndLoadModifications({ id: '1', bundleId: '1' })
+    const action = scenario.setAndLoadModifications({ id: '1', bundleId: '1' })
+    const store = makeMockStore()
+    const actionResult = store.dispatch(action)
+    const fetchResult = await actionResult[1]
 
-    // should receive an array of actions
-    // - set
-    // - modifications.getForScenario
-    expect(loadResult).toMatchSnapshot()
-
-    // don't bother to test getForScenario
-    // since it is tested in the modifications file
+    expect(action).toMatchSnapshot()
+    expect(actionResult).toMatchSnapshot()
+    expect(fetchResult).toMatchSnapshot()
   })
 
   it('createVariant should work', () => {

--- a/lib/actions/get-feeds-routes-and-stops.js
+++ b/lib/actions/get-feeds-routes-and-stops.js
@@ -101,8 +101,7 @@ function getUnfetchedRoutes ({
 
             return setFeeds([...fetchedFeeds])
           } else {
-            console.error('No bundles were returned.')
-            window.alert('No bundles were returned.')
+            return lockUiWithError('No bundles were returned.')
           }
         }
       }

--- a/lib/actions/get-feeds-routes-and-stops.js
+++ b/lib/actions/get-feeds-routes-and-stops.js
@@ -1,7 +1,8 @@
 /** use the graphql api to get data needed for modifications */
 
-import {setFeeds} from './'
-import {serverAction} from './network'
+import fetch from '@conveyal/woonerf/fetch'
+
+import {lockUiWithError, setFeeds} from './'
 import * as query from '../graphql/query'
 import * as types from '../utils/modification-types'
 
@@ -27,10 +28,13 @@ function getAllRoutesAndStops ({
   bundleId,
   routeIds
 }) {
-  return serverAction({
+  return fetch({
     url: query.compose(query.data, {bundleId, routeIds}),
-    next: async (response) => {
-      const json = await response.json()
+    next (error, response) {
+      if (error) {
+        return lockUiWithError(error)
+      }
+      const json = response.value
 
       // make sure the bundle ID hasn't changed in the meantime from a concurrent request
       if (bundleId === currentBundleId) {
@@ -74,10 +78,13 @@ function getUnfetchedRoutes ({
   const unfetchedRouteIds = getUnfetchedRouteIds({fetchedFeeds, routeIds})
   // no routes found that haven't been fetched
   if (unfetchedRouteIds.length > 0) {
-    return serverAction({
+    return fetch({
       url: query.compose(query.route, {bundleId, routeIds}),
-      next: async (response) => {
-        const json = await response.json()
+      next (error, response) {
+        if (error) {
+          return lockUiWithError(error)
+        }
+        const json = response.value
         // if another request has changed the bundle out from under us, bail
         if (bundleId === currentBundleId) {
           if (json.bundle && json.bundle.length > 0) {

--- a/lib/actions/index.js
+++ b/lib/actions/index.js
@@ -1,26 +1,29 @@
+import fetch from '@conveyal/woonerf/fetch'
 import {createAction} from 'redux-actions'
 
-import {serverAction} from './network'
+export const lockUiWithError = createAction('lock ui with error')
 
 // bundle
 export const addBundle = createAction('add bundle')
 export const deleteBundle = (id) => [deleteBundleLocally(id), deleteBundleOnServer(id)]
 const deleteBundleLocally = createAction('delete bundle')
 const deleteBundleOnServer = (id) =>
-  serverAction({
+  fetch({
     url: `/api/bundle/${id}`,
     options: {
       method: 'delete'
-    }
+    },
+    next: (error) => error && lockUiWithError(error)
   })
 export const saveBundle = (bundle) => [setBundle(bundle), saveBundleToServer(bundle)]
 const saveBundleToServer = (bundle) =>
-  serverAction({
+  fetch({
     url: `/api/bundle/${bundle.id}`,
     options: {
       method: 'put',
-      body: JSON.stringify(bundle)
-    }
+      body: bundle
+    },
+    next: (error) => error && lockUiWithError(error)
   })
 export const setBundle = createAction('set bundle')
 export const setBundles = createAction('set bundles')

--- a/lib/actions/modifications.js
+++ b/lib/actions/modifications.js
@@ -1,9 +1,10 @@
+import fetch from '@conveyal/woonerf/fetch'
 import {push} from 'react-router-redux'
 import {createAction} from 'redux-actions'
 import uuid from 'uuid'
 
+import {lockUiWithError} from './'
 import getFeedsRoutesAndStops from './get-feeds-routes-and-stops'
-import {lockUiWithError, serverAction} from './network'
 import {
   create as createModification,
   formatForServer,
@@ -15,10 +16,14 @@ export function copyFromScenario ({
   toScenarioId,
   variants
 }) {
-  return serverAction({
+  return fetch({
     url: `/api/scenario/${fromScenarioId}/modifications`,
-    next: async (response) => {
-      const modifications = await response.json()
+    next (error, response) {
+      if (error) {
+        return lockUiWithError(error)
+      }
+
+      const modifications = response.value
       return modifications
         .map((modification) => {
           const newVariants = []
@@ -49,7 +54,7 @@ export const create = ({
   type,
   variants
 }) =>
-  serverAction({
+  fetch({
     url: '/api/modification',
     options: {
       body: JSON.stringify(createModification({
@@ -60,8 +65,11 @@ export const create = ({
       })),
       method: 'post'
     },
-    next: async (response) => {
-      const modification = await response.json()
+    next (error, response) {
+      if (error) {
+        return lockUiWithError(error)
+      }
+      const modification = response.value
       return [
         setLocally(modification),
         push(`/projects/${projectId}/scenarios/${scenarioId}/modifications/${modification.id}`)
@@ -71,11 +79,12 @@ export const create = ({
 
 const deleteLocally = createAction('delete modification')
 const deleteOnServer = (id) =>
-  serverAction({
+  fetch({
     url: `/api/modification/${id}`,
     options: {
       method: 'delete'
-    }
+    },
+    next: (error) => error && lockUiWithError(error)
   })
 export const deleteModification = (id) => [deleteLocally(id), deleteOnServer(id)]
 
@@ -83,10 +92,13 @@ export function getForScenario ({
   bundleId,
   scenarioId
 }) {
-  return serverAction({
+  return fetch({
     url: `/api/scenario/${scenarioId}/modifications`,
-    next: async (response) => {
-      const modifications = await response.json()
+    next (error, response) {
+      if (error) {
+        return lockUiWithError(error)
+      }
+      const modifications = response.value
       return [
         setAll(modifications),
         getFeedsRoutesAndStops({
@@ -99,12 +111,13 @@ export function getForScenario ({
 }
 
 export const saveToServer = (m) =>
-  serverAction({
+  fetch({
     url: `/api/modification/${m.id}`,
     options: {
-      body: JSON.stringify(formatForServer(m)),
+      body: formatForServer(m),
       method: 'put'
-    }
+    },
+    next: (error) => error && lockUiWithError(error)
   })
 
 export const set = (m) => [setLocally(m), saveToServer(m)]

--- a/lib/actions/modifications.js
+++ b/lib/actions/modifications.js
@@ -57,12 +57,12 @@ export const create = ({
   fetch({
     url: '/api/modification',
     options: {
-      body: JSON.stringify(createModification({
+      body: createModification({
         feedId,
         scenarioId,
         type,
         variants
-      })),
+      }),
       method: 'post'
     },
     next (error, response) {

--- a/lib/actions/project.js
+++ b/lib/actions/project.js
@@ -58,7 +58,7 @@ export const loadAll = () =>
     url: '/api/project',
     next: (error, response) => error
       ? lockUiWithError(error)
-      : [console.log(response), setAll(response.value)]
+      : setAll(response.value)
   })
 
 export const save = (project) => [setLocally(project), saveToServer(project)]

--- a/lib/actions/project.js
+++ b/lib/actions/project.js
@@ -1,48 +1,50 @@
+import fetch from '@conveyal/woonerf/fetch'
 import {createAction} from 'redux-actions'
 import {push} from 'react-router-redux'
 import uuid from 'uuid'
 
+import {lockUiWithError, setBundles} from './'
 import {setCenter as setMapCenter} from './map'
-import {serverAction} from './network'
-import {setBundles} from './'
 import {setAll as setScenarios} from './scenario'
 import {clear as clearBrowsochrones} from '../utils/browsochrones'
 
 export const create = (project) => {
   project.id = uuid.v4()
-  return serverAction({
+  return fetch({
     url: '/api/project',
     options: {
-      body: JSON.stringify(project),
+      body: project,
       method: 'post'
     },
-    next: async (response) => [
-      setLocally(project),
-      push(`/projects/${project.id}`)
-    ]
+    next: (error, response) => error
+      ? lockUiWithError(error)
+      : [setLocally(project), push(`/projects/${project.id}`)]
   })
 }
 
 const deleteLocally = createAction('delete project')
 export const deleteProject = (id) =>
-  serverAction({
+  fetch({
     options: {
       method: 'delete'
     },
     url: `/api/project/${id}`,
-    next: async () => [
-      deleteLocally(id),
-      push('/')
-    ]
+    next: (error) => error
+      ? lockUiWithError(error)
+      : [deleteLocally(id), push('/')]
   })
 
 export const load = (id) =>
-  serverAction({
+  fetch({
     url: `/api/project/${id}`,
-    next: async (response) => {
-      const project = await response.json()
-      clearBrowsochrones()
+    next (error, response) {
+      if (error) {
+        return lockUiWithError(error)
+      }
+
+      const project = response.value
       return [
+        clearBrowsochrones(),
         setLocally({...project, bundles: [], scenarios: []}),
         setMapCenter([(project.bounds.west + project.bounds.east) / 2, (project.bounds.north + project.bounds.south) / 2]),
         setBundles(project.bundles),
@@ -52,22 +54,22 @@ export const load = (id) =>
   })
 
 export const loadAll = () =>
-  serverAction({
+  fetch({
     url: '/api/project',
-    next: async (response) => {
-      const projects = await response.json()
-      return setAll(projects)
-    }
+    next: (error, response) => error
+      ? lockUiWithError(error)
+      : [console.log(response), setAll(response.value)]
   })
 
 export const save = (project) => [setLocally(project), saveToServer(project)]
 const saveToServer = (project) =>
-  serverAction({
+  fetch({
     url: `/api/project/${project.id}`,
     options: {
-      body: JSON.stringify(project),
+      body: project,
       method: 'put'
-    }
+    },
+    next: (error) => error && lockUiWithError(error)
   })
 
 export const setAll = createAction('set all projects')

--- a/lib/actions/scenario.js
+++ b/lib/actions/scenario.js
@@ -1,9 +1,10 @@
+import fetch from '@conveyal/woonerf/fetch'
 import {createAction} from 'redux-actions'
 import {push} from 'react-router-redux'
 import uuid from 'uuid'
 
+import {lockUiWithError} from './'
 import {getForScenario as getModificationsForScenario} from './modifications'
-import {serverAction} from './network'
 
 // scenario stuff
 const addScenario = createAction('add scenario')
@@ -12,20 +13,24 @@ export const create = ({
   name,
   projectId
 }) =>
-  serverAction({
+  fetch({
     url: '/api/scenario',
     options: {
-      body: JSON.stringify({
+      body: {
         bundleId,
         id: uuid.v4(),
         name,
         projectId,
         variants: ['Default']
-      }),
+      },
       method: 'post'
     },
-    next: async (response) => {
-      const scenario = await response.json()
+    next (error, response) {
+      if (error) {
+        return lockUiWithError(error)
+      }
+
+      const scenario = response.value
       return [
         addScenario(scenario),
         push(`/projects/${projectId}/scenarios/${scenario.id}`)
@@ -38,24 +43,25 @@ export const deleteScenario = ({
   projectId,
   scenarioId
 }) =>
-  serverAction({
+  fetch({
     url: `/api/scenario/${scenarioId}`,
     options: {
       method: 'delete'
     },
-    next: async () => {
-      return [
-        deleteLocally(scenarioId),
-        push(`/projects/${projectId}`)
-      ]
-    }
+    next: (error) => error
+      ? lockUiWithError(error)
+      : [deleteLocally(scenarioId), push(`/projects/${projectId}`)]
   })
 
 export const load = (id) =>
-  serverAction({
+  fetch({
     url: `/api/scenario/${id}`,
-    next: async (response) => {
-      const scenario = await response.json()
+    next (error, response) {
+      if (error) {
+        return lockUiWithError(error)
+      }
+
+      const scenario = response.value
       return [
         set(scenario),
         getModificationsForScenario({bundleId: scenario.bundleId, scenarioId: scenario.id})
@@ -64,16 +70,15 @@ export const load = (id) =>
   })
 
 export const saveToServer = (scenario) =>
-  serverAction({
+  fetch({
     url: `/api/scenario/${scenario.id}`,
     options: {
-      body: JSON.stringify(scenario),
+      body: scenario,
       method: 'put'
     },
-    next: async (response) => {
-      const scenario = await response.json()
-      return set(scenario)
-    }
+    next: (error, response) => error
+      ? lockUiWithError(error)
+      : set(response.value)
   })
 export const set = createAction('set scenario')
 export const setAll = createAction('set scenarios')

--- a/lib/components/__tests__/__snapshots__/create-grid.js.snap
+++ b/lib/components/__tests__/__snapshots__/create-grid.js.snap
@@ -50,6 +50,7 @@ exports[`Component > EditBundle renders correctly 1`] = `
 
 exports[`Component > EditBundle renders csv upload correctly 1`] = `
 <CreateGrid
+  fetch={[Function]}
   finish={[Function]}
   projectId="PROJECT ID">
   <Panel>
@@ -238,6 +239,7 @@ exports[`Component > EditBundle renders csv upload correctly 1`] = `
 
 exports[`Component > EditBundle renders shapefile upload correctly 1`] = `
 <CreateGrid
+  fetch={[Function]}
   finish={[Function]}
   projectId="PROJECT ID">
   <Panel>

--- a/lib/components/__tests__/__snapshots__/create-grid.js.snap
+++ b/lib/components/__tests__/__snapshots__/create-grid.js.snap
@@ -104,26 +104,12 @@ exports[`Component > EditBundle renders csv upload correctly 1`] = `
               label="Grid files"
               multiple={true}
               name="files"
-              onChange={[Function]}
-              value={
-                Array [
-                  Object {
-                    "name": "TEST.CSV",
-                  },
-                ]
-              }>
+              onChange={[Function]}>
               <Group
                 label="Grid files"
                 multiple={true}
                 name="files"
-                onChange={[Function]}
-                value={
-                  Array [
-                    Object {
-                      "name": "TEST.CSV",
-                    },
-                  ]
-                }>
+                onChange={[Function]}>
                 <div
                   className="form-group">
                   <label>
@@ -134,28 +120,14 @@ exports[`Component > EditBundle renders csv upload correctly 1`] = `
                     multiple={true}
                     name="files"
                     onChange={[Function]}
-                    type="file"
-                    value={
-                      Array [
-                        Object {
-                          "name": "TEST.CSV",
-                        },
-                      ]
-                    }>
+                    type="file">
                     <input
                       className="form-control"
                       multiple={true}
                       name="files"
                       onChange={[Function]}
                       placeholder="Grid files"
-                      type="file"
-                      value={
-                        Array [
-                          Object {
-                            "name": "TEST.CSV",
-                          },
-                        ]
-                      } />
+                      type="file" />
                   </Input>
                 </div>
               </Group>
@@ -293,44 +265,12 @@ exports[`Component > EditBundle renders shapefile upload correctly 1`] = `
               label="Grid files"
               multiple={true}
               name="files"
-              onChange={[Function]}
-              value={
-                Array [
-                  Object {
-                    "name": "TEST.shp",
-                  },
-                  Object {
-                    "name": "TEST.shx",
-                  },
-                  Object {
-                    "name": "TEST.dbf",
-                  },
-                  Object {
-                    "name": "TEST.prj",
-                  },
-                ]
-              }>
+              onChange={[Function]}>
               <Group
                 label="Grid files"
                 multiple={true}
                 name="files"
-                onChange={[Function]}
-                value={
-                  Array [
-                    Object {
-                      "name": "TEST.shp",
-                    },
-                    Object {
-                      "name": "TEST.shx",
-                    },
-                    Object {
-                      "name": "TEST.dbf",
-                    },
-                    Object {
-                      "name": "TEST.prj",
-                    },
-                  ]
-                }>
+                onChange={[Function]}>
                 <div
                   className="form-group">
                   <label>
@@ -341,46 +281,14 @@ exports[`Component > EditBundle renders shapefile upload correctly 1`] = `
                     multiple={true}
                     name="files"
                     onChange={[Function]}
-                    type="file"
-                    value={
-                      Array [
-                        Object {
-                          "name": "TEST.shp",
-                        },
-                        Object {
-                          "name": "TEST.shx",
-                        },
-                        Object {
-                          "name": "TEST.dbf",
-                        },
-                        Object {
-                          "name": "TEST.prj",
-                        },
-                      ]
-                    }>
+                    type="file">
                     <input
                       className="form-control"
                       multiple={true}
                       name="files"
                       onChange={[Function]}
                       placeholder="Grid files"
-                      type="file"
-                      value={
-                        Array [
-                          Object {
-                            "name": "TEST.shp",
-                          },
-                          Object {
-                            "name": "TEST.shx",
-                          },
-                          Object {
-                            "name": "TEST.dbf",
-                          },
-                          Object {
-                            "name": "TEST.prj",
-                          },
-                        ]
-                      } />
+                      type="file" />
                   </Input>
                 </div>
               </Group>

--- a/lib/components/__tests__/__snapshots__/r5-version.js.snap
+++ b/lib/components/__tests__/__snapshots__/r5-version.js.snap
@@ -2,6 +2,9 @@ exports[`Component > R5Version renders correctly 1`] = `
 <div>
   <div
     className="form-group">
+    <label>
+      Label
+    </label>
     <i
       aria-label="Show all analysis backend versions (advanced)"
       className="fa fa-flask fa-fw "

--- a/lib/components/__tests__/create-grid.js
+++ b/lib/components/__tests__/create-grid.js
@@ -9,6 +9,7 @@ describe('Component > EditBundle', () => {
 
   it('renders correctly', () => {
     const tree = renderer.create(<CreateGrid
+      fetch={jest.fn()}
       projectId='PROJECT ID'
       finish={jest.fn()}
       />).toJSON()
@@ -19,6 +20,7 @@ describe('Component > EditBundle', () => {
   /** extra fields should appear when uploading a CSV */
   it('renders csv upload correctly', () => {
     const cg = <CreateGrid
+      fetch={jest.fn()}
       projectId='PROJECT ID'
       finish={jest.fn()}
       />
@@ -35,6 +37,7 @@ describe('Component > EditBundle', () => {
   /** extra fields should not appear when uploading a shapefile */
   it('renders shapefile upload correctly', () => {
     const cg = <CreateGrid
+      fetch={jest.fn()}
       projectId='PROJECT ID'
       finish={jest.fn()}
       />

--- a/lib/components/__tests__/edit-bundle.js
+++ b/lib/components/__tests__/edit-bundle.js
@@ -11,6 +11,7 @@ describe('Component > EditBundle', () => {
       bundle: {},
       bundleId: '1',
       deleteBundle: jest.fn(),
+      fetch: jest.fn(),
       name: 'Test Bundle',
       projectId: '1',
       saveBundle: jest.fn()

--- a/lib/components/__tests__/edit-project.js
+++ b/lib/components/__tests__/edit-project.js
@@ -16,6 +16,7 @@ describe('Component > EditProject', () => {
       },
       indicators: [],
       description: 'A test scenario',
+      fetch: jest.fn(),
       id: '1',
       name: 'Test Scenario',
       r5Version: '1 billion',

--- a/lib/components/__tests__/r5-version.js
+++ b/lib/components/__tests__/r5-version.js
@@ -1,4 +1,4 @@
-/* global describe, it, expect */
+/* global describe, it, expect, jest */
 
 describe('Component > R5Version', () => {
   const renderer = require('react-test-renderer')
@@ -6,7 +6,12 @@ describe('Component > R5Version', () => {
   const R5Version = require('../r5-version')
 
   it('renders correctly', () => {
-    const props = {}
+    const props = {
+      fetch: jest.fn(),
+      label: 'Label',
+      name: 'Name',
+      onChange: jest.fn()
+    }
 
     // mount component
     const tree = renderer.create(

--- a/lib/components/analysis/__tests__/__snapshots__/index.js.snap
+++ b/lib/components/analysis/__tests__/__snapshots__/index.js.snap
@@ -23,7 +23,11 @@ exports[`Components > Analysis > Single Point should render correctly 1`] = `
   isochroneLonLat={Object {}}
   loadRegionalAnalyses={[Function]}
   modifications={Array []}
-  profileRequest={Object {}}
+  profileRequest={
+    Object {
+      "date": "2016-01-16",
+    }
+  }
   projectId=""
   removeIsochroneLayerFromMap={[Function]}
   removeOpportunityLayerFromMap={[Function]}

--- a/lib/components/analysis/__tests__/__snapshots__/regional.js.snap
+++ b/lib/components/analysis/__tests__/__snapshots__/regional.js.snap
@@ -107,6 +107,7 @@ exports[`Components > Analysis > Regional should handle rendering comparison 1`]
       "zoom": 9,
     }
   }
+  fetch={[Function]}
   grid={
     Object {
       "data": Array [],
@@ -588,6 +589,7 @@ exports[`Components > Analysis > Regional should load analysis if it is not load
       2000,
     ]
   }
+  fetch={[Function]}
   grid={
     Object {
       "data": Array [],
@@ -756,6 +758,7 @@ exports[`Components > Analysis > Regional should render correctly 1`] = `
       2000,
     ]
   }
+  fetch={[Function]}
   grid={
     Object {
       "data": Array [],

--- a/lib/components/analysis/__tests__/index.js
+++ b/lib/components/analysis/__tests__/index.js
@@ -44,7 +44,9 @@ describe('Components > Analysis > Single Point', function () {
       isShowingIsochrone={false}
       isShowingOpportunities={false}
       modifications={[]}
-      profileRequest={{}}
+      profileRequest={{
+        date: '2016-01-16'
+      }}
       projectId=''
       scenarioApplicationErrors={[]}
       scenarioId=''

--- a/lib/components/analysis/__tests__/regional-analysis-selector.js
+++ b/lib/components/analysis/__tests__/regional-analysis-selector.js
@@ -8,11 +8,13 @@ import Regional from '../regional-analysis-selector'
 
 describe('Components > Analysis > Regional Analysis Selector', () => {
   it('renders correctly', () => {
+    const deleteRegionalAnalysis = jest.fn()
     const load = jest.fn()
     const select = jest.fn()
 
     const tree = renderer.create(
       <Regional
+        deleteRegionalAnalysis={deleteRegionalAnalysis}
         loadRegionalAnalyses={load}
         projectId='5678'
         regionalAnalyses={mockRegionalAnalyses}
@@ -22,6 +24,7 @@ describe('Components > Analysis > Regional Analysis Selector', () => {
     ).toJSON()
 
     expect(load).toBeCalled()
+    expect(deleteRegionalAnalysis).not.toBeCalled()
     expect(select).not.toBeCalled()
     expect(tree).toMatchSnapshot()
   })

--- a/lib/components/analysis/__tests__/regional.js
+++ b/lib/components/analysis/__tests__/regional.js
@@ -24,6 +24,7 @@ describe('Components > Analysis > Regional', () => {
       // actions
       addRegionalAnalysisLayerToMap={addRegionalAnalysisLayerToMap}
       addRegionalComparisonLayerToMap={jest.fn()}
+      fetch={jest.fn()}
       loadRegionalAnalyses={jest.fn()}
       removeRegionalAnalysisLayerFromMap={jest.fn()}
       removeRegionalComparisonLayerFromMap={jest.fn()}
@@ -52,6 +53,7 @@ describe('Components > Analysis > Regional', () => {
       // actions
       addRegionalAnalysisLayerToMap={addRegionalAnalysisLayerToMap}
       addRegionalComparisonLayerToMap={jest.fn()}
+      fetch={jest.fn()}
       loadRegionalAnalyses={loadRegionalAnalyses}
       removeRegionalAnalysisLayerFromMap={jest.fn()}
       removeRegionalComparisonLayerFromMap={jest.fn()}
@@ -87,6 +89,7 @@ describe('Components > Analysis > Regional', () => {
       // actions
       addRegionalAnalysisLayerToMap={addRegionalAnalysisLayerToMap}
       addRegionalComparisonLayerToMap={jest.fn()}
+      fetch={jest.fn()}
       loadRegionalAnalyses={jest.fn()}
       removeRegionalAnalysisLayerFromMap={jest.fn()}
       removeRegionalComparisonLayerFromMap={jest.fn()}

--- a/lib/components/analysis/regional.js
+++ b/lib/components/analysis/regional.js
@@ -1,6 +1,7 @@
 /** render a regional analysis */
 
-import React, { Component, PropTypes } from 'react'
+import Icon from '@conveyal/woonerf/components/icon'
+import React, {Component, PropTypes} from 'react'
 import Select from 'react-select'
 import {sprintf} from 'sprintf-js'
 
@@ -10,8 +11,6 @@ import messages from '../../utils/messages'
 import ProfileRequestDisplay from './profile-request-display'
 import Collapsible from '../collapsible'
 import {Slider} from '../input'
-import Icon from '../icon'
-import authenticatedFetch from '../../utils/authenticated-fetch'
 
 export default class RegionalAnalysis extends Component {
   static propTypes = {
@@ -29,6 +28,7 @@ export default class RegionalAnalysis extends Component {
     // actions
     addRegionalAnalysisLayerToMap: PropTypes.func.isRequired,
     addRegionalComparisonLayerToMap: PropTypes.func.isRequired,
+    fetch: PropTypes.func.isRequired,
     loadRegionalAnalyses: PropTypes.func.isRequired,
     removeRegionalAnalysisLayerFromMap: PropTypes.func.isRequired,
     removeRegionalComparisonLayerFromMap: PropTypes.func.isRequired,
@@ -95,20 +95,38 @@ export default class RegionalAnalysis extends Component {
     </div>
   }
 
+  /**
+   * Perform an authenticated fetch to get a presigned URL to download a grid from S3,
+   * then download it. Pass in the path to fetch.
+   */
+  downloadFromS3 (url) {
+    const {fetch} = this.props
+    fetch({
+      url,
+      next (error, response) {
+        if (error) {
+          window.alert(error)
+        } else {
+          window.open(response.value.url)
+        }
+      }
+    })
+  }
+
   downloadScenarioGIS = (e) => {
     e.preventDefault()
-    downloadFromS3(`/api/regional/${this.props.analysis.id}/grid/mean/tiff?redirect=false`)
+    this.downloadFromS3(`/api/regional/${this.props.analysis.id}/grid/mean/tiff?redirect=false`)
   }
 
   downloadComparisonGIS = (e) => {
     e.preventDefault()
-    downloadFromS3(`/api/regional/${this.props.comparisonAnalysis.id}/grid/mean/tiff?redirect=false`)
+    this.downloadFromS3(`/api/regional/${this.props.comparisonAnalysis.id}/grid/mean/tiff?redirect=false`)
   }
 
   downloadProbabilityGIS = (e) => {
     e.preventDefault()
     // NB base comes first (TODO change?)
-    downloadFromS3(`/api/regional/${this.props.comparisonAnalysis.id}/${this.props.analysis.id}/tiff?redirect=false`)
+    this.downloadFromS3(`/api/regional/${this.props.comparisonAnalysis.id}/${this.props.analysis.id}/tiff?redirect=false`)
   }
 
   renderGisExport () {
@@ -229,13 +247,4 @@ function MinimumImprovementProbabilitySelector ({
       onChange={(e) => setMinimumImprovementProbability(parseFloat(e.target.value))}
       />
   )
-}
-
-/**
- * Perform an authenticated fetch to get a presigned URL to download a grid from S3,
- * then download it. Pass in the path to fetch.
- */
-async function downloadFromS3 (path) {
-  const res = await authenticatedFetch(path).then(res => res.json())
-  window.open(res.url)
 }

--- a/lib/components/create-grid.js
+++ b/lib/components/create-grid.js
@@ -79,7 +79,6 @@ export default class CreateGrid extends Component {
           label={messages.analysis.gridFiles}
           name='files'
           onChange={this.setFiles}
-          value={files}
           />
 
         {csv && this.renderCsvFields()}

--- a/lib/components/create-grid.js
+++ b/lib/components/create-grid.js
@@ -1,9 +1,8 @@
 /** Create a grid by uploading files */
 
-import React, { Component, PropTypes } from 'react'
+import Icon from '@conveyal/woonerf/components/icon'
+import React, {Component, PropTypes} from 'react'
 
-import authenticatedFetch from '../utils/authenticated-fetch'
-import Icon from './icon'
 import {File, Text} from './input'
 import {Body, Heading, Panel} from './panel'
 import messages from '../utils/messages'
@@ -11,6 +10,7 @@ import messages from '../utils/messages'
 export default class CreateGrid extends Component {
   static propTypes = {
     projectId: PropTypes.string.isRequired,
+    fetch: PropTypes.func.isRequired,
     finish: PropTypes.func.isRequired
   }
 
@@ -21,38 +21,37 @@ export default class CreateGrid extends Component {
   }
 
   render () {
-    const { uploading } = this.state
+    const {uploading} = this.state
 
-    return <Panel>
-      <Heading>{messages.analysis.createGrid}</Heading>
-      { uploading ? this.renderUploading() : this.renderForm()}
-    </Panel>
+    return (
+      <Panel>
+        <Heading>{messages.analysis.createGrid}</Heading>
+        {uploading ? <Uploading /> : this.renderForm()}
+      </Panel>
+    )
   }
 
-  renderUploading () {
-    return <Body>
-      <Icon type='spinner' className='fa-spin pull-left' />
-      {messages.analysis.uploading}
-    </Body>
-  }
-
-  onSubmit = async (e) => {
+  onSubmit = (e) => {
     e.preventDefault()
-
+    const {fetch, finish, projectId} = this.props
+    const body = new window.FormData(e.target)
     this.setState({ ...this.state, uploading: true })
 
-    const body = new window.FormData(e.target)
-    const { projectId, finish } = this.props
-
-    // TODO make the backend async
-    await authenticatedFetch(`/api/grid/${projectId}`, {
-      method: 'post',
-      body
+    fetch({
+      url: `/api/grid/${projectId}`,
+      options: {
+        body,
+        method: 'post'
+      },
+      next (error, response) {
+        if (error) {
+          window.alert(error)
+          console.error(error)
+        } else {
+          finish(projectId)
+        }
+      }
     })
-
-    // TODO handle error
-
-    finish(projectId)
   }
 
   setFiles = (e) => {
@@ -64,7 +63,7 @@ export default class CreateGrid extends Component {
   }
 
   renderForm () {
-    let { name, files, uploading, csv } = this.state
+    const {csv, files, name, uploading} = this.state
 
     return <Body>
       <form onSubmit={this.onSubmit} method='post' encType='multipart/form-data'>
@@ -114,4 +113,13 @@ export default class CreateGrid extends Component {
         />
     </span>
   }
+}
+
+function Uploading () {
+  return (
+    <Body>
+      <Icon type='spinner' className='fa-spin pull-left' />
+      {messages.analysis.uploading}
+    </Body>
+  )
 }

--- a/lib/components/edit-bundle.js
+++ b/lib/components/edit-bundle.js
@@ -54,7 +54,7 @@ export default class EditBundle extends Pure {
           body: new window.FormData(e.target),
           method: 'post'
         },
-        next (err, response) {
+        next: (err, response) => {
           if (err) {
             console.error(err)
             console.error(err.stack)
@@ -72,16 +72,17 @@ export default class EditBundle extends Pure {
 
   /** check if the upload has completed */
   _checkUploadState = () => {
-    this.props.fetch({
+    const {addBundle, fetch} = this.props
+    fetch({
       url: `/api/bundle/${this.state.bundleId}`,
-      next (error, response) {
+      next: (error, response) => {
         if (error) {
           console.error(error, error.stack)
           // this request failing does not imply that the bundle failed to upload
           setTimeout(this._checkUploadState, POLL_TIMEOUT_MS)
         } else if (response.value.state === STATUS_DONE) {
           this.setState({files: undefined, name: undefined, uploading: false, uploadFailed: false, bundleId: undefined})
-          this.props.addBundle(response.value)
+          addBundle(response.value)
         } else {
           setTimeout(this._checkUploadState, POLL_TIMEOUT_MS)
         }
@@ -148,7 +149,7 @@ export default class EditBundle extends Pure {
                 ><Icon type='trash' /> {messages.bundle.delete}
               </Button>
             }
-            {uploading && <span><Icon className='fa-spin' type='spinner' /> Uploading&hellip;</span>}
+            {uploading && <span><Icon className='fa-spin' type='spinner' /> {bundleId ? 'Uploading' : 'Processing'}&hellip;</span>}
           </form>
         </Body>
       </Panel>

--- a/lib/components/edit-bundle.js
+++ b/lib/components/edit-bundle.js
@@ -1,24 +1,26 @@
+import Icon from '@conveyal/woonerf/components/icon'
+import Pure from '@conveyal/woonerf/components/pure'
 import React, {PropTypes} from 'react'
 
 import {Button} from './buttons'
-import DeepEqualComponent from './deep-equal'
 import {Body, Heading, Panel} from './panel'
-import Icon from './icon'
 import {File, Text} from './input'
 import messages from '../utils/messages'
-import authenticatedFetch, {parseJSON} from '../utils/authenticated-fetch'
 
 // how often to poll when waiting for a bundle to be read on the server.
 const POLL_TIMEOUT_MS = 1000
+const STATUS_DONE = 'DONE'
 
-export default class EditBundle extends DeepEqualComponent {
+export default class EditBundle extends Pure {
   static propTypes = {
-    addBundle: PropTypes.func.isRequired,
     bundle: PropTypes.object,
     bundleId: PropTypes.string,
-    deleteBundle: PropTypes.func.isRequired,
     name: PropTypes.string,
     projectId: PropTypes.string.isRequired,
+
+    addBundle: PropTypes.func.isRequired,
+    deleteBundle: PropTypes.func.isRequired,
+    fetch: PropTypes.func.isRequired,
     saveBundle: PropTypes.func.isRequired
   }
 
@@ -40,26 +42,28 @@ export default class EditBundle extends DeepEqualComponent {
   _submit = (e) => {
     // don't submit the form
     e.preventDefault()
-    const {bundle, saveBundle} = this.props
+    const {bundle, fetch, saveBundle} = this.props
     const {files, name} = this.state
     if (bundle && name) {
       bundle.name = name
       saveBundle(bundle)
     } else if (name && files) {
-      const data = new window.FormData(e.target)
-
-      authenticatedFetch('/api/bundle', {
-        method: 'post',
-        body: data
-      })
-      .then(parseJSON)
-      .then((res) => {
-        this.setState({...this.state, bundleId: res.id})
-        setTimeout(this._checkUploadState, POLL_TIMEOUT_MS)
-      }, (err) => {
-        console.error(err)
-        console.error(err.stack)
-        this.setState({...this.state, uploading: false, uploadFailed: true})
+      fetch({
+        url: '/api/bundle',
+        options: {
+          body: new window.FormData(e.target),
+          method: 'post'
+        },
+        next (err, response) {
+          if (err) {
+            console.error(err)
+            console.error(err.stack)
+            this.setState({...this.state, uploading: false, uploadFailed: true})
+          } else {
+            this.setState({...this.state, bundleId: response.value.id})
+            setTimeout(this._checkUploadState, POLL_TIMEOUT_MS)
+          }
+        }
       })
 
       this.setState({...this.state, uploading: true, uploadFailed: false})
@@ -68,19 +72,20 @@ export default class EditBundle extends DeepEqualComponent {
 
   /** check if the upload has completed */
   _checkUploadState = () => {
-    authenticatedFetch(`/api/bundle/${this.state.bundleId}`)
-    .then(parseJSON)
-    .then((res) => {
-      if (res.status === 'DONE') {
-        this.setState({files: undefined, name: undefined, uploading: false, uploadFailed: false, bundleId: undefined})
-        this.props.addBundle(res)
-      } else {
-        setTimeout(this._checkUploadState, POLL_TIMEOUT_MS)
+    this.props.fetch({
+      url: `/api/bundle/${this.state.bundleId}`,
+      next (error, response) {
+        if (error) {
+          console.error(error, error.stack)
+          // this request failing does not imply that the bundle failed to upload
+          setTimeout(this._checkUploadState, POLL_TIMEOUT_MS)
+        } else if (response.value.state === STATUS_DONE) {
+          this.setState({files: undefined, name: undefined, uploading: false, uploadFailed: false, bundleId: undefined})
+          this.props.addBundle(response.value)
+        } else {
+          setTimeout(this._checkUploadState, POLL_TIMEOUT_MS)
+        }
       }
-    }, (err) => {
-      console.error(err, err.stack)
-      // this request failing does not imply that the bundle failed to upload
-      setTimeout(this._checkUploadState, POLL_TIMEOUT_MS)
     })
   }
 

--- a/lib/components/edit-bundle.js
+++ b/lib/components/edit-bundle.js
@@ -80,7 +80,7 @@ export default class EditBundle extends Pure {
           console.error(error, error.stack)
           // this request failing does not imply that the bundle failed to upload
           setTimeout(this._checkUploadState, POLL_TIMEOUT_MS)
-        } else if (response.value.state === STATUS_DONE) {
+        } else if (response.value.status === STATUS_DONE) {
           this.setState({files: undefined, name: undefined, uploading: false, uploadFailed: false, bundleId: undefined})
           addBundle(response.value)
         } else {

--- a/lib/components/edit-project.js
+++ b/lib/components/edit-project.js
@@ -12,24 +12,27 @@ const cardinalDirections = ['North', 'South', 'East', 'West']
 
 export default class EditProject extends DeepEqualComponent {
   static propTypes = {
-    addComponentToMap: PropTypes.func.isRequired,
     bounds: PropTypes.shape({
       north: PropTypes.number,
       east: PropTypes.number,
       south: PropTypes.number,
       west: PropTypes.number
     }).isRequired,
-    isEditing: PropTypes.bool.isRequired,
     description: PropTypes.string,
     id: PropTypes.string,
+    indicators: PropTypes.array.isRequired,
+    isEditing: PropTypes.bool.isRequired,
     name: PropTypes.string,
     r5Version: PropTypes.string,
+
+    // actions
+    addComponentToMap: PropTypes.func.isRequired,
+    fetch: PropTypes.func.isRequired,
+    load: PropTypes.func.isRequired,
     removeComponentFromMap: PropTypes.func.isRequired,
     save: PropTypes.func.isRequired,
-    load: PropTypes.func.isRequired,
-    setLocally: PropTypes.func.isRequired,
     setCenter: PropTypes.func.isRequired,
-    indicators: PropTypes.array.isRequired
+    setLocally: PropTypes.func.isRequired
   }
 
   state = {...this.props}
@@ -105,7 +108,7 @@ export default class EditProject extends DeepEqualComponent {
   }
 
   render () {
-    const {bounds, description, isEditing, r5Version} = this.props
+    const {bounds, fetch, description, isEditing, r5Version} = this.props
     const {name} = this.state
     const readyToCreate = name && name.length > 0
     return (
@@ -125,6 +128,7 @@ export default class EditProject extends DeepEqualComponent {
             value={description}
             />
           <R5Version
+            fetch={fetch}
             label={messages.project.r5Version}
             name={messages.project.r5Version}
             onChange={this.onChangeR5Version}

--- a/lib/components/edit-scenario.js
+++ b/lib/components/edit-scenario.js
@@ -13,14 +13,15 @@ export default class EditScenario extends DeepEqualComponent {
     bundleId: PropTypes.string,
     bundleName: PropTypes.string,
     bundles: PropTypes.array.isRequired,
-    close: PropTypes.func.isRequired,
-    create: PropTypes.func.isRequired,
-    deleteScenario: PropTypes.func.isRequired,
     id: PropTypes.string,
     isEditing: PropTypes.bool.isRequired,
     name: PropTypes.string,
     projectId: PropTypes.string.isRequired,
-    variants: PropTypes.array.isRequired,
+    variants: PropTypes.array,
+
+    close: PropTypes.func.isRequired,
+    create: PropTypes.func.isRequired,
+    deleteScenario: PropTypes.func.isRequired,
     save: PropTypes.func.isRequired
   }
 

--- a/lib/components/modification/__tests__/__snapshots__/edit-alignment.js.snap
+++ b/lib/components/modification/__tests__/__snapshots__/edit-alignment.js.snap
@@ -57,7 +57,7 @@ exports[`Component > Modification > Edit Alignment renders correctly 1`] = `
     className="checkbox">
     <label>
       <input
-        defaultChecked={undefined}
+        defaultChecked={false}
         onChange={[Function]}
         type="checkbox" />
        

--- a/lib/components/modification/__tests__/edit-alignment.js
+++ b/lib/components/modification/__tests__/edit-alignment.js
@@ -10,6 +10,7 @@ import EditAlignment from '../edit-alignment'
 describe('Component > Modification > Edit Alignment', function () {
   it('renders correctly', function () {
     const props = {
+      extendFromEnd: false,
       mapState: {
         modificationId: mockModification.id
       },

--- a/lib/components/modification/segment-speeds.js
+++ b/lib/components/modification/segment-speeds.js
@@ -6,6 +6,7 @@ import Collapsible from '../collapsible'
 import DeepEqual from '../deep-equal'
 import {Group, Input, Number as InputNumber} from '../input'
 import {toPrecision} from '../../utils/math'
+import {getAverageSpeedOfSegments, getTravelTimeMinutes} from '../../utils/segments'
 
 export default class SegmentSpeeds extends DeepEqual {
   static propTypes = {
@@ -126,7 +127,7 @@ export default class SegmentSpeeds extends DeepEqual {
 
     const averageSpeed = getAverageSpeedOfSegments({
       segmentDistances,
-      speeds: segmentSpeeds
+      segmentSpeeds
     }) || DEFAULT_SEGMENT_SPEED
 
     const travelTime = getTravelTimeMinutes({
@@ -182,31 +183,5 @@ export default class SegmentSpeeds extends DeepEqual {
         </Collapsible>
       </div>
     )
-  }
-}
-
-function getAverageSpeedOfSegments ({segmentDistances, speeds}) {
-  const totalDistance = sum(segmentDistances)
-  const weightedSpeeds = speeds.map((s, i) => (s * segmentDistances[i]))
-  return weightedSpeeds.reduce((total, speed) => (total + speed), 0) / totalDistance
-}
-
-function getTravelTimeMinutes ({
-  dwellTime, // seconds
-  numberOfStops,
-  segmentDistances, // km
-  segmentSpeeds // kph
-}) {
-  if (numberOfStops > 0) {
-    const segmentTimes = segmentDistances.map(
-      (segmentDistance, i) => (segmentDistance / (segmentSpeeds[i] || DEFAULT_SEGMENT_SPEED)))
-    const totalMovingTime = sum(segmentTimes) * 60
-
-    // add the dwell times
-    const dwellMinutes = dwellTime / 60
-    const dwellingTime = numberOfStops * dwellMinutes
-    return totalMovingTime + dwellingTime
-  } else {
-    return 0
   }
 }

--- a/lib/components/r5-version.js
+++ b/lib/components/r5-version.js
@@ -1,7 +1,6 @@
 /** Select an R5 version, based on what is available in S3 */
 
-import React, {Component} from 'react'
-import fetch from 'isomorphic-fetch'
+import React, {Component, PropTypes} from 'react'
 import Select from 'react-select'
 
 import Icon from './icon'
@@ -13,6 +12,15 @@ const RELEASE_VERSION_REGEX = /^v[0-9]+\.[0-9]+\.[0-9]+$/
 const VERSION_PARSE_REGEX = /^v([0-9]+).([0-9]+).([0-9]+)-?([0-9]+)?-?(.*)?$/
 
 export default class R5Version extends Component {
+  static propTypes = {
+    label: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+    value: PropTypes.string,
+
+    fetch: PropTypes.func.isRequired,
+    onChange: PropTypes.func.isRequired
+  }
+
   state = {
     allVersions: [],
     releaseVersions: [],
@@ -24,32 +32,39 @@ export default class R5Version extends Component {
   }
 
   fetchVersions () {
-    const {value, onChange} = this.props
+    const {fetch} = this.props
     // retrieve R5 versions from S3
-    fetch(R5_BUCKET)
-      .then(res => res.text())
-      .then(res => {
-        const parser = new window.DOMParser()
-        const r5doc = parser.parseFromString(res, 'application/xml')
+    fetch({
+      url: R5_BUCKET,
+      next: (error, response) => {
+        if (error) window.alert(error)
+        else this.setVersionsFromXML(response.value)
+      }
+    })
+  }
 
-        const listing = Array.from(r5doc.querySelectorAll('Contents'))
-          .map((item) => item.querySelector('Key').childNodes[0].nodeValue) // get just key
-          .filter((item) => item !== 'index.html') // don't include the main page
-          .map((item) => item.replace(/.jar$/, '')) // and remove .jar
+  setVersionsFromXML (text) {
+    const {onChange, value} = this.props
+    const parser = new window.DOMParser()
+    const r5doc = parser.parseFromString(text, 'application/xml')
 
-        listing.sort(sortR5Versions)
+    const listing = Array.from(r5doc.querySelectorAll('Contents'))
+      .map((item) => item.querySelector('Key').childNodes[0].nodeValue) // get just key
+      .filter((item) => item !== 'index.html') // don't include the main page
+      .map((item) => item.replace(/.jar$/, '')) // and remove .jar
 
-        const releaseVersions = listing
-          .filter(i => RELEASE_VERSION_REGEX.test(i))
+    listing.sort(sortR5Versions)
 
-        // if no version selected, force choosing latest version.
-        if (value == null) onChange({ value: releaseVersions[0] })
+    const releaseVersions = listing
+      .filter(i => RELEASE_VERSION_REGEX.test(i))
 
-        // if the version selected is not a release version, show all versions
-        const showAllVersions = releaseVersions.indexOf(this.props.value) === -1 && listing.indexOf(this.props.value) > -1
+    // if no version selected, force choosing latest version.
+    if (value == null) onChange({ value: releaseVersions[0] })
 
-        this.setState({...this.state, allVersions: listing, releaseVersions, showAllVersions})
-      })
+    // if the version selected is not a release version, show all versions
+    const showAllVersions = releaseVersions.indexOf(this.props.value) === -1 && listing.indexOf(this.props.value) > -1
+
+    this.setState({...this.state, allVersions: listing, releaseVersions, showAllVersions})
   }
 
   toggleAllVersions = () => {

--- a/lib/components/report/__tests__/__snapshots__/add-trips.js.snap
+++ b/lib/components/report/__tests__/__snapshots__/add-trips.js.snap
@@ -142,7 +142,7 @@ exports[`Report > AddTrips renders correctly 1`] = `
         </td>
         <td>
           <span>
-            NaN km/h (NaN mph)
+            0 km/h (0 mph)
           </span>
         </td>
         <td>

--- a/lib/components/report/__tests__/__snapshots__/reroute.js.snap
+++ b/lib/components/report/__tests__/__snapshots__/reroute.js.snap
@@ -206,7 +206,7 @@ exports[`Report > Reroute renders correctly 1`] = `
         </th>
         <td>
           <span>
-            NaN km/h (NaN mph)
+            10 km/h (6.2 mph)
           </span>
         </td>
       </tr>

--- a/lib/components/report/__tests__/reroute.js
+++ b/lib/components/report/__tests__/reroute.js
@@ -13,7 +13,7 @@ describe('Report > Reroute', () => {
   it('renders correctly', () => {
     const props = {
       feedsById: { '1': mockFeed },
-      modification: mockModification
+      modification: { ...mockModification, segmentSpeeds: mockModification.segments.map(s => 10) }
     }
 
     // mount component

--- a/lib/components/report/add-trips.js
+++ b/lib/components/report/add-trips.js
@@ -4,12 +4,13 @@ import {latLngBounds} from 'leaflet'
 import React, { Component, PropTypes } from 'react'
 import lineDistance from '@turf/line-distance'
 
-import messages from '../../utils/messages'
-import Distance from './distance'
-import Speed from './speed'
 import DaysOfService from './days-of-service'
+import Distance from './distance'
 import MiniMap from './mini-map'
 import AddTripPatternLayer from '../scenario-map/add-trip-pattern-layer'
+import Speed from './speed'
+import messages from '../../utils/messages'
+import {getAverageSpeedOfSegments} from '../../utils/segments'
 import {secondsToHhMmString} from '../../utils/time'
 
 export default class AddTrips extends Component {
@@ -19,9 +20,10 @@ export default class AddTrips extends Component {
 
   render () {
     const {modification} = this.props
-    const km = modification.segments
+    const segmentDistances = modification.segments
       .map(seg => lineDistance(seg.geometry, 'kilometers'))
-      .reduce((a, b) => a + b)
+
+    const km = segmentDistances.reduce((a, b) => a + b)
     const bounds = latLngBounds(Array.concat(...modification.segments.map(seg => seg.geometry.coordinates.map(([lon, lat]) => [lat, lon]))))
 
     return <div>
@@ -52,6 +54,7 @@ export default class AddTrips extends Component {
               bidirectional={modification.bidirectional}
               key={`add-trips-entry-${i}`}
               lengthKm={km}
+              segmentDistances={segmentDistances}
               {...tt}
               />)}
         </tbody>
@@ -69,12 +72,15 @@ function TimeTable ({
   lengthKm,
   name,
   sourceTrip,
-  speed,
+  segmentSpeeds,
+  segmentDistances,
   startTime,
   ...rest
 }) {
   // TODO may be off by one, for instance ten-minute service for an hour will usually be 5 trips not 6
   const nTrips = Math.floor((endTime - startTime) / headwaySecs)
+
+  const speed = getAverageSpeedOfSegments({ segmentSpeeds, segmentDistances })
 
   return <tr>
     <td>{name}</td>

--- a/lib/components/report/reroute.js
+++ b/lib/components/report/reroute.js
@@ -6,13 +6,14 @@ import lineDistance from '@turf/line-distance'
 import lineSlice from '@turf/line-slice'
 import {point} from '@turf/helpers'
 
+import Distance from './distance'
 import MiniMap from './mini-map'
 import RerouteLayer from '../scenario-map/reroute-layer'
+import Speed from './speed'
 import messages from '../../utils/messages'
 import {getPatternsForModification} from '../../utils/patterns'
 import getStops from '../../utils/get-stops'
-import Distance from './distance'
-import Speed from './speed'
+import {getAverageSpeedOfSegments} from '../../utils/segments'
 
 export default class Reroute extends Component {
   static propTypes = {
@@ -49,6 +50,11 @@ export default class Reroute extends Component {
     let patternLength = lineDistance(pattern.geometry, 'kilometers')
     let stops = getStops(modification.segments)
     let segmentLength = stops.slice(-1)[0].distanceFromStart / 1000
+    const segmentDistances = modification.segments
+      .map(seg => lineDistance(seg.geometry, 'kilometers'))
+
+    const { segmentSpeeds } = modification
+    const speed = getAverageSpeedOfSegments({ segmentDistances, segmentSpeeds })
 
     // figure out removed segment length
     const fromStopIndex = modification.fromStop != null ? pattern.stops.findIndex((s) => s.stop_id === modification.fromStop) : 0
@@ -104,7 +110,7 @@ export default class Reroute extends Component {
         </tr>
         <tr>
           <th>{messages.report.reroute.segmentSpeed}</th>
-          <td><Speed kmh={modification.speed} /></td>
+          <td><Speed kmh={speed} /></td>
         </tr>
         <tr>
           <th>{messages.report.reroute.segmentDwell}</th>

--- a/lib/components/scenario-map/transit-editor/__tests__/index.js
+++ b/lib/components/scenario-map/transit-editor/__tests__/index.js
@@ -19,7 +19,8 @@ describe('Component > Transit-Editor > TransitEditor', () => {
       feeds: [mockFeed],
       followRoad: true,
       modification: mockModification,
-      replaceModification: jest.fn()
+      spacing: 0,
+      updateModification: jest.fn()
     }
 
     // mount component
@@ -30,7 +31,7 @@ describe('Component > Transit-Editor > TransitEditor', () => {
           />
       </Map>
     )
-    expect(props.replaceModification).not.toBeCalled()
+    expect(props.updateModification).not.toBeCalled()
     // expect marker to be added to map by intercepting call to Leaflet
     expect(tree).toMatchSnapshot()
   })

--- a/lib/containers/__tests__/__snapshots__/modification-editor.js.snap
+++ b/lib/containers/__tests__/__snapshots__/modification-editor.js.snap
@@ -44,16 +44,10 @@ Array [
     "type": "set modification",
   },
   Object {
-    "type": "increment outstanding requests",
+    "type": "increment outstanding fetches",
   },
   Object {
-    "type": "increment outstanding requests",
-  },
-  Object {
-    "type": "decrement outstanding requests",
-  },
-  Object {
-    "type": "decrement outstanding requests",
+    "type": "increment outstanding fetches",
   },
 ]
 `;

--- a/lib/containers/__tests__/edit-project.js
+++ b/lib/containers/__tests__/edit-project.js
@@ -1,6 +1,6 @@
-/* global describe, expect, it, jasmine */
+/* global describe, expect, it */
 
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 10 * 60 * 1000 // 10 minutes
+// jasmine.DEFAULT_TIMEOUT_INTERVAL = 10 * 60 * 1000 // 10 minutes
 
 describe('Container > Edit Project', () => {
   const {mount} = require('enzyme')

--- a/lib/containers/__tests__/modification-editor.js
+++ b/lib/containers/__tests__/modification-editor.js
@@ -1,6 +1,6 @@
-/* global describe, expect, it, jasmine */
+/* global describe, expect, it */
 
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 10 * 60 * 1000 // 10 minutes
+// jasmine.DEFAULT_TIMEOUT_INTERVAL = 10 * 60 * 1000 // 10 minutes
 
 describe('Container > Modification Editor', () => {
   const {mount} = require('enzyme')

--- a/lib/containers/create-grid.js
+++ b/lib/containers/create-grid.js
@@ -1,5 +1,6 @@
 /** Upload a grid file to Scenario Editor */
 
+import fetch from '@conveyal/woonerf/fetch'
 import {connect} from 'react-redux'
 import {goBack} from 'react-router-redux'
 import CreateGrid from '../components/create-grid'
@@ -13,6 +14,7 @@ function mapStateToProps (state, { params }) {
 
 function mapDispatchToProps (dispatch) {
   return {
+    fetch: (opts) => dispatch(fetch(opts)),
     finish: projectId => dispatch([load(projectId), goBack()])
   }
 }

--- a/lib/containers/edit-bundle.js
+++ b/lib/containers/edit-bundle.js
@@ -1,6 +1,6 @@
 import fetch from '@conveyal/woonerf/fetch'
 import {connect} from 'react-redux'
-import {goBack} from 'react-router-redux'
+import {push} from 'react-router-redux'
 
 import {addBundle, deleteBundle, saveBundle} from '../actions'
 import EditBundle from '../components/edit-bundle'
@@ -19,8 +19,14 @@ function mapStateToProps (state, props) {
 
 function mapDispatchToProps (dispatch, props) {
   return {
-    addBundle: (...args) => [dispatch(addBundle(...args)), dispatch(goBack())],
-    deleteBundle: () => [dispatch(deleteBundle(props.params.bundleId)), dispatch(goBack())],
+    addBundle: (...args) => [
+      dispatch(addBundle(...args)),
+      dispatch(push(`/projects/${props.params.projectId}/scenarios/create`))
+    ],
+    deleteBundle: () => [
+      dispatch(deleteBundle(props.params.bundleId)),
+      dispatch(push(`/projects/${props.params.projectId}`))
+    ],
     fetch: (opts) => dispatch(fetch(opts)),
     saveBundle: (...args) => dispatch(saveBundle(...args))
   }

--- a/lib/containers/edit-bundle.js
+++ b/lib/containers/edit-bundle.js
@@ -1,3 +1,4 @@
+import fetch from '@conveyal/woonerf/fetch'
 import {connect} from 'react-redux'
 import {goBack} from 'react-router-redux'
 
@@ -20,6 +21,7 @@ function mapDispatchToProps (dispatch, props) {
   return {
     addBundle: (...args) => [dispatch(addBundle(...args)), dispatch(goBack())],
     deleteBundle: () => [dispatch(deleteBundle(props.params.bundleId)), dispatch(goBack())],
+    fetch: (opts) => dispatch(fetch(opts)),
     saveBundle: (...args) => dispatch(saveBundle(...args))
   }
 }

--- a/lib/containers/edit-project.js
+++ b/lib/containers/edit-project.js
@@ -1,3 +1,4 @@
+import fetch from '@conveyal/woonerf/fetch'
 import {connect} from 'react-redux'
 import {push} from 'react-router-redux'
 
@@ -32,6 +33,7 @@ function mapDispatchToProps (dispatch, {
     addComponentToMap: () => dispatch(addComponent(EDIT_PROJECT_BOUNDS_COMPONENT)),
     create: (opts) => dispatch(create(opts)),
     deleteProject: () => dispatch(deleteProject(params.projectId)),
+    fetch: (opts) => dispatch(fetch(opts)),
     removeComponentFromMap: () => dispatch(removeComponent(EDIT_PROJECT_BOUNDS_COMPONENT)),
     save: (opts) => dispatch([save(opts), push(`/projects/${params.projectId}`)]),
     setCenter: (c) => dispatch(setCenter(c)),

--- a/lib/containers/regional-analysis-results.js
+++ b/lib/containers/regional-analysis-results.js
@@ -1,8 +1,15 @@
-import RegionalAnalysis from '../components/analysis/regional'
-import {load, setActiveRegionalAnalyses, loadRegionalAnalysisGrids, setMinimumImprovementProbability} from '../actions/analysis/regional'
-import {addComponent, removeComponent} from '../actions/map'
-import {REGIONAL_COMPONENT, REGIONAL_COMPARISON_COMPONENT, ISOCHRONE_COMPONENT, OPPORTUNITY_COMPONENT} from '../constants/map'
+import fetch from '@conveyal/woonerf/fetch'
 import {connect} from 'react-redux'
+
+import {
+  load,
+  loadRegionalAnalysisGrids,
+  setActiveRegionalAnalyses,
+  setMinimumImprovementProbability
+} from '../actions/analysis/regional'
+import {addComponent, removeComponent} from '../actions/map'
+import RegionalAnalysis from '../components/analysis/regional'
+import {REGIONAL_COMPONENT, REGIONAL_COMPARISON_COMPONENT, ISOCHRONE_COMPONENT, OPPORTUNITY_COMPONENT} from '../constants/map'
 
 function mapStateToProps (state, ownProps) {
   const { project, analysis } = state
@@ -28,20 +35,21 @@ function mapStateToProps (state, ownProps) {
 
 function mapDispatchToProps (dispatch, ownProps) {
   return {
+    addRegionalAnalysisLayerToMap: () => dispatch(addComponent(REGIONAL_COMPONENT)),
+    addRegionalComparisonLayerToMap: () => dispatch(addComponent(REGIONAL_COMPARISON_COMPONENT)),
+    addIsochroneLayerToMap: () => dispatch(addComponent(ISOCHRONE_COMPONENT)),
+    addOpportunityLayerToMap: () => dispatch(addComponent(OPPORTUNITY_COMPONENT)),
+    fetch: (opts) => dispatch(fetch(opts)),
+    loadRegionalAnalyses: (projectId) => dispatch(load(projectId)),
+    removeRegionalAnalysisLayerFromMap: () => dispatch(removeComponent(REGIONAL_COMPONENT)),
+    removeRegionalComparisonLayerFromMap: () => dispatch(removeComponent(REGIONAL_COMPARISON_COMPONENT)),
+    removeIsochroneLayerFromMap: () => dispatch(removeComponent(ISOCHRONE_COMPONENT)),
+    removeOpportunityLayerFromMap: () => dispatch(removeComponent(OPPORTUNITY_COMPONENT)),
     setActiveRegionalAnalysis: ({ id, comparisonId, percentile }) => dispatch([
       setActiveRegionalAnalyses({ id, comparisonId }),
       loadRegionalAnalysisGrids({ id, comparisonId, percentile })
     ]),
-    setMinimumImprovementProbability: (p) => dispatch(setMinimumImprovementProbability(p)),
-    addRegionalAnalysisLayerToMap: () => dispatch(addComponent(REGIONAL_COMPONENT)),
-    removeRegionalAnalysisLayerFromMap: () => dispatch(removeComponent(REGIONAL_COMPONENT)),
-    addRegionalComparisonLayerToMap: () => dispatch(addComponent(REGIONAL_COMPARISON_COMPONENT)),
-    removeRegionalComparisonLayerFromMap: () => dispatch(removeComponent(REGIONAL_COMPARISON_COMPONENT)),
-    removeIsochroneLayerFromMap: () => dispatch(removeComponent(ISOCHRONE_COMPONENT)),
-    addIsochroneLayerToMap: () => dispatch(addComponent(ISOCHRONE_COMPONENT)),
-    removeOpportunityLayerFromMap: () => dispatch(removeComponent(OPPORTUNITY_COMPONENT)),
-    addOpportunityLayerToMap: () => dispatch(addComponent(OPPORTUNITY_COMPONENT)),
-    loadRegionalAnalyses: (projectId) => dispatch(load(projectId))
+    setMinimumImprovementProbability: (p) => dispatch(setMinimumImprovementProbability(p))
   }
 }
 

--- a/lib/reducers/network.js
+++ b/lib/reducers/network.js
@@ -1,5 +1,28 @@
+import {
+  DECREMENT_FETCH,
+  FETCH_ERROR,
+  INCREMENT_FETCH
+} from '@conveyal/woonerf/fetch'
 
 export const reducers = {
+  [DECREMENT_FETCH] (state, action) {
+    return {
+      ...state,
+      outstandingRequests: state.outstandingRequests - 1
+    }
+  },
+  [INCREMENT_FETCH] (state, action) {
+    return {
+      ...state,
+      outstandingRequests: state.outstandingRequests + 1
+    }
+  },
+  [FETCH_ERROR] (state, action) {
+    return {
+      ...state,
+      error: action.payload
+    }
+  },
   'decrement outstanding requests' (state, action) {
     return {
       ...state,

--- a/lib/utils/mock-data.js
+++ b/lib/utils/mock-data.js
@@ -1,10 +1,11 @@
 import multi from '@conveyal/woonerf/store/multi'
 import promise from '@conveyal/woonerf/store/promise'
+import {middleware as fetchMiddleware} from '@conveyal/woonerf/fetch'
 import configureStore from 'redux-mock-store'
 
 import {ADD_TRIP_PATTERN} from './modification-types'
 
-export const makeMockStore = configureStore([multi, promise])
+export const makeMockStore = configureStore([multi, promise, fetchMiddleware])
 
 export const mockSegmentGeom = {
   type: 'LineString',

--- a/lib/utils/segments.js
+++ b/lib/utils/segments.js
@@ -1,0 +1,39 @@
+/** Functions to manipulate the segments object present in reroute and add trips */
+
+import sum from 'lodash.sum'
+import {DEFAULT_SEGMENT_SPEED} from '../constants/timetables'
+
+/**
+ * Get the average travel speed given speeds of the segments.
+ * Output units are the same as input units of speed, e.g. if segmentSpeeds is kmph, output will be
+ * kmph.
+ */
+export function getAverageSpeedOfSegments ({segmentDistances, segmentSpeeds}) {
+  const totalDistance = sum(segmentDistances)
+  const weightedSpeeds = segmentSpeeds.map((s, i) => (s * segmentDistances[i]))
+  return weightedSpeeds.reduce((total, speed) => (total + speed), 0) / totalDistance
+}
+
+/**
+ * Get the travel time in minutes given dwell times in seconds, segment distances in km, and speeds
+ * in kph.
+ */
+export function getTravelTimeMinutes ({
+  dwellTime, // seconds
+  numberOfStops,
+  segmentDistances, // km
+  segmentSpeeds // kph
+}) {
+  if (numberOfStops > 0) {
+    const segmentTimes = segmentDistances.map(
+      (segmentDistance, i) => (segmentDistance / (segmentSpeeds[i] || DEFAULT_SEGMENT_SPEED)))
+    const totalMovingTime = sum(segmentTimes) * 60
+
+    // add the dwell times
+    const dwellMinutes = dwellTime / 60
+    const dwellingTime = numberOfStops * dwellMinutes
+    return totalMovingTime + dwellingTime
+  } else {
+    return 0
+  }
+}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@conveyal/gridualizer": "^2.0.0",
     "@conveyal/lonlat": "^1.1.0",
-    "@conveyal/woonerf": "^2.0.0",
+    "@conveyal/woonerf": "^2.0.1",
     "@mapbox/polyline": "^0.2.0",
     "@turf/bearing": "^3.7.5",
     "@turf/destination": "^3.7.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,9 +15,9 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@conveyal/lonlat/-/lonlat-1.1.0.tgz#01c41dbf7e9d8c926e3753d3423890d8fa95a187"
 
-"@conveyal/woonerf@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@conveyal/woonerf/-/woonerf-2.0.0.tgz#ba9ab8a79f544b9bcfe054902c643a60bb755668"
+"@conveyal/woonerf@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@conveyal/woonerf/-/woonerf-2.0.1.tgz#ab4a1b6969ace038294a4847006ce5bc83071507"
   dependencies:
     auth0-lock "^10.10.2"
     isomorphic-fetch "^2.2.1"
@@ -136,7 +136,7 @@ JSONStream@^1.0.3:
     jsonparse "^1.2.0"
     through ">=2.2.7 <3"
 
-abab@^1.0.0:
+abab@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.3.tgz#b81de5f7274ec4e756d797cd834f303642724e5d"
 
@@ -144,33 +144,33 @@ abbrev@1:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.0.9.tgz#91b4792588a7738c25f35dd6f63752a2f8776135"
 
-acorn-globals@^1.0.4:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-1.0.9.tgz#55bb5e98691507b74579d0513413217c380c54cf"
+acorn-globals@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-3.1.0.tgz#fd8270f71fbb4996b004fa880ee5d46573a731bf"
   dependencies:
-    acorn "^2.1.0"
+    acorn "^4.0.4"
 
-acorn-jsx@^3.0.0, acorn-jsx@^3.0.1:
+acorn-jsx@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
   dependencies:
     acorn "^3.0.4"
 
+acorn@4.0.4, acorn@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.4.tgz#17a8d6a7a6c4ef538b814ec9abac2779293bf30a"
+
 acorn@^1.0.3:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-1.2.2.tgz#c8ce27de0acc76d896d2b1fad3df588d9e82f014"
 
-acorn@^2.1.0, acorn@^2.4.0, acorn@^2.7.0:
+acorn@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-2.7.0.tgz#ab6e7d9d886aaca8b085bc3312b79a198433f0e7"
 
 acorn@^3.0.4, acorn@^3.1.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
-
-acorn@^4.0.1:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.4.tgz#17a8d6a7a6c4ef538b814ec9abac2779293bf30a"
 
 agent-base@2:
   version "2.0.1"
@@ -1258,8 +1258,8 @@ braces@^1.8.2:
     repeat-element "^1.1.2"
 
 brorand@^1.0.1:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.0.6.tgz#4028706b915f91f7b349a2e0bf3c376039d216e5"
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.0.7.tgz#6677fa5e4901bdbf9c9ec2a748e28dca407a9bfc"
 
 browser-pack@^6.0.1:
   version "6.0.2"
@@ -1518,8 +1518,8 @@ buffer@4.9.1, buffer@^4.1.0:
     isarray "^1.0.0"
 
 buffer@^5.0.2:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.0.2.tgz#41d0407ff76782e9ec19f52f88e237ce6bb0de6d"
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.0.3.tgz#90d5b2dbcef4004e7e307d0e488595a302e1f8fd"
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
@@ -1593,8 +1593,8 @@ caniuse-api@^1.3.2:
     lodash.uniq "^4.3.0"
 
 caniuse-db@^1.0.30000346, caniuse-db@^1.0.30000617, caniuse-db@^1.0.30000618:
-  version "1.0.30000619"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000619.tgz#bffaa8150637c3182d3914a9718369b079299529"
+  version "1.0.30000622"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000622.tgz#9d9690b577384990a58e33ebb903a14da735e5fd"
 
 canvas@^1.6.2:
   version "1.6.2"
@@ -2010,11 +2010,11 @@ css-what@2.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
 
-cssom@0.3.x, "cssom@>= 0.3.0 < 0.4.0":
+cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.2.tgz#b8036170c79f07a90ff2f16e22284027a243848b"
 
-"cssstyle@>= 0.2.36 < 0.3.0":
+"cssstyle@>= 0.2.37 < 0.3.0":
   version "0.2.37"
   resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-0.2.37.tgz#541097234cb2513c83ceed3acddc27ff27987d54"
   dependencies:
@@ -2334,16 +2334,16 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
 electron-to-chromium@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.2.1.tgz#63ac7579a1c5bedb296c8607621f2efc9a54b968"
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.2.2.tgz#e41bc9488c88e3cfa1e94bde28e8420d7d47c47c"
 
 element-class@^0.2.0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/element-class/-/element-class-0.2.2.tgz#9d3bbd0767f9013ef8e1c8ebe722c1402a60050e"
 
 elliptic@^6.0.0:
-  version "6.3.2"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.3.2.tgz#e4c81e0829cf0a65ab70e998b8232723b5c1bc48"
+  version "6.3.3"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.3.3.tgz#5482d9646d54bcb89fd7d994fc9e2e9568876e3f"
   dependencies:
     bn.js "^4.4.0"
     brorand "^1.0.1"
@@ -2517,8 +2517,8 @@ eslint-config-standard@6.2.1:
   resolved "https://registry.yarnpkg.com/eslint-config-standard/-/eslint-config-standard-6.2.1.tgz#d3a68aafc7191639e7ee441e7348739026354292"
 
 eslint-plugin-promise@~3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-3.4.0.tgz#6ba9048c2df57be77d036e0c68918bc9b4fc4195"
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-3.4.1.tgz#6911a9010bf84e17d82e19e0ab0f80ab3ad6db4c"
 
 eslint-plugin-react@~6.7.1:
   version "6.7.1"
@@ -2571,23 +2571,23 @@ eslint@~3.10.2:
     user-home "^2.0.0"
 
 espree@^3.3.1:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-3.3.2.tgz#dbf3fadeb4ecb4d4778303e50103b3d36c88b89c"
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.4.0.tgz#41656fa5628e042878025ef467e78f125cb86e1d"
   dependencies:
-    acorn "^4.0.1"
+    acorn "4.0.4"
     acorn-jsx "^3.0.0"
 
-esprima@^2.6.0, esprima@^2.7.1:
+esprima@^2.7.1:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
+
+esprima@^3.1.1, esprima@~3.1.0:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
 
 esprima@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.0.0.tgz#53cf247acda77313e551c3aa2e73342d3fb4f7d9"
-
-esprima@~3.1.0:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
 
 esrecurse@^4.1.0:
   version "4.1.0"
@@ -2877,7 +2877,7 @@ form-data@~1.0.0-rc4:
     combined-stream "^1.0.5"
     mime-types "^2.1.11"
 
-formidable@^1.0.17:
+formidable@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.1.1.tgz#96b8886f7c3c3508b932d6bd70c4d3a88f35f1a9"
 
@@ -3224,8 +3224,8 @@ homedir-polyfill@^1.0.0:
     parse-passwd "^1.0.0"
 
 hosted-git-info@^2.1.4, hosted-git-info@^2.1.5:
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.1.5.tgz#0ba81d90da2e25ab34a332e6ec77936e1598118b"
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.2.0.tgz#7a0d097863d886c0fabbdcd37bf1758d8becf8a5"
 
 html-encoding-sniffer@^1.0.1:
   version "1.0.1"
@@ -3294,7 +3294,7 @@ iconv-lite@0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
 
-iconv-lite@^0.4.13, iconv-lite@~0.4.13:
+iconv-lite@~0.4.13:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.15.tgz#fe265a218ac6a57cfe854927e9d04c19825eddeb"
 
@@ -3908,40 +3908,39 @@ js-tokens@^3.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
 
 js-yaml@^3.5.1, js-yaml@^3.7.0:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.7.0.tgz#5c967ddd837a9bfdca5f2de84253abe8a1c03b80"
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.8.1.tgz#782ba50200be7b9e5a8537001b7804db3ad02628"
   dependencies:
     argparse "^1.0.7"
-    esprima "^2.6.0"
+    esprima "^3.1.1"
 
 jsbn@^0.1.0, jsbn@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.0.tgz#650987da0dd74f4ebf5a11377a2aa2d273e97dfd"
 
 jsdom@^9.9.1:
-  version "9.9.1"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-9.9.1.tgz#84f3972ad394ab963233af8725211bce4d01bfd5"
+  version "9.10.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-9.10.0.tgz#72d04d9fd5f1164d016dc350ef889af6d0d1a25a"
   dependencies:
-    abab "^1.0.0"
-    acorn "^2.4.0"
-    acorn-globals "^1.0.4"
+    abab "^1.0.3"
+    acorn "^4.0.4"
+    acorn-globals "^3.1.0"
     array-equal "^1.0.0"
     content-type-parser "^1.0.1"
-    cssom ">= 0.3.0 < 0.4.0"
-    cssstyle ">= 0.2.36 < 0.3.0"
+    cssom ">= 0.3.2 < 0.4.0"
+    cssstyle ">= 0.2.37 < 0.3.0"
     escodegen "^1.6.1"
     html-encoding-sniffer "^1.0.1"
-    iconv-lite "^0.4.13"
     nwmatcher ">= 1.3.9 < 2.0.0"
     parse5 "^1.5.1"
-    request "^2.55.0"
-    sax "^1.1.4"
-    symbol-tree ">= 3.1.0 < 4.0.0"
-    tough-cookie "^2.3.1"
+    request "^2.79.0"
+    sax "^1.2.1"
+    symbol-tree "^3.2.1"
+    tough-cookie "^2.3.2"
     webidl-conversions "^3.0.1"
     whatwg-encoding "^1.0.1"
-    whatwg-url "^4.1.0"
-    xml-name-validator ">= 2.0.1 < 3.0.0"
+    whatwg-url "^4.3.0"
+    xml-name-validator "^2.0.1"
 
 jsesc@^1.3.0:
   version "1.3.0"
@@ -4015,10 +4014,9 @@ jsprim@^1.2.2:
     verror "1.3.6"
 
 jsx-ast-utils@^1.3.3:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-1.3.5.tgz#9ba6297198d9f754594d62e59496ffb923778dd4"
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-1.4.0.tgz#5afe38868f56bc8cc7aeaef0100ba8c75bd12591"
   dependencies:
-    acorn-jsx "^3.0.1"
     object-assign "^4.1.0"
 
 jszip@^2.4.0:
@@ -4356,7 +4354,7 @@ lodash@^3.6.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.0.0, lodash@^4.1.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0:
+lodash@^4.0.0, lodash@^4.1.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@~4.17.2:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -4367,10 +4365,6 @@ lodash@~1.3.1:
 lodash@~3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.5.0.tgz#19bb3f4d51278f0b8c818ed145c74ecf9fe40e6d"
-
-lodash@~4.9.0:
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.9.0.tgz#4c20d742f03ce85dc700e0dd7ab9bcab85e6fc14"
 
 log-symbols@^1.0.2:
   version "1.0.2"
@@ -4659,14 +4653,14 @@ netrc@^0.1.4:
   resolved "https://registry.yarnpkg.com/netrc/-/netrc-0.1.4.tgz#6be94fcaca8d77ade0a9670dc460914c94472444"
 
 nock@^9.0.0:
-  version "9.0.2"
-  resolved "https://registry.yarnpkg.com/nock/-/nock-9.0.2.tgz#f6a5f4a8d560d61f48b5ad428ccff8dc9b62701e"
+  version "9.0.3"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-9.0.3.tgz#43b1e857eabb1b75adf07130269e24f83a3fd0b8"
   dependencies:
     chai ">=1.9.2 <4.0.0"
     debug "^2.2.0"
     deep-equal "^1.0.0"
     json-stringify-safe "^5.0.1"
-    lodash "~4.9.0"
+    lodash "~4.17.2"
     mkdirp "^0.5.0"
     propagate "0.4.0"
     qs "^6.0.2"
@@ -5011,8 +5005,8 @@ parse-asn1@^5.0.0:
     pbkdf2 "^3.0.3"
 
 parse-github-repo-url@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/parse-github-repo-url/-/parse-github-repo-url-1.3.0.tgz#d4de02d68e2e60f0d6a182e7a8cb21b6f38c730b"
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/parse-github-repo-url/-/parse-github-repo-url-1.4.0.tgz#286c53e2c9962e0641649ee3ac9508fca4dd959c"
 
 parse-glob@^3.0.4:
   version "3.0.4"
@@ -5411,8 +5405,8 @@ postcss-value-parser@^3.0.2, postcss-value-parser@^3.2.3, postcss-value-parser@^
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz#87f38f9f18f774a4ab4c8a232f5c5ce8872a9d15"
 
 postcss@^5.0.0, postcss@^5.0.14, postcss@^5.0.16, postcss@^5.0.19, postcss@^5.0.2, postcss@^5.0.21, postcss@^5.0.3, postcss@^5.0.4, postcss@^5.1.1, postcss@^5.2.0, postcss@^5.2.11:
-  version "5.2.11"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.11.tgz#ff29bcd6d2efb98bfe08a022055ec599bbe7b761"
+  version "5.2.12"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.12.tgz#6a2b15e35dd65634441bb0961fa796904c7890e0"
   dependencies:
     chalk "^1.1.3"
     js-base64 "^2.1.9"
@@ -5446,8 +5440,8 @@ pretty-ms@^2.1.0:
     plur "^1.0.0"
 
 private@^0.1.6:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/private/-/private-0.1.6.tgz#55c6a976d0f9bafb9924851350fe47b9b5fbb7c1"
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/private/-/private-0.1.7.tgz#68ce5e8a1ef0a23bb570cc28537b5332aba63ef1"
 
 process-nextick-args@~1.0.6:
   version "1.0.7"
@@ -5598,8 +5592,8 @@ react-chartjs@^0.8.0:
   resolved "https://registry.yarnpkg.com/react-chartjs/-/react-chartjs-0.8.0.tgz#d41386b3d3cbfef9003f5a655e7ea48a49fbfa19"
 
 react-datetime@^2.7.5:
-  version "2.8.3"
-  resolved "https://registry.yarnpkg.com/react-datetime/-/react-datetime-2.8.3.tgz#0ef74b3505cfc517b44ac113bbd6cdbc50d3e308"
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/react-datetime/-/react-datetime-2.8.4.tgz#af247643aa480b99710ac4b45fff1a7b8d59111f"
   dependencies:
     object-assign "^3.0.0"
     react-onclickoutside "^4.1.0"
@@ -5924,7 +5918,7 @@ request-promise@^4.1.1:
     request-promise-core "1.1.1"
     stealthy-require "^1.0.0"
 
-request@^2.55.0, request@^2.72.0, request@^2.74.0, request@^2.78.0, request@^2.79.0:
+request@^2.72.0, request@^2.74.0, request@^2.78.0, request@^2.79.0:
   version "2.79.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.79.0.tgz#4dfe5bf6be8b8cdc37fcf93e04b65577722710de"
   dependencies:
@@ -6116,9 +6110,13 @@ sane@~1.4.1:
     walker "~1.0.5"
     watch "~0.10.0"
 
-sax@1.1.5, sax@>=0.6.0, sax@^1.1.4:
+sax@1.1.5, sax@>=0.6.0:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.1.5.tgz#1da50a8d00cdecd59405659f5ff85349fe773743"
+
+sax@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
 
 semantic-release@^6.3.2:
   version "6.3.6"
@@ -6519,15 +6517,15 @@ subarg@^1.0.0:
     minimist "^1.1.0"
 
 superagent@^3.3.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/superagent/-/superagent-3.4.1.tgz#4bd12741224d0ece6d9f757f1c3becbe7f24c115"
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-3.4.2.tgz#aa9a00f21720e230a6e7e9d7f07e0ab84509b833"
   dependencies:
     component-emitter "^1.2.0"
     cookiejar "^2.0.6"
     debug "^2.2.0"
     extend "^3.0.0"
     form-data "^2.1.1"
-    formidable "^1.0.17"
+    formidable "^1.1.1"
     methods "^1.1.1"
     mime "^1.3.4"
     qs "^6.1.0"
@@ -6555,7 +6553,7 @@ symbol-observable@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
 
-"symbol-tree@>= 3.1.0 < 4.0.0":
+symbol-tree@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.1.tgz#8549dd1d01fa9f893c18cc9ab0b106b4d9b168cb"
 
@@ -6689,7 +6687,7 @@ to-fast-properties@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.2.tgz#f3f5c0c3ba7299a7ef99427e44633257ade43320"
 
-tough-cookie@^2.3.1, tough-cookie@~2.3.0:
+tough-cookie@^2.3.2, tough-cookie@~2.3.0:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.2.tgz#f081f76e4c85720e6c37a5faced737150d84072a"
   dependencies:
@@ -7010,7 +7008,7 @@ whatwg-fetch@^0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz#0e3684c6cb9995b43efc9df03e4c365d95fd9cc0"
 
-whatwg-url@^4.1.0:
+whatwg-url@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-4.3.0.tgz#92aaee21f4f2a642074357d70ef8500a7cbb171a"
   dependencies:
@@ -7077,7 +7075,7 @@ write@^0.2.1:
   dependencies:
     mkdirp "^0.5.1"
 
-"xml-name-validator@>= 2.0.1 < 3.0.0":
+xml-name-validator@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
 


### PR DESCRIPTION
Anytime authenticated fetch is used manually we are unable to map it easily to state to show loading indicators or status messages. This PR is going to move all uses of fetch to use the woonerf/fetch action pattern. 

Note: This does not include edits to `utils/browsochrones.js`. That requires a lot of unpacking and will come in a subsequent pull request.