### PR TITLE
feat(regional): Allow using an uploaded grid to constrain the extents of a regional analysis

### DIFF
--- a/configurations/default/messages.yml
+++ b/configurations/default/messages.yml
@@ -112,6 +112,9 @@ analysis:
   gisExport: Export to GIS
   downloadRegional: Download %s
   downloadRegionalProbability: Download probability of improvement
+  extents: Analysis extents
+  showAdvanced: Show advanced options
+  hideAdvanced: Hide advanced options
   modes:
     walk: Walk
     bicycle: Bike

--- a/lib/components/analysis/index.js
+++ b/lib/components/analysis/index.js
@@ -12,7 +12,7 @@ import messages from '../../utils/messages'
 import Histogram from './histogram'
 import Regional from './regional-analysis-selector'
 import convertToR5Modification from '../../utils/convert-to-r5-modification'
-import {Button} from '../buttons'
+import {Button, IconToggle} from '../buttons'
 import SpectrogramSelector from './spectrogram-selector'
 import Icon from '../icon'
 import {Group, Text, Checkbox} from '../input'
@@ -98,15 +98,17 @@ export default class SinglePointAnalysis extends Component {
   /** run a new query */
   runAnalysis = (e) => {
     const { workerVersion, runAnalysis, modifications, bundleId, currentIndicator, isochroneCutoff, variantIndex, scenarioId, profileRequest } = this.props
+    const { regionalAnalysisExtents, regionalAnalysisName } = this.state
 
     runAnalysis({
-      name: this.state.regionalAnalysisName,
+      name: regionalAnalysisName,
       workerVersion,
       bundleId,
       grid: currentIndicator,
       cutoffMinutes: isochroneCutoff,
       scenarioId,
       variant: variantIndex,
+      extents: regionalAnalysisExtents,
       request: {
         ...profileRequest,
         scenario: {
@@ -170,6 +172,12 @@ export default class SinglePointAnalysis extends Component {
   /** show the regional analysis creation name box */
   prepareCreateRegionalAnalysis = (e) => this.setState({...this.state, creatingRegionalAnalysis: true})
   setRegionalAnalysisName = (e) => this.setState({...this.state, regionalAnalysisName: e.target.value})
+  setRegionalAnalysisExtents= (e) => this.setState({...this.state, regionalAnalysisExtents: e.value})
+  setShowRegionalAnalysisExtents = (shown) => {
+    // when turning off the regional analysis extents chooser, turn it off
+    if (!shown) this.setState({...this.state, showRegionalAnalysisExtents: shown, regionalAnalysisExtents: undefined})
+    else this.setState({...this.state, showRegionalAnalysisExtents: shown})
+  }
 
   /** Render the results of an analysis */
   renderResults () {
@@ -270,7 +278,7 @@ export default class SinglePointAnalysis extends Component {
       variantName
     } = this.props
 
-    const { regionalAnalysisName, creatingRegionalAnalysis } = this.state
+    const { regionalAnalysisName, creatingRegionalAnalysis, regionalAnalysisExtents, showRegionalAnalysisExtents } = this.state
 
     return (
       <div>
@@ -350,16 +358,36 @@ export default class SinglePointAnalysis extends Component {
           }
 
           {spectrogramData && creatingRegionalAnalysis &&
-            <form>
+            <Group label={messages.analysis.newRegionalAnalysis}>
+              <IconToggle
+                icon='flask'
+                checked={showRegionalAnalysisExtents}
+                checkedTooltip={messages.analysis.hideAdvanced}
+                uncheckedTooltip={messages.analysis.showAdvanced}
+                onChange={this.setShowRegionalAnalysisExtents}
+                />
               <Text
                 value={regionalAnalysisName}
                 label={messages.analysis.regionalAnalysisName}
                 onChange={this.setRegionalAnalysisName}
                 />
+
+              { showRegionalAnalysisExtents &&
+                <Group label={messages.analysis.extents}>
+                  <Select
+                    options={indicators.map(({ name, key }) => { return { value: key, label: name } })}
+                    onChange={this.setRegionalAnalysisExtents}
+                    placeholder={messages.analysis.extents}
+                    value={regionalAnalysisExtents}
+                    width={600}
+                    />
+                </Group>
+                }
+
               <Button type='submit' onClick={this.runAnalysis} aria-label={messages.analysis.startRegionalAnalysis}>
                 <Icon type='check' />
               </Button>
-            </form>
+            </Group>
           }
 
           <Regional

--- a/lib/components/buttons.js
+++ b/lib/components/buttons.js
@@ -1,6 +1,7 @@
-import React from 'react'
+import React, {PropTypes} from 'react'
 
-import {pure} from './deep-equal'
+import DeepEqualComponent, {pure} from './deep-equal'
+import Icon from './icon'
 
 export const Group = pure(function ButtonGroup ({children, justified, vertical, radio}) {
   const classNames = ['btn-group']
@@ -54,3 +55,46 @@ export const Button = pure(function Button ({block, children, className, onClick
     {...props}
     >{children}</a>
 })
+
+/** A toggle button that uses a shaded icon to indicate checkiness */
+export class IconToggle extends DeepEqualComponent {
+  static propTypes = {
+    checked: PropTypes.bool.isRequired,
+    checkedTooltip: PropTypes.string.isRequired, // The tooltip when the icon is checked
+    icon: PropTypes.string.isRequired,
+    uncheckedTooltip: PropTypes.string.isRequired,
+
+    onChange: PropTypes.func.isRequired
+  }
+
+  toggle = (e) => {
+    const {onChange, checked} = this.props
+    // TODO maintain in state?
+    onChange(!checked)
+  }
+
+  keypress = (e) => {
+    if (e.charCode === 32) {
+      // spacebar
+      this.toggle()
+    }
+  }
+
+  render () {
+    const {icon, checked, checkedTooltip, uncheckedTooltip} = this.props
+    return <Icon
+      type={icon}
+      style={{
+        color: checked ? '#000' : '#aaa',
+        cursor: 'pointer'
+      }}
+      title={checked ? checkedTooltip : uncheckedTooltip}
+      aria-label={checked ? checkedTooltip : uncheckedTooltip}
+      role='switch'
+      aria-checked={checked}
+      tabIndex={0} // reintroduce to tab flow
+      onClick={this.toggle}
+      onKeyPress={this.keypress}
+      />
+  }
+}

--- a/lib/components/r5-version.js
+++ b/lib/components/r5-version.js
@@ -3,7 +3,7 @@
 import React, {Component, PropTypes} from 'react'
 import Select from 'react-select'
 
-import Icon from './icon'
+import {IconToggle} from './buttons'
 import messages from '../utils/messages'
 import {Group} from './input'
 
@@ -82,16 +82,13 @@ export default class R5Version extends Component {
 
     return <div>
       <Group {...this.props}>
-        <Icon
-          type='flask'
-          style={{
-            color: showAllVersions ? '#000' : '#aaa',
-            cursor: 'pointer'
-          }}
-          title={showAllVersions ? messages.project.showReleaseVersions : messages.project.showAllVersions}
-          aria-label={showAllVersions ? messages.project.showReleaseVersions : messages.project.showAllVersions}
-          onClick={this.toggleAllVersions}
-          />
+        <IconToggle
+          checked={showAllVersions}
+          checkedTooltip={messages.project.showReleaseVersions}
+          uncheckedTooltip={messages.project.showAllVersions}
+          icon='flask'
+          onChange={this.toggleAllVersions}
+        />
 
         <Select
           options={(showAllVersions ? allVersions : releaseVersions).map(v => ({ value: v, label: v }))}


### PR DESCRIPTION
This is one way to fix #325; it allows the user to select a grid (presumably one they've uploaded) and it will use its extents as the extents of the regional analysis. This adds a flask button that causes a grid selector to be shown:

![image](https://cloud.githubusercontent.com/assets/566958/23681460/092f7798-035d-11e7-9cb0-6609b867a727.png)

I'm not sure if it's the best way since it requires uploading a grid with the proper extents, but I needed to hack something together for a project and this was the easiest. Now that we have a bit more time I'm open to suggestions for better implementations.

Just drawing a box on the map is attractive but we need to save the extents somehow so multiple analyses can use the same extents.