### PR TITLE
Correctly set auto create stops on new modifications

### DIFF
--- a/lib/components/modification/edit-alignment.js
+++ b/lib/components/modification/edit-alignment.js
@@ -84,14 +84,24 @@ export default class EditAlignment extends DeepEqual {
    * Toggle whether stops should be created automatically.
    */
   _onAutoCreateStopsChange = (e) => {
-    const {modification, update} = this.props
+    const {mapState, modification, update} = this.props
     const spacing = e.target.checked ? DEFAULT_STOP_SPACING_METERS : 0
 
-    this._updateMapState({spacing})
+    if (mapState.state === MAP_STATE_TRANSIT_EDITOR) {
+      this._updateMapState({spacing})
+    } else {
+      this.setState({
+        ...this.state,
+        createStopsAutomatically: spacing > 0,
+        spacing
+      })
+    }
 
-    update({
-      segments: modification.segments.map((segment) => ({...segment, spacing}))
-    })
+    if (modification.segments.length > 0) {
+      update({
+        segments: modification.segments.map((segment) => ({...segment, spacing}))
+      })
+    }
   }
 
   /**


### PR DESCRIPTION
We were using `mapState` to manage this so if you weren't currently editing the alignment, it wouldn't maintain the state when you checked/unchecked the box.

fixes #280 