### PR TITLE
feat(analysis): Show error messages raised by browsochrones

### DIFF
--- a/lib/utils/browsochrones.js
+++ b/lib/utils/browsochrones.js
@@ -169,11 +169,15 @@ async function ensureScenarioLoadedForInstance ({
 
     const { browsochrones } = instance
 
-    await Promise.all([
-      browsochrones.setQuery(metadata),
-      browsochrones.setStopTrees(stopTrees),
-      browsochrones.setTransitiveNetwork(metadata.transitive) // TODO shouldn't have to do this.
-    ])
+    try {
+      await Promise.all([
+        browsochrones.setQuery(metadata),
+        browsochrones.setStopTrees(stopTrees),
+        browsochrones.setTransitiveNetwork(metadata.transitive) // TODO shouldn't have to do this.
+      ])
+    } catch (e) {
+      throw new AnalysisError(-1, e.message, e.filename ? `${e.filename}: ${e.lineno}` : '')
+    }
 
     instance.staticSiteRequest = request
     instance.scenarioHash = scenarioHash
@@ -231,7 +235,12 @@ async function ensureOriginLoadedForInstance ({
       body: JSON.stringify(body)
     }, () => updateStatus(INITIALIZING_CLUSTER)).then(handleResponse(resType.ARRAY_BUFFER))
 
-    await instance.browsochrones.setOrigin(origin, { x, y })
+    try {
+      await instance.browsochrones.setOrigin(origin, { x, y })
+    } catch (e) {
+      throw new AnalysisError(-1, e.message, e.filename ? `${e.filename}: ${e.lineno}` : '')
+    }
+
     // overwrite things like the date so that they are equal when changing cutoff
     instance.staticSiteRequest.request = profileRequest
     const { spectrogramData } = await instance.browsochrones.generateSurface(indicator, 'AVERAGE')


### PR DESCRIPTION
This shows errors from the new array bounds checks and depends on conveyal/web-worker-promise-interface#29 and conveyal/browsochrones#77.