### PR TITLE
Default to 0 stop spacing for segments

### DIFF
--- a/lib/utils/update-add-stops-terminus.js
+++ b/lib/utils/update-add-stops-terminus.js
@@ -34,7 +34,7 @@ export default function updateAddStopsTerminus ({
         stopAtEnd: true,
         fromStopId: `${modification.feed}:${toStop.stop_id}`,
         toStopId: `${modification.feed}:${toStop.stop_id}`,
-        spacing: 400
+        spacing: 0
       }
     ]
   } else if (toStop == null) {
@@ -48,7 +48,7 @@ export default function updateAddStopsTerminus ({
         stopAtEnd: true,
         fromStopId: `${modification.feed}:${fromStop.stop_id}`,
         toStopId: `${modification.feed}:${fromStop.stop_id}`,
-        spacing: 400
+        spacing: 0
       }
     ]
   } else {
@@ -65,7 +65,7 @@ export default function updateAddStopsTerminus ({
         stopAtEnd: true,
         fromStopId: `${modification.feed}:${fromStop.stop_id}`,
         toStopId: `${modification.feed}:${toStop.stop_id}`,
-        spacing: 400
+        spacing: 0
       }
     ]
   }


### PR DESCRIPTION
We switched "Create Stops Automatically" to be off by default. With a default spacing in selected
segments for reroute modifications this caused a mismatch in what was presented vs assumed. This
commit sets the default stop spacing to be 0 to match.

closes #502