### PR TITLE
fix(regional): bump gridualizer version so comparisons work :tools:

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/conveyal/scenario-editor#readme",
   "dependencies": {
-    "@conveyal/gridualizer": "^2.0.0",
+    "@conveyal/gridualizer": "^2.0.1",
     "@conveyal/lonlat": "^1.1.1",
     "@conveyal/woonerf": "^2.0.1",
     "@mapbox/polyline": "^0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@conveyal/gridualizer@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@conveyal/gridualizer/-/gridualizer-2.0.0.tgz#178539185db0d0f5475114b458feeb46dab0fdc2"
+"@conveyal/gridualizer@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@conveyal/gridualizer/-/gridualizer-2.0.1.tgz#445cb3da277035506ba8aa0cbd2702acbe1c6267"
   dependencies:
     d3-color "^1.0.2"
     d3-scale "^1.0.4"
@@ -2038,12 +2038,12 @@ cz-conventional-changelog@1.2.0, cz-conventional-changelog@^1.1.6:
     word-wrap "^1.0.3"
 
 d3-array@1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.0.2.tgz#174237bf356a852fadd6af87743d928631de7655"
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.1.1.tgz#a01abe63a25ffb91d3423c3c6d051b4d36bc8a09"
 
 d3-collection@1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/d3-collection/-/d3-collection-1.0.2.tgz#df5acb5400443e9eabe9c1379896c67e52426b39"
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/d3-collection/-/d3-collection-1.0.3.tgz#00bdea94fbc1628d435abbae2f4dc2164e37dd34"
 
 d3-color@1, d3-color@^1.0.2:
   version "1.0.2"
@@ -2060,8 +2060,8 @@ d3-interpolate@1, d3-interpolate@^1.1.3:
     d3-color "1"
 
 d3-scale@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-1.0.4.tgz#50e28bf6a193b706745528515ed9b3d44205a033"
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-1.0.5.tgz#418506f0fb18eb052b385e196398acc2a4134858"
   dependencies:
     d3-array "1"
     d3-collection "1"
@@ -2072,14 +2072,14 @@ d3-scale@^1.0.4:
     d3-time-format "2"
 
 d3-time-format@2:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-2.0.3.tgz#3241569b74ddc9c42e0689c0e8a903579fd6280a"
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-2.0.5.tgz#9d7780204f7c9119c9170b1a56db4de9a8af972e"
   dependencies:
     d3-time "1"
 
 d3-time@1:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.0.4.tgz#2ceba09a76b7450c992a1ded4e10fc6195e69649"
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.0.6.tgz#a55b13d7d15d3a160ae91708232e0835f1d5e945"
 
 d@^0.1.1, d@~0.1.1:
   version "0.1.1"


### PR DESCRIPTION
The quantile scale does not work in Gridualizer 2.0.0 due to an import error with the constructor.
Ergo, install 2.0.1.

Fixes #328.

This is basically what is deployed to production, except that here I have updated package.json to require gridualizer ^2.0.1 whereas on production it grabbed 2.0.1 just because it's the latest 2.x release.