### PR TITLE
Help tooltips

### DIFF
--- a/configurations/default/messages.yml
+++ b/configurations/default/messages.yml
@@ -10,6 +10,7 @@ authentication:
   username: Logged in as %s
 bundle:
   create: Create a bundle
+  createBundleTooltip: Upload one or many GTFS feeds (.zip file with agency.txt, routes.txt, stops.txt, etc.).
   delete: Delete this bundle
   deleteConfirmation: Are you sure you would like to delete this bundle?
   edit: Edit bundle

--- a/configurations/default/messages.yml
+++ b/configurations/default/messages.yml
@@ -136,6 +136,7 @@ analysis:
   # accessibility pre-formatted as string, don't use %d
   percentileOfAccessibility: %(name)s: %(percentage)d%% of %(weightByName)s can access at least %(accessibility)s %(accessToName)s
   createGrid: Upload new opportunity dataset
+  createGridTooltip: Upload a .csv with lat/lon columns, or the files making up a shapefile (unzipped .shp .shx .dbf and .prj)
   opportunityDataset: Opportunity dataset
   selectOpportunityDataset: Select an opportunity dataset...
   cutoff: Travel time cutoff (minutes)

--- a/lib/components/create-grid.js
+++ b/lib/components/create-grid.js
@@ -3,6 +3,7 @@
 import Icon from '@conveyal/woonerf/components/icon'
 import PropTypes from 'prop-types'
 import React, {Component} from 'react'
+import ReactTooltip from 'react-tooltip'
 
 import {File, Text} from './input'
 import {Body, Heading, Panel} from './panel'
@@ -28,6 +29,12 @@ export default class CreateGrid extends Component {
       <Panel>
         <Heading>
           {messages.analysis.createGrid}
+          <a data-tip='React-tooltip'>
+          <Icon className='fa-question-circle-o fa-lg pull-right' / >
+          </a>
+          <ReactTooltip className='help-tooltip' place='right'>
+            {messages.analysis.createGridTooltip}
+          </ReactTooltip>
         </Heading>
         {uploading ? <Uploading /> : this.renderForm()}
       </Panel>

--- a/lib/components/edit-bundle.js
+++ b/lib/components/edit-bundle.js
@@ -2,6 +2,7 @@ import Icon from '@conveyal/woonerf/components/icon'
 import Pure from '@conveyal/woonerf/components/pure'
 import PropTypes from 'prop-types'
 import React from 'react'
+import ReactTooltip from 'react-tooltip'
 
 import {Button} from './buttons'
 import {Body, Heading, Panel} from './panel'
@@ -114,6 +115,12 @@ export default class EditBundle extends Pure {
       <Panel>
         <Heading>
           {bundleId ? messages.bundle.edit : messages.bundle.create}
+          <a data-tip='React-tooltip'>
+          <Icon className='fa-question-circle-o fa-lg pull-right' / >
+          </a>
+          <ReactTooltip className='help-tooltip' place='right'>
+            {messages.bundle.createBundleTooltip}
+          </ReactTooltip>
         </Heading>
         <Body>
           <form

--- a/lib/styles.css
+++ b/lib/styles.css
@@ -603,3 +603,10 @@ input[type="number"] {
   margin-top: 6px;
   margin-bottom: 6px;
 }
+
+.help-tooltip {
+  max-width: 400px;
+  z-index: 1000 !important;
+  opacity: 100 !important;
+  background-color: #333 !important;
+}

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "react-router-redux": "^4.0.5",
     "react-select": "^1.0.0-rc.3",
     "react-select-geocoder": "^1.2.0",
+    "react-tooltip": "^3.3.0",
     "redux": "^3.6.0",
     "redux-actions": "^1.2.1",
     "reselect": "^2.5.3",


### PR DESCRIPTION
Uses react-tooltip to add instructions about opportunity dataset and GTFS bundle upload.

Adds a ❔ to those panels.  When users hover over ❔, a tooltip with abbreviated instructions appears.  We could consider making the ❔s link to the appropriate readthedocs pages, but the maintenance required to update links as readthedocs changes might not be worth it.