### PR TITLE
fix(error): Fix lock UI with error.

### DIFF
--- a/lib/actions/analysis/index.js
+++ b/lib/actions/analysis/index.js
@@ -1,8 +1,8 @@
 import lonlat from '@conveyal/lonlat'
 import {createAction} from 'redux-actions'
 
-import {serverAction, lockUiWithError} from '../network'
-
+import {lockUiWithError} from '../'
+import {serverAction} from '../network'
 import {getIsochronesAndAccessibility, ScenarioApplicationError, AnalysisError, statusByPriority} from '../../utils/browsochrones'
 
 export const clearIsochroneResults = createAction('clear isochrone results')
@@ -89,7 +89,7 @@ export const fetchIsochrone = ({
             showScenarioApplicationErrors(err.errors)
           ]
         } else if (err instanceof AnalysisError) {
-          return lockUiWithError(err.statusText)
+          return lockUiWithError({ error: err.statusText, detailMessage: err.errorText })
         } else {
           // unexpected error, rethrow
           throw err

--- a/lib/actions/index.js
+++ b/lib/actions/index.js
@@ -1,7 +1,36 @@
 import fetch from '@conveyal/woonerf/fetch'
 import {createAction} from 'redux-actions'
 
-export const lockUiWithError = createAction('lock ui with error')
+// cannot use createAction with Error objects as payload:
+// https://github.com/acdlite/redux-actions/issues/194
+// thus write an action creator from scratch
+export const lockUiWithError = (error) => {
+  if (error.error) {
+    // already correctly formatted
+    return {
+      type: 'lock ui with error',
+      payload: error,
+      error: true
+    }
+  } else if (error.stack) {
+    // return the stack trace as the detail
+    return {
+      type: 'lock ui with error',
+      payload: {
+        error: error.message,
+        detailMessage: error.stack
+      },
+      error: true
+    }
+  } else {
+    // coerce the object itself to a string
+    return {
+      type: 'lock ui with error',
+      payload: { error },
+      error: true
+    }
+  }
+}
 
 // bundle
 export const addBundle = createAction('add bundle')

--- a/lib/actions/network.js
+++ b/lib/actions/network.js
@@ -1,15 +1,14 @@
 import {BadRequest, RequestTimeout} from 'http-errors'
 import {createAction} from 'redux-actions'
 
+import {lockUiWithError} from './'
 import authenticatedFetch from '../utils/authenticated-fetch'
 import messages from '../utils/messages'
 
-const IDENTITY = (i) => i
 const REQUEST_TIMEOUT_MS = 5 * 60 * 1000 // if things take more than 60s to save we have a problem
 
 export const decrementOutstandingRequests = createAction('decrement outstanding requests')
 export const incrementOutstandingRequests = createAction('increment outstanding requests')
-export const lockUiWithError = createAction('lock ui with error', IDENTITY, { error: true })
 
 function fetchAction ({
   url,

--- a/lib/reducers/network.js
+++ b/lib/reducers/network.js
@@ -20,7 +20,9 @@ export const reducers = {
   [FETCH_ERROR] (state, action) {
     return {
       ...state,
-      error: action.payload
+      error: {
+        error: action.payload.statusText
+      }
     }
   },
   'decrement outstanding requests' (state, action) {


### PR DESCRIPTION
Allow calling lock ui with error with a string, an Error object, or { error, detailMessage } object.
Don't use createAction due to an upstream :ant: https://github.com/acdlite/redux-actions/issues/194

fixes #300