### PR TITLE
fix(regional): Add direct dependency on xorshift package :package:

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
     "reselect": "^2.5.3",
     "shpjs": "^3.3.2",
     "sprintf.js": "^0.1.4",
-    "uuid": "^3.0.1"
+    "uuid": "^3.0.1",
+    "xorshift": "^1.0.0"
   },
   "devDependencies": {
     "enzyme": "^2.6.0",


### PR DESCRIPTION
XorShift was being included transitively, which meant that when it was minified, the reference to it
became broken.