### PR TITLE
Catch and report errors and unhandled promise rejections

### DIFF
--- a/lib/components/report/index.js
+++ b/lib/components/report/index.js
@@ -30,10 +30,22 @@ type Props = {
   scenarioTimetables: Timetable[]
 }
 
+function alertOnError (error: {
+  message?: string,
+  reason?: string
+}) {
+  window.alert(`Error while rendering report! ${error.message || error.reason || ''}`)
+}
+
 /**
  * Main report generation component
  */
 export default class Report extends Component<void, Props, void> {
+  componentWillMount () {
+    window.addEventListener('error', alertOnError)
+    window.addEventListener('unhandledrejection', alertOnError)
+  }
+
   componentDidMount () {
     const {loadScenario, loadProject, projectId, scenarioId} = this.props
     loadScenario(scenarioId)

--- a/lib/components/sidebar.js
+++ b/lib/components/sidebar.js
@@ -72,6 +72,8 @@ export default class Sidebar extends PureComponent<void, Props, State> {
     })
     window.addEventListener('error', (error) =>
       this.setState({error: error.message}))
+    window.addEventListener('unhandledrejection', (error) =>
+      this.setState({error: error.reason}))
   }
 
   render () {


### PR DESCRIPTION
Shows an alert in the Report view and the error icon in the normal application. Closes #429