### PR TITLE
Explanatory tooltips (now on latest base branch)

### DIFF
--- a/configurations/default/messages.yml
+++ b/configurations/default/messages.yml
@@ -70,6 +70,7 @@ project:
   customOpenStreetMapData: Custom OpenStreetMap data in PBF format (optional)
 scenario:
   createAction: Create a new Scenario
+  createActionTooltip: Each scenario can include variants with modifications that are applied to the same GTFS bundle.
   delete: Delete scenario
   deleteConfirmation: Are you sure you would like to delete this scenario?
   editAction: Save changes to scenario

--- a/configurations/default/messages.yml
+++ b/configurations/default/messages.yml
@@ -137,6 +137,7 @@ analysis:
   # accessibility pre-formatted as string, don't use %d
   percentileOfAccessibility: %(name)s: %(percentage)d%% of %(weightByName)s can access at least %(accessibility)s %(accessToName)s
   createGrid: Upload new opportunity dataset
+  createGridTooltip: Upload a .csv with lat/lon columns, or the files making up a shapefile (unzipped .shp .shx .dbf and .prj)
   opportunityDataset: Opportunity dataset
   selectOpportunityDataset: Select an opportunity dataset...
   cutoff: Travel time cutoff (minutes)

--- a/lib/components/create-grid.js
+++ b/lib/components/create-grid.js
@@ -29,12 +29,10 @@ export default class CreateGrid extends Component {
       <Panel>
         <Heading>
           {messages.analysis.createGrid}
-          <a data-tip='React-tooltip'>
-            <Icon className='fa-question-circle-o fa-lg pull-right' / >
+          <a data-tip={messages.analysis.createGridTooltip}>
+            <Icon type='question-circle-o' className='fa-lg pull-right' />
+            <ReactTooltip className='help-tooltip' place='right' />
           </a>
-          <ReactTooltip className='help-tooltip' place='right'>
-            {messages.analysis.createGridTooltip}
-          </ReactTooltip>
         </Heading>
         {uploading ? <Uploading /> : this.renderForm()}
       </Panel>

--- a/lib/components/create-grid.js
+++ b/lib/components/create-grid.js
@@ -3,6 +3,7 @@
 import Icon from '@conveyal/woonerf/components/icon'
 import PropTypes from 'prop-types'
 import React, {Component} from 'react'
+import ReactTooltip from 'react-tooltip'
 
 import {File, Text} from './input'
 import {Body, Heading, Panel} from './panel'
@@ -28,6 +29,12 @@ export default class CreateGrid extends Component {
       <Panel>
         <Heading>
           {messages.analysis.createGrid}
+          <a data-tip='React-tooltip'>
+            <Icon className='fa-question-circle-o fa-lg pull-right' / >
+          </a>
+          <ReactTooltip className='help-tooltip' place='right'>
+            {messages.analysis.createGridTooltip}
+          </ReactTooltip>
         </Heading>
         {uploading ? <Uploading /> : this.renderForm()}
       </Panel>

--- a/lib/components/edit-scenario.js
+++ b/lib/components/edit-scenario.js
@@ -67,20 +67,17 @@ export default class EditScenario extends PureComponent {
       name && name.length > 0 && bundleId && bundleId.length > 0
     return (
       <Panel>
+        <Heading>
           {isEditing &&
-            <Heading>
-              {messages.scenario.editTitle}
-            </Heading>}
+            messages.scenario.editTitle}
           {!isEditing &&
-            <Heading>
-              {messages.scenario.createAction}
-              <a data-tip='React-tooltip'>
-                <Icon type='question-circle-o' className='fa-lg pull-right' / >
-              </a>
-              <ReactTooltip className='help-tooltip' place='right'>
-                {messages.scenario.createActionTooltip}
-              </ReactTooltip>
-            </Heading>}
+            messages.scenario.createAction}
+          {!isEditing &&
+              <a data-tip={messages.scenario.createActionTooltip}>
+                <Icon type='question-circle-o' className='fa-lg pull-right' />
+                <ReactTooltip className='help-tooltip' place='right' />
+              </a>}
+        </Heading>
         <Body>
           <Text
             name='Scenario name'

--- a/lib/components/edit-scenario.js
+++ b/lib/components/edit-scenario.js
@@ -3,6 +3,7 @@ import Icon from '@conveyal/woonerf/components/icon'
 import PropTypes from 'prop-types'
 import React, {PureComponent} from 'react'
 import Select from 'react-select'
+import ReactTooltip from 'react-tooltip'
 
 import {Button} from './buttons'
 import {Group as FormGroup, Text} from './input'
@@ -66,11 +67,20 @@ export default class EditScenario extends PureComponent {
       name && name.length > 0 && bundleId && bundleId.length > 0
     return (
       <Panel>
-        <Heading>
-          {isEditing
-            ? messages.scenario.editTitle
-            : messages.scenario.createAction}
-        </Heading>
+          {isEditing &&
+            <Heading>
+              {messages.scenario.editTitle}
+            </Heading>}
+          {!isEditing &&
+            <Heading>
+              {messages.scenario.createAction}
+              <a data-tip='React-tooltip'>
+                <Icon type='question-circle-o' className='fa-lg pull-right' / >
+              </a>
+              <ReactTooltip className='help-tooltip' place='right'>
+                {messages.scenario.createActionTooltip}
+              </ReactTooltip>
+            </Heading>}
         <Body>
           <Text
             name='Scenario name'
@@ -92,7 +102,7 @@ export default class EditScenario extends PureComponent {
                 })}
                 onChange={option =>
                   this.setState({...this.state, bundleId: option.value})}
-                placeholder='Select a bundle...'
+                placeholder='Select a GTFS bundle...'
                 value={bundleId}
               />
             </FormGroup>}

--- a/lib/styles.css
+++ b/lib/styles.css
@@ -617,3 +617,10 @@ input[type="range"].form-control {
 .tooltip.right .tooltip-arrow {
   border-right-color: #333;
 }
+
+.help-tooltip {
+  max-width: 400px;
+  z-index: 1000 !important;
+  opacity: 100 !important;
+  background-color: #333 !important;
+}

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "react-router-redux": "^4.0.5",
     "react-select": "^1.0.0-rc.3",
     "react-select-geocoder": "^1.2.0",
+    "react-tooltip": "^3.3.0",
     "redux": "^3.6.0",
     "redux-actions": "^1.2.1",
     "reselect": "^2.5.3",


### PR DESCRIPTION
Uses react-tooltip to add instructions about opportunity dataset and GTFS bundle upload.

Adds a ❔ to those panels. When users hover over ❔, a tooltip with abbreviated instructions appears. We could consider making the ❔s link to the appropriate readthedocs pages, but the maintenance required to update links as readthedocs changes might not be worth it.