### PR TITLE
Don't require user to manually select a grid before results are shown

### DIFF
--- a/lib/actions/__tests__/__snapshots__/project.js.snap
+++ b/lib/actions/__tests__/__snapshots__/project.js.snap
@@ -73,20 +73,26 @@ Array [
     "type": "decrement outstanding fetches",
   },
   Array [
-    Object {
-      "payload": Object {
-        "bounds": Object {
-          "east": -76,
-          "north": 39,
-          "south": 38,
-          "west": -77,
+    Array [
+      Object {
+        "payload": Object {
+          "bounds": Object {
+            "east": -76,
+            "north": 39,
+            "south": 38,
+            "west": -77,
+          },
+          "description": "Project description",
+          "id": 1,
+          "name": "Mock Project",
         },
-        "description": "Project description",
-        "id": 1,
-        "name": "Mock Project",
+        "type": "set project",
       },
-      "type": "set project",
-    },
+      Object {
+        "payload": null,
+        "type": "set current indicator",
+      },
+    ],
     Array [
       Object {
         "payload": Object {
@@ -191,21 +197,27 @@ Array [
     "type": "decrement outstanding fetches",
   },
   Array [
-    Object {
-      "payload": Object {
-        "bounds": Object {
-          "east": -76.81503295898438,
-          "north": 39.02345139405932,
-          "south": 38.777640223073355,
-          "west": -77.25723266601562,
+    Array [
+      Object {
+        "payload": Object {
+          "bounds": Object {
+            "east": -76.81503295898438,
+            "north": 39.02345139405932,
+            "south": 38.777640223073355,
+            "west": -77.25723266601562,
+          },
+          "bundles": Array [],
+          "description": "Project description",
+          "name": "Project name",
+          "scenarios": Array [],
         },
-        "bundles": Array [],
-        "description": "Project description",
-        "name": "Project name",
-        "scenarios": Array [],
+        "type": "set project",
       },
-      "type": "set project",
-    },
+      Object {
+        "payload": null,
+        "type": "set current indicator",
+      },
+    ],
     Object {
       "payload": Object {
         "lat": 38.900545808566335,
@@ -264,12 +276,18 @@ Array [
 
 exports[`actions > project save should work 1`] = `
 Array [
-  Object {
-    "payload": Object {
-      "id": "1",
+  Array [
+    Object {
+      "payload": Object {
+        "id": "1",
+      },
+      "type": "set project",
     },
-    "type": "set project",
-  },
+    Object {
+      "payload": null,
+      "type": "set current indicator",
+    },
+  ],
   Object {
     "payload": Object {
       "next": [Function],
@@ -288,12 +306,18 @@ Array [
 
 exports[`actions > project save should work 2`] = `
 Array [
-  Object {
-    "payload": Object {
-      "id": "1",
+  Array [
+    Object {
+      "payload": Object {
+        "id": "1",
+      },
+      "type": "set project",
     },
-    "type": "set project",
-  },
+    Object {
+      "payload": null,
+      "type": "set current indicator",
+    },
+  ],
   Array [
     Object {
       "payload": Object {

--- a/lib/actions/project.js
+++ b/lib/actions/project.js
@@ -4,6 +4,7 @@ import {push} from 'react-router-redux'
 import uuid from 'uuid'
 
 import {lockUiWithError, setBundles} from './'
+import {setCurrentIndicator} from './analysis'
 import {setCenter as setMapCenter} from './map'
 import {setAll as setScenarios} from './scenario'
 import {clear as clearBrowsochrones} from '../utils/browsochrones'
@@ -89,5 +90,15 @@ const saveToServer = (project) =>
       : [setLocally(response.value), awaitLoad(response.value.id, () => push(`/projects/${response.value.id}`))]
   })
 
+const setProjectLocally = createAction('set project')
+
 export const setAll = createAction('set all projects')
-export const setLocally = createAction('set project')
+export const setLocally = (project) => {
+  let indicator = null
+  if (project.indicators != null && project.indicators.length > 0) {
+    if (project.indicators.find(i => i.key === 'Jobs_total')) indicator = 'Jobs_total'
+    else indicator = project.indicators[0].key
+  }
+
+  return [setProjectLocally(project), setCurrentIndicator(indicator)]
+}

--- a/lib/containers/opportunity.js
+++ b/lib/containers/opportunity.js
@@ -8,7 +8,10 @@ import {ReactDot} from '@conveyal/gridualizer'
 
 function mapStateToProps ({ analysis, project }) {
   return {
-    grid: analysis.grid,
+    // pass in an empty grid if no grid is loaded, so this component can be added to the map
+    // without needing to synchronize with the grid loading, and then just be updated when the
+    // grid loads
+    grid: analysis.grid || { zoom: 0, width: 0, height: 0, north: 0, west: 0, data: [] },
     color: process.env.OPPORTUNITY_COLOR
   }
 }

--- a/lib/reducers/analysis.js
+++ b/lib/reducers/analysis.js
@@ -171,6 +171,12 @@ export const reducers = {
         minimumImprovementProbability: action.payload
       }
     }
+  },
+  'set current indicator' (state, action) {
+    return {
+      ...state,
+      currentIndicator: action.payload
+    }
   }
 }
 


### PR DESCRIPTION
Currently, the layer showing the grid on the map is added as soon as the results come back. However, this fails on the first request as the grid may not have been added to the state. This puts a default grid in the state so that rendering does not fail in the split-second before the correct grid is displayed.