### PR TITLE
Rename hierarchy

### DIFF
--- a/configurations/default/messages.yml
+++ b/configurations/default/messages.yml
@@ -73,7 +73,7 @@ project:
   createActionTooltip: Each project can include scenarios with modifications that are applied to the same GTFS bundle.
   delete: Delete project
   deleteConfirmation: Are you sure you would like to delete this project?
-  editAction: Save changes to project
+  editAction: Save project
   editTitle: Edit project
   editName: Edit project name
   importShapefile: Import route alignment shapefile
@@ -96,6 +96,7 @@ scenario:
   delete: Delete this scenario
   deleteConfirmation: Are you sure you want to delete this scenario? Proceeding will clear references to it from all modifications.
   activeIn: Active in scenario numbers
+  export: Select scenario to #followed by print, e.g.
 transitEditor:
   startEdit: Edit route geometry
   stopEdit: Stop editing
@@ -205,6 +206,7 @@ analysis:
   aggregateTo: Aggregate results to
   weightBy: Weighted by
   newAggregationArea: Upload new aggregation area
+  uploadAggregationArea: Upload
   aggregationAreaName: Aggregation area name
   aggregationAreaFiles: Select aggregation area files (.shp)
   # string not decimal, the number is preformatted

--- a/configurations/default/messages.yml
+++ b/configurations/default/messages.yml
@@ -1,6 +1,6 @@
 common:
+  project: Project
   scenario: Scenario
-  variant: Variant
   help: help # stylized as lowercase since it's next to the conveyal analysis which is lowercase
   yes: yes
   no: no
@@ -211,7 +211,7 @@ report:
   keepTripsOutside: Existing trips outside modified windows are kept.
   removeTripsOutside: All existing trips are removed.
   newFrequencies: New frequencies
-  variant: Variant: %s
+  variant: Scenario: %s
   bundle: Using bundle: %s
   phasing:
     phaseFromSeconds: Phase: %(time)s from %(timetable)s

--- a/configurations/default/messages.yml
+++ b/configurations/default/messages.yml
@@ -9,7 +9,7 @@ authentication:
   logOut: Log out
   username: Logged in as %s
 bundle:
-  create: Create a bundle
+  create: Create GTFS bundle
   delete: Delete this bundle
   deleteConfirmation: Are you sure you would like to delete this bundle? Projects using this bundle will no longer work.
   edit: Edit bundle
@@ -23,8 +23,8 @@ nav:
   scenarios: Projects
   gtfsBundles: GTFS Bundles
   opportunityDatasets: Opportunity Datasets
-  editScenario: Edit Scenario
-  analyzeScenario: Analyze Scenario
+  editScenario: Edit Scenarios
+  analyzeScenario: Analyze Scenarios
   notConnectedToInternet: You are not connected to the internet
   unfinishedRequests: You have unfinished requests. Are you sure you want to exit?
 phasing:
@@ -82,7 +82,7 @@ project:
   loading: Loading project...
   loadingGTFS: Loading GTFS bundle & modifications...
   route: Route
-  uploadBundle: Upload new GTFS Bundle
+  uploadBundle: Upload a new GTFS Bundle
   uploadOpportunityDataset: Upload a new Opportunity Dataset
   goToExisting: or go to an existing project
   goToScenario: Go to project
@@ -147,7 +147,7 @@ analysis:
   selectPercentileOfAccessibility: Percentile of accessibility
   # accessibility pre-formatted as string, don't use %d
   percentileOfAccessibility: %(name)s: %(percentage)d%% of %(weightByName)s can access at least %(accessibility)s %(accessToName)s
-  createGrid: Upload new opportunity dataset
+  createGrid: Upload a new opportunity dataset
   createGridTooltip: Upload a .csv with lat/lon columns, or the files making up a shapefile (unzipped .shp .shx .dbf and .prj)
   opportunityDataset: Opportunity dataset
   selectOpportunityDataset: Select an opportunity dataset...

--- a/configurations/default/messages.yml
+++ b/configurations/default/messages.yml
@@ -18,9 +18,9 @@ map:
 nav:
   createBundle: Create Bundle
   selectBundle: Select Bundle
-  projects: Projects
-  projectSettings: Project Settings
-  scenarios: Project Scenarios
+  projects: Regions
+  projectSettings: Shared Settings
+  scenarios: Projects
   gtfsBundles: GTFS Bundles
   opportunityDatasets: Opportunity Datasets
   editScenario: Edit Scenario
@@ -37,20 +37,22 @@ phasing:
   headwayMismatchWarning: Warning! The selected timetable's %(selectedTimetableHeadway)s minute headway does not equal this timetable's headway, which could cause unintended behavior.
   noAvailableStopsWarning: The selected timetable does not contain stops available to phase from!
   exactTimesWarning: Exact times is not available because phasing is enabled on this timetable.
-project:
+region:
   welcome: welcome to
-  createAction: Create a new Project
-  goToExisting: or go to an existing project
-  goToProject: Go to Project
-  createTitle: Create a new Project
-  configure: Configure project settings
-  deleteAction: DANGER: Delete this project
-  deleteConfirmation: Are you sure you would like to delete this project? This will delete all scenarios and modifications associated with this project.
-  editAction: Save project
-  editTitle: Edit project
-  versionOutdated: The chosen analysis backend version of this project is outdated.
-  editProject: Edit project.
-  loadingProject: Loading project...
+  createAction: Set up a new region
+  goToExisting: or go to an existing region
+  goToProject: Go to region
+  name:  Region Name
+  description: Description
+  configure: Configure shared settings for region
+  deleteAction: DANGER: Delete this region
+  deleteConfirmation: Are you sure you would like to delete this region? This will delete all associated scenarios and modifications.
+  editAction: Save changes
+  editTitle: Edit region
+  versionOutdated: The chosen analysis backend version of this region is outdated.
+  editProject: Edit region
+  loadingProject: Loading region...
+  osmBounds: OpenStreetMap bounds
   r5Version: Analysis backend version
   latestReleaseVersionNotSelected: There is a more recent version of the analysis backend available.
     Changing backend versions may enable new features or increased performance, but may also cause

--- a/configurations/default/messages.yml
+++ b/configurations/default/messages.yml
@@ -51,7 +51,7 @@ region:
   editTitle: Edit region
   versionOutdated: The chosen analysis backend version of this region is outdated.
   editProject: Edit region
-  loadingProject: Loading region...
+  loadingProject: Loading region…
   osmBounds: OpenStreetMap bounds
   r5Version: Analysis backend version
   latestReleaseVersionNotSelected: There is a more recent version of the analysis backend available.
@@ -79,14 +79,14 @@ project:
   importShapefile: Import route alignment shapefile
   importModifications: Import modifications from another project
   importAction: Import modifications
-  loading: Loading project...
-  loadingGTFS: Loading GTFS bundle & modifications...
+  loading: Loading project…
+  loadingGTFS: Loading GTFS bundle & modifications…
   route: Route
   uploadBundle: Upload a new GTFS Bundle
   uploadOpportunityDataset: Upload a new Opportunity Dataset
   goToExisting: or go to an existing project
   goToScenario: Go to project
-  select: Select a project...
+  select: Select a project…
 scenario:
   plural: Scenarios
   enterName: Enter a name for your scenario:
@@ -149,12 +149,13 @@ analysis:
   # accessibility pre-formatted as string, don't use %d
   percentileOfAccessibility: %(name)s: %(percentage)d%% of %(weightByName)s can access at least %(accessibility)s %(accessToName)s
   createGrid: Upload a new opportunity dataset
+  grid: Opportunity Data
   createGridTooltip: Upload a .csv with lat/lon columns, or the files making up a shapefile (unzipped .shp .shx .dbf and .prj)
   opportunityDataset: Opportunity dataset
-  selectOpportunityDataset: Select an opportunity dataset...
+  selectOpportunityDataset: Select an opportunity dataset…
   cutoff: Travel time cutoff (minutes)
   addGrid: Add opportunity dataset
-  uploading: uploading...
+  uploading: uploading…
   gridName: Opportunity dataset
   gridFiles: Select opportunity dataset
   latField: Latitude field
@@ -202,7 +203,7 @@ analysis:
     APPLYING_SCENARIO: Applying scenario…
     PERFORMING_ANALYSIS: Performing analysis…
     COMPUTING_ISOCHRONE: Computing isochrone…
-    INITIALIZING_CLUSTER: Initializing compute cluster (may take several minutes)…
+    INITIALIZING_CLUSTER: Initializing compute cluster (may take several minutes)
   aggregateTo: Aggregate results to
   weightBy: Weighted by
   newAggregationArea: Upload new aggregation area
@@ -216,12 +217,12 @@ analysis:
   regionalBounds: Bounds of analysis
   regionalBoundsSame: Same as %s
   regionalBoundsCustom: Custom
-  regionalBoundsProject: Same as project
+  regionalBoundsProject: Entire region
   bookmark: Bookmark
   createBookmark: Create bookmark
   bookmarkName: Bookmark name
-  selectComparisonScenario: Select comparison project...
-  selectComparisonScenarioVariant: Select comparison scenario...
+  selectComparisonScenario: Select comparison project…
+  selectComparisonScenarioVariant: Select comparison scenario…
 report:
   keepTripsOutside: Existing trips outside modified windows are kept.
   removeTripsOutside: All existing trips are removed.

--- a/configurations/default/messages.yml
+++ b/configurations/default/messages.yml
@@ -11,7 +11,7 @@ authentication:
 bundle:
   create: Create a bundle
   delete: Delete this bundle
-  deleteConfirmation: Are you sure you would like to delete this bundle? Scenarios using this bundle will no longer work.
+  deleteConfirmation: Are you sure you would like to delete this bundle? Projects using this bundle will no longer work.
   edit: Edit bundle
 map:
   northAbbr: N # Local abbreviation for north, used to label north arrow
@@ -66,23 +66,34 @@ project:
     STORING_CENSUS: Storing census data…
     DONE: Done
   customOpenStreetMapData: Custom OpenStreetMap data in PBF format
-scenario:
-  createAction: Create a new Scenario
-  createActionTooltip: Each scenario can include variants with modifications that are applied to the same GTFS bundle.
-  delete: Delete scenario
-  deleteConfirmation: Are you sure you would like to delete this scenario?
-  editAction: Save changes to scenario
-  editTitle: Edit scenario
-  editName: Edit scenario name
-  importShapefile: Import shapefile
-  importModifications: Import modifications from another scenario
-  loading: Loading scenario...
+project:
+  createAction: Create new Project
+  createActionTooltip: Each project can include scenarios with modifications that are applied to the same GTFS bundle.
+  delete: Delete project
+  deleteConfirmation: Are you sure you would like to delete this project?
+  editAction: Save changes to project
+  editTitle: Edit project
+  editName: Edit project name
+  importShapefile: Import route alignment shapefile
+  importModifications: Import modifications from another project
+  importAction: Import modifications
+  loading: Loading project...
   loadingGTFS: Loading GTFS bundle & modifications...
   route: Route
   uploadBundle: Upload new GTFS Bundle
   uploadOpportunityDataset: Upload a new Opportunity Dataset
-  goToExisting: or go to an existing scenario
-  goToScenario: Go to Scenario
+  goToExisting: or go to an existing project
+  goToScenario: Go to project
+  select: Select a project...
+scenario:
+  plural: Scenarios
+  enterName: Enter a name for your scenario:
+  editName: Rename this scenario
+  createAction: Create new scenario
+  showModifications: Show modifications for this scenario on the map
+  delete: Delete this scenario
+  deleteConfirmation: Are you sure you want to delete this scenario? Proceeding will clear references to it from all modifications.
+  activeIn: Active in scenario numbers
 transitEditor:
   startEdit: Edit route geometry
   stopEdit: Stop editing
@@ -205,8 +216,8 @@ analysis:
   bookmark: Bookmark
   createBookmark: Create bookmark
   bookmarkName: Bookmark name
-  selectComparisonScenario: Select comparison scenario...
-  selectComparisonScenarioVariant: Select comparison scenario variant...
+  selectComparisonScenario: Select comparison project...
+  selectComparisonScenarioVariant: Select comparison scenario...
 report:
   keepTripsOutside: Existing trips outside modified windows are kept.
   removeTripsOutside: All existing trips are removed.

--- a/configurations/default/messages.yml
+++ b/configurations/default/messages.yml
@@ -17,7 +17,6 @@ map:
   northAbbr: N # Local abbreviation for north, used to label north arrow
 nav:
   createBundle: Create Bundle
-  openScenario: Open Scenario
   importShapefile: Import Shapefile
   selectBundle: Select Bundle
   projects: Projects
@@ -151,7 +150,6 @@ analysis:
   errorsInScenario: Errors were found in the scenario:
   warningsInScenario: Warnings were found applying the scenario
   errorsInModification: in modification %s
-  runAnalysis: Perform regional analysis
   minimumImprovementProbability: Minimum probability of change
   probabilityImprovement: Show areas with probability of change > %01.2f
   compare: Compare to another scenario
@@ -275,4 +273,3 @@ report:
   addTrips:
     bidirectional: bidirectional
     unidirectional: unidirectional
-welcome: welcome to

--- a/configurations/default/messages.yml
+++ b/configurations/default/messages.yml
@@ -17,7 +17,6 @@ map:
   northAbbr: N # Local abbreviation for north, used to label north arrow
 nav:
   createBundle: Create Bundle
-  importShapefile: Import Shapefile
   selectBundle: Select Bundle
   projects: Projects
   projectSettings: Project Settings

--- a/docs/analysis/index.md
+++ b/docs/analysis/index.md
@@ -1,171 +1,93 @@
-Once you have prepared a scenario, you can use the analysis functionality to evaluate the accessibility
-impacts of your scenario. To enter the analysis mode, click on the graph button in the sidebar.
+Once you have prepared a scenario, you can evaluate its accessibility impacts. To enter the Analyze Scenarios view, click on the graph button in the sidebar.
 
 <img src="../img/select-analysis.png" alt="Selecting the button to enter analysis mode" />
 
-If your project is in the United States, you should shortly see an isochrone and several accessibility plots.
-If your project is outside the US, or if you want to compute accessibility using a land use dataset other than the
-US Census [LODES](https://lehd.ces.census.gov/data/#lodes), you'll need to [upload opportunity data](upload-opportunity-data) (e.g. job locations) in order
-to complete analysis.
+If your project is in the United States, you should shortly see the accessibility results described below. If your project is outside the US, or if you want to compute accessibility using a land use dataset other than the US Census [LODES](https://lehd.ces.census.gov/data/#lodes), you'll first need to [upload opportunity data](upload-opportunity-data) (e.g. job locations).
 
-Once you have opportunity data loaded, you will see the following when you enter analysis mode. It will take several minutes to load
-the first time you use it, while the compute cluster starts up. The spinner to the right of the
-variant name will indicate that the cluster is initializing.
+Once a compute cluster has initialized (which may take several minutes the first time you use a GTFS bundle), several components will be visible in the analysis mode.
 
 <figure>
   <img src="../img/analysis-start.png" />
   <figcaption>The initial analysis page</figcaption>
 </figure>
 
-The UI consists of several components. On the right is a map display consisting of several components.
-The gray dots represent the density of opportunities. For instance, if you're analyzing access to jobs,
-there will be tightly packed dots in areas of dense employment, and less tightly packed dots elsewhere.
-One dot represents one or multiple opportunities (e.g. jobs), and the scale may differ between zoom
-levels and opportunity datasets. For example, if at a given zoom level, one dot represents 4 jobs, at that
-same zoom level one dot might represent only two residents.
+# Isochrone map
+On the map, gray dots represent the density of opportunities. For instance, if your selected Opportunity Data are jobs, there will be tightly packed dots in areas of dense employment, and less tightly packed dots elsewhere. One dot represents one or multiple opportunities (e.g. jobs), and the scale may differ between zoom levels and opportunity datasets. For example, if at a given zoom level, one dot represents 4 jobs, at that same zoom level one dot might represent only two residents. Modifications on the map will be shown according to the visibility set in the Edit Scenarios view.
 
-The map also shows an isochrone (the area shaded in blue), which represents the area of the city that
-can be reached from the marker location within a given travel time (the default is 60 minutes, and it
-is controlled by the slider in the left panel.) To change the origin of the analysis, simply drag the marker
-to a new location.
+The map will also show a blue isochrone, which represents the area reachable within a given travel time (the default is 60 minutes, and it is controlled by the slider in the left panel) from the origin marker. To change the origin of the analysis, simply drag the marker to a new location.
 
-Clicking on the map will display the distribution of travel times from the origin to that location.
-For example, in the image below, the travel time varies between about 30 and 50 minutes depending on
-when one leaves.
+If multiple scenarios are being compared, the isochrone for the first scenario remains blue, while the isochrone for the second is red. Thus, areas reachable under both scenarios are purple, areas reachable only under the first scenario are blue, and areas reachable only under the second scenario are red.
+
+Clicking on the map will display the distribution of travel times from the origin to that location. For example, in the image below, the travel time varies between about 30 and 50 minutes depending on when one leaves.
 
 <figure>
   <img src="../img/destination-travel-time-distribution.png" />
   <figcaption>The travel time distribution from an origin to a destination</figcaption>
 </figure>
 
-# Routing controls
+# Analysis panel
+The left panel has controls for the analysis and displays the accessibility afforded by the scenario.
 
-The left panel has a number of controls for the analysis, and displays the accessibility afforded by the
-scenario. At the top of the panel, the variant of the scenario is listed, and can be changed to
-analyze a different variant. Below that, a second scenario and a variant within that scenario may be selected
-in order to perform a comparison. A comparison with baseline GTFS data with no modifications applied
-is possible by choosing the current scenario and the "Baseline" variant, which exists automatically
-for every scenario.
+At the top of the panel, available scenarios and opportunity data layers are listed in drop-down menus. For example, you might be interested in how a given scenario provides access to jobs, or access to schools, or some other variable of interest represented in an Opportunity Dataset you uploaded.
 
-Below that, the analysis settings can be expanded and different parameters for the analysis can be set:
+Additional scenarios can be selected for comparison. A "Baseline" scenario with no modifications (i.e. the unmodified GTFS bundle you uploaded) is automatically available for every project.
 
-<figure>
-  <img src="../img/analysis-settings.png" />
-  <figcaption>The analysis settings pane</figcaption>
-</figure>
-
-Here you can set a number of parameters. The first panel allows the creation and use of "bookmarks,"
-which store particular analysis settings (e.g. origin location, type of opportunity, departure date
-and time, travel time cutoff, etc.). Once you have a set of settings you would like save, you can choose
-"Create Bookmark," enter a name for the bookmark, and click "Create Bookmark" again to save it. Once that is
-done, you can select a bookmark from the dropdown box to automatically fill in all of the settings from
-that bookmark. Bookmarks are shared by all scenarios in a project; this way, the same locations and
-settings can be used to analyze the effects of multiple scenarios.
-
-Next is the mode selector; you can choose to perform your analysis with or without transit, and using
-walking, biking or driving. For instance, in the image above, a combination of walking and transit has
-been chosen. Note that, due to data availability, traffic congestion is not taken into account in
-driving time estimates.
-
-Next are the from and to time; these represent the time period
-you are analyzing. These default to 7:00 and 9:00, meaning our accessibility results will display
-the opportunities accessible by someone leaving the chosen origin point between 7:00 and 9:00. Below
-that is the date of the analysis. This date determines what service will be included in the analysis.
-To avoid inadvertently introducing differences in results due to differences in service on different
-days, we recommend choosing a single date and using it for the duration of a project. This date should,
-of course, be within the validity period of the baseline GTFS feed you are using.
-
-Below that is the transfer limit. This specifies the number of transfers that will be considered to
-find the optimal trip.
-
-The next field is the number of simulated schedules. When there are lines that have headways rather
-than full schedules, this controls the number of random schedules that are generated. Results will be
-more accurate when it is set higher, at the cost of speed. For quick, interactive analysis, we
-recommend setting it to 200, whereas, for final analysis, we recommend setting it to 1000. For more on this,
-see [methodology](/analysis/methodology).
-
-Below the analysis settings pane is a dropdown to choose a category of opportunities to measure accessibility to.
-For example, you might be interested in access to jobs, or access to schools, or some other variable of
-interest. In the US, these categories will be automatically populated from the US Census [LODES](https://lehd.ces.census.gov/data/#lodes)
-dataset. If you are outside the US, or if you want to use data that isn't included in LODES, you can
-[upload alternate data](/analysis/upload-opportunity-data). The opportunities from the selected category
-will be displayed on the map as dots.
-
-The last item in the analysis settings area is a refresh button, used to reload scenario results after editing parameters.
-
-# Accessibility display
-
-Below the analysis controls are the displays of accessibility. The main component is the stacked
-percentile plot, described in the next section. Additionally, directly below the comparison controls
-are readouts of the accessibility (number of opportunities reachable) from the chosen origin under the scenario and
-(if applicable) any comparison scenario.
-
-## Stacked percentiles
+## Charts of accessibility results
+Directly below the comparison controls are readouts of the accessibility (number of opportunities reachable) from the chosen origin under the scenario and (if applicable) any comparison scenario.
 
 <figure>
   <img src="../img/analysis-stacked-percentile.png" />
   <figcaption>A stacked percentile plot</figcaption>
 </figure>
 
-The main display of accessibility results is the stacked percentile plot. The right portion of the plot
-shows the distribution of cumulative accessibility, i.e. the number of opportunities reachable given
-varying travel time budgets. The graph is not a single line, because there is variation in transit travel
-time depending on when a user of the transport system leaves their origin.
-Rather, the graph shows the number of opportunities given 95th, 75th, 50th, 25th, and 5th percentile
-travel time. The bottom of the shaded area is the number of opportunities which are almost always
-reachable, while the top is the number of opportunities that are occasionally reachable. The darkened
-line is the number of opportunities that are reachable at least half the time (i.e. have a median travel
-  time of less than the travel time cutoff). For a more detailed explanation, see the [methodology](/analysis/methodology)
-  page.
+The main display of accessibility results is the stacked percentile plot. The right portion of the plot shows the distribution of cumulative accessibility, i.e. the number of opportunities reachable given varying travel time budgets. The graph is not a single line, because there is variation in transit travel time depending on when a user of the transport system leaves their origin. Rather, the graph shows the number of opportunities given 95th, 75th, 50th, 25th, and 5th percentile travel time. The bottom of the shaded area is the number of opportunities which are almost always reachable, while the top is the number of opportunities that are reachable only in the best cases (e.g. when someone leaves their house at the perfect time and has no waiting time). The darkened line is the number of opportunities that are reachable at least half the time (i.e. have a median travel   time of less than the travel time cutoff). For a more detailed explanation, see the [methodology](/analysis/methodology) page.
 
-The currently-selected travel time budget is indicated by the vertical line on the plot, and can be controlled using
-the slider below the plot. This also controls the isochrone.
+The currently-selected travel time budget is indicated by the vertical line on the plot, and can be controlled using the slider below the plot. This also controls the isochrone on the map.
 
-To the left of the Y axis labels is a box-and-whisker plot. This shows the same information as the cumulative
-plot, but only for the currently selected travel time budget. The lowest whisker shows the number of
-opportunities accessible given 95th percentile travel time, the box shows the number of opportunities
-accessible given 75th, 50th and 25th percentile travel time, and the top whisker shows the number of
-opportunities reachable given 5th percentile travel time.
+To the left of the Y axis labels is a box-and-whisker plot. This shows the same information as the cumulative plot, but only for the currently selected travel time budget. The lowest whisker shows the number of opportunities accessible given 95th percentile travel time, the box shows the number of opportunities accessible given 75th, 50th and 25th percentile travel time, and the top whisker shows the number of opportunities reachable given 5th percentile travel time.
 
-
-## Comparing scenarios
-
-When a comparison scenario and variant are selected in the analysis settings panel, the display will
-be slightly different, because it will include information for both scenarios. The isochrone for the
-originally chosen scenario remains blue, while the isochrone
-for the comparison scenario is red. Thus, the areas reachable under both scenarios are purple, the areas reachable under the originally chosen
-scenario are blue, and the areas reachable only under the comparison scenario are red.
+When multiple scenarios are selected, the charts will be slightly different, because they will include information for both scenarios.
 
 <figure>
   <img src="../img/analysis-comparison.png" />
   <figcaption>Comparison analysis in Atlanta, Georgia, USA</figcaption>
 </figure>
 
-The stacked percentile plot is similar as well. The main difference is that two box plots will be
-displayed, in red and blue, to the left of the axis. The blue box plot is for the scenario currently
-being analyzed, while the red one is for the scenario being compared against. Above the chart, there
-is a selector that allows you to select whether to view the cumulative curves for the scenario being
-analyzed, the scenario being compared against, or both (in which case the plots will be simplified and
-  only the bands between the 75th and 25th percentile travel times will be shown, for visual simplicity).
+TTwo box plots will be displayed, in red and blue, to the left of the axis. The blue box plot is for the first scenario, while the red one is for the second scenario. Above the chart, there is a selector that allows you to select whether to view the cumulative curves for the first scenario, the second scenario, or both (in which case the plots will be simplified and only the bands between the 75th and 25th percentile travel times will be shown, for simplicity).
 
 <figure>
   <img src="../img/stacked-percentile-comparison.png" />
   <figcaption>A stacked percentile plot comparing two scenarios</figcaption>
 </figure>
 
+To download an isochrone shown on the map, click "Isochrone as GeoJSON".  The downloaded file can be used directly in GIS software or converted to other formats using a tool like [mapshaper] (http://mapshaper.org).
+
+## Detailed analysis settings
+Below the accessibility charts, different parameters for the analysis can be set:
+
+<figure>
+  <img src="../img/analysis-settings.png" />
+  <figcaption>The analysis settings pane</figcaption>
+</figure>
+
+Here you can set a number of parameters. The first panel allows the creation and use of "bookmarks," which store particular analysis settings (e.g. origin location, type of opportunity, departure date and time, travel time cutoff, etc.). Once you have a set of settings you would like save, you can choose "Create Bookmark" and enter a name. Once that is done, you can select a bookmark from the dropdown box to automatically fill in all of the settings from that bookmark. Bookmarks are shared by all projects in a region.
+
+Next is the mode selector; you can choose to perform your analysis with or without transit, and using walking, biking or driving. For instance, in the image above, a combination of walking and transit has been chosen. Note that traffic congestion is not taken into account in driving time estimates, though this may be a feature of a future release when more detailed datasets are available.
+
+Next are the date, from time, and to time. These represent the time period you are analyzing. These default to 7:00 and 9:00, meaning our accessibility results will display the opportunities accessible by someone leaving the chosen origin point on the chosen day between 7:00 and 9:00. To avoid inadvertently introducing differences in results due to differences in service on different days, we recommend choosing a single date and using it for the duration of a project. You should check that the date chosen is sufficiently representative in the GTFS feeds you are using (e.g. a non-holiday weekday).
+
+Maximum transfers is an upper limit on the number of transfers that will be considered when finding optimal trips.  The next field is the number of simulated schedules. When your GTFS feeds or scenarios include frequency-based routes (i.e. routes that do not have timetables with exact times specified), this parameter controls the number of schedules simulated for sampling. Final results will be more accurate when it is set higher, but computation may take longer. For quick, interactive analysis, we recommend setting it to 200, whereas, for final analysis, we recommend setting it to 1000. For more on this, see [methodology](/analysis/methodology).
+
 # Errors and warnings when analyzing scenarios
 
-Occasionally, analysis will fail because there is an error in a scenario. When this occurs, error
-messages will be displayed detailing the issues, as shown below. One simply needs to return to the modification editor
-and correct the errors in the relevant modifications.
+Occasionally, analysis will fail because there is an error in a scenario. When this occurs, error messages will be displayed detailing the issues, as shown below. One simply needs to return to the modification editor and correct the errors in the relevant modifications.
 
 <figure>
   <img src="../img/scenario-error.png" />
   <figcaption>Scenario errors displayed in the editor</figcaption>
 </figure>
 
-In other cases, the scenario may generate a warning, for instance if you remove more time from a segment
-when speeding it up than the length of that segment. This is not necessarily an error, but may require attention.
+In other cases, the scenario may generate a warning, for instance if you remove more time from a segment when speeding it up than the length of that segment. This is not necessarily an error, but may require attention.
 
 <figure>
   <img src="../img/scenario-warning.png" />
@@ -173,34 +95,22 @@ when speeding it up than the length of that segment. This is not necessarily an 
 </figure>
 
 # Starting a regional analysis
+The analysis interface also allows starting Regional Analyses, which involves repeating an accessibility calculation for every location in a regular grid. To start a regional analysis, first set the appropriate parameters using the controls in this view, and confirm that the isochrones and accessibility plots are as expected.
 
-The analysis interface also allows starting regional analyses, which involves computing the accessibility
-for every location in a regular grid across the region. To start a regional analysis, first set the
-appropriate parameters using the controls in this view, and confirm that the isochrones and accessibility
-plots are as expected. When you are ready, choose the "Create regional analysis" button. You can then
-enter a name for your regional analysis, and choose the bounds you want to use; by default, the entire
-project area is analyzed, but for efficiency it is also possible to analyze a smaller area. You can set
-the bounds of the analysis by dragging the pins on the map, or by selecting an existing regional analysis
-and using the same bounds. If you plan to compare two regional analyses, they must have the same bounds.
-Finally, there is a slider where you can select the percentile of travel time you wish to use for this
-analysis (for example, you might be analyzing accessibility to a class of employment that generally requires
-  workers to arrive at a particular time, and workers thus need a reliable trip where they have a
-  very high probability of arriving within the travel time budget, regardless of the exact timing of
-  their departure/arrival).
+You can also choose geographic bounds for your regional analysis. By default, the entire region is analyzed, but for efficiency it is also possible to analyze a smaller area. You can set the bounds of the analysis by dragging the pins on the map, or by selecting an existing regional analysis and using the same bounds. If you plan to compare two regional analyses, they must have the same bounds. Finally, there is a slider where you can select the percentile of travel time you wish to use for this analysis (for example, you might be analyzing accessibility to a class of employment that generally requires workers to arrive at a particular time, and workers thus need a reliable trip where they have a very high probability of arriving within the travel time budget, regardless of the exact timing of their departure/arrival).
+
+When you have configured all of these options, click "New regional analysis" at the top of the panel and enter a name.
 
 <figure>
   <img src="../img/create-regional-analysis.png" />
   <figcaption>Creating a regional analysis</figcaption>
 </figure>
 
-After a few seconds, you will see your regional analysis appear in the list with a progress bar. Since
-we are computing the accessibility for every origin in the city, it can take a significant amount of time
-for all of the number-crunching to occur.
+After a few seconds, you will see your regional analysis appear in the list with a progress bar. Since we are computing the accessibility for every origin in the city, it can take a significant amount of time for all of the number-crunching to occur.
 
 <figure>
   <img src="../img/regional-progress.png" />
   <figcaption>Displaying the progress of a regional analysis</figcaption>
 </figure>
 
-Once a regional analysis is complete, it can be viewed by clicking the right arrow next to its name,
-which will take you to the [regional analysis view](/analysis/regional).
+Once a regional analysis is complete, it can be viewed by clicking the right arrow next to its name, which will take you to the [regional analysis view](/analysis/regional).

--- a/docs/analysis/methodology.md
+++ b/docs/analysis/methodology.md
@@ -1,25 +1,9 @@
-This is a summary of the methodology used in Conveyal Analysis. For a more complete treatment of the
-subject, please see
+This is a summary of the accessibility indicators used in Conveyal Analysis. For more details, please see Conway, Matthew Wigginton, Andrew Byrd, and Marco van der Linden (2017). “[Evidence-Based Transit and Land Use Sketch Planning Using Interactive Accessibility Methods on Combined Schedule and Headway-Based Networks](http://trrjournalonline.trb.org/doi/abs/10.3141/2653-06)”
 
-Conway, Matthew Wigginton, Andrew Byrd, and Marco van der Linden. “Evidence-Based Transit and Land Use Sketch Planning Using Interactive Accessibility Methods on Combined Schedule and Headway-Based Networks.” _Transportation Research Record_ 2653 (2017). doi:10.3141/2653-06.
+Our method to compute accessibility works by exhaustively planning trips from an origin to all destinations in the analysis area. Those destinations are cells of a fine regular grid. We project all uploaded opportunity data into this grid. When we plan trips to each cell, we then simply sum the opportunity values of all cells that are within the travel time threshold.
 
-Our method to compute accessibility works by exhaustively planning trips from an origin to all destinations
-in the analysis area. Those destinations are cells of a fine regular grid. We project all uploaded
-opportunity data into this grid. When we plan trips to each cell, we then simply sum the opportunity
-values of all cells that are within the travel time threshold.
+However, you may recall that we don't compute a single travel time but rather look at the travel time over a time window. To do this, we compute the travel times for a trip departing at each minute within the time window (for example 7:00, 7:01, 7:02...8:59 for a 7:00–9:00 time window). We then compute different percentiles of travel time (e.g. the median) to each location in the region, and sum the number of opportunities at locations with a median travel time less than the user-specified travel time cutoff.
 
-However, you may recall that we don't compute a single travel time but rather look at the travel time
-over a time window. To do this, we compute the travel times for a trip departing at each minute within
-the time window (for example 7:00, 7:01, 7:02&nbsp;.&nbsp;.&nbsp;.&nbsp;8:59 for a 7:00–9:00 time window).
-We then compute the median, or other percentile, travel time to each location in the region, and sum the number of opportunities
-at locations with a median travel time less than the travel time budget.
+We use the median or percentile travel time, rather than the mean, because it can handle travel times that are infinite or undefined (for example, because the only route to a particular destination uses a bus that stops running before the end of the time window).
 
-We use the median or percentile travel time, rather than the mean as was used in Conveyal's previous
-Transport Analyst project, because it can handle travel times that are infinite or undefined (for example,
-because the only route to a particular destination uses a bus that stops running before the end of the
-time window).
-
-Others simply calculate the accessibility at each departure
-time and taking a mean of accessibility as is done by the University of Minnesota
-[Accessibility Observatory](http://ao.umn.edu/). Conveyal Analysis does not do this because the
-travel time to each opportunity should be treated independently. Consider a situation of a small town situated between two major cities each with 500,000 jobs, with hourly train service to each city. Suppose that we’re interested in the number of jobs reachable in one hour, given departure during a time window of 8:00 to 9:00 AM. Further suppose that, due to how the train schedules are written, it is possible to commute to all jobs in the first city in under an hour if you leave between 8:00 and 8:15, and all the jobs in the second city are accessible if you leave between 8:30 and 8:45, and at other times no jobs are accessible. This corresponds to hourly trains to each city, leaving at 8:15 in one direction and 8:45 in the other, and needing 45 minutes to travel to the respective city. Using the average of accessibility, this location would have an accessibility of 250,000, because ¼ of the time 500,000 jobs are accessible in the first city, ¼ of the time 500,000 jobs are accessible in the second city, and ½ of the time no jobs are accessible. Thus the accessibility value would be 250,000 even though there is no job that can be reached in an average travel time of less than 60 minutes.
+Others  calculate the accessibility at each departure time and taking a mean of accessibility as is done by the University of Minnesota [Accessibility Observatory](http://ao.umn.edu/). Conveyal Analysis does not use this approach because the travel time to each opportunity should be treated independently. Consider a situation of a small town situated between two major cities each with 500,000 jobs, with hourly train service to each city. Suppose that we’re interested in the number of jobs reachable in one hour, given departure during a time window of 8:00 to 9:00 AM. Further suppose that, due to how the train schedules are written, it is possible to commute to all jobs in the first city in under an hour if you leave between 8:00 and 8:15, and all the jobs in the second city are accessible if you leave between 8:30 and 8:45, and at other times no jobs are accessible. This corresponds to hourly trains to each city, leaving at 8:15 in one direction and 8:45 in the other, and needing 45 minutes to travel to the respective city. Using the average of accessibility, this location would have an accessibility of 250,000, because ¼ of the time 500,000 jobs are accessible in the first city, ¼ of the time 500,000 jobs are accessible in the second city, and ½ of the time no jobs are accessible. Thus the accessibility value would be 250,000 even though there is no job that can be reached in an average travel time of less than 60 minutes.

--- a/docs/analysis/regional.md
+++ b/docs/analysis/regional.md
@@ -1,27 +1,15 @@
 # Regional analysis
 
-After a regional analysis has completed, you can access it by selecting it from the main analysis screen.
-Upon selecting a regional analysis, you will see a screen like the following:
+After a regional analysis has completed, you can access it by selecting it in the Regional Analysis view. Upon selecting a regional analysis, you will see a screen like the following:
 
 <figure>
   <img src="../../img/regional.png" />
   <figcaption>Viewing a regional analysis</figcaption>
 </figure>
 
-The map shows the average accessibility experienced at each location, with the legend to the left.
-This is the number of opportunities reachable from each location within the travel time budget
-used to create the analysis. You can view the parameters used to create this regional analysis by
-clicking on the "&lt;title of regional analysis&gt; settings" button below the legend to unfold the settings
-used for the analysis. You can also export a regional analysis to GIS in GeoTIFF format in order to create
-publication-quality maps using the download link.
+The map shows the average accessibility experienced at each location, with the legend to the left. This is the number of opportunities reachable from each location within the travel time cutoff specified when creating the regional analysis. You can view the parameters used to create this regional analysis by clicking on the "&lt;title of regional analysis&gt; settings" button below the legend to unfold the settings used for the analysis. You can also export a regional analysis to GIS in GeoTIFF format in order to create publication-quality maps using the download link.
 
-Clicking anywhere on the map will display the
-sampling distribution of the accessibility indicator at that location. This distribution represents
-how much random variation there could be in the indicator and how much it might vary if the analysis
-were run again. For instance, in the image below, the estimate of accessibility is 650,000, but if the
-analysis were re-run, we might be just as likely to get a value of 550,000 or 600,000, due to uncertainty
-due not knowing how the newly-added, frequency-based transit line here will eventually be scheduled.
-This is computed using a kernel density estimate from the distribution computed by the analysis backend.
+Clicking anywhere on the map will display the sampling distribution of the accessibility indicator at that location. This distribution represents how much random variation there could be in the indicator and how much it might vary if the analysis were run again. For instance, in the image below, the estimate of accessibility is 650,000, but if the analysis were re-run, we might be just as likely to get a value of 550,000 or 600,000, due to uncertainty due not knowing how the newly-added, frequency-based transit line here will eventually be scheduled. This is computed using a kernel density estimate from the distribution computed by the analysis backend.
 
 <figure>
   <img src="../../img/sampling-distribution.png" />
@@ -30,45 +18,17 @@ This is computed using a kernel density estimate from the distribution computed 
 
 # Comparing regional analyses
 
-You can also compare two regional analyses from different scenarios in the same project by selecting
-a comparison scenario. The map will show the differences in accessibility between the two analyses,
-with blue areas showing increased accessibility, and red areas showing decreased accessibility,
-relative to the comparison analysis.
+You can also compare two regional analyses from different projects in the same region. The map will show the differences in accessibility between the two analyses, with blue areas showing increased accessibility, and red areas showing decreased accessibility, relative to the comparison analysis.
 
-You can also filter the displayed locations by the probability of change using the slider. When there are trips that
-have headways rather than explicit timetables, the exact performance of the network, particularly the
-transfer timing, is not known, and thus there is random variation in the results. In order to account for
-this variation, we use a Monte Carlo approach of generating random timetables that meet the constraints
-of the scenario. Thus, there is random variation in the accessibility numbers. We use a
-statistical bootstrapping technique to estimate this variation and produce a _p_-value that a change
-at a particular origin is due to the scenario, rather than simply random variation. We can use that _p_-value
-to determine which changes are statistically significant. For instance, if
-the slider is set at 0.98, only changes that we are 98% sure are not due to random variation will be shown.
-The analyst should note that, given the large number of cells in a regional analysis, it is likely
-that a small number of cells may show as having a 98% probability of change even when there is in fact no change.
-Generally, changes that are in fact due to the scenario rather than due to random variation will appear
-geographically clustered.
+You can also filter the displayed locations by the probability of change using the slider. When there are trips that have headways rather than explicit timetables, the exact performance of the network, particularly the transfer timing, is not known, and thus there is random variation in the results. In order to account for this variation, we use a Monte Carlo approach of generating random timetables that meet the constraints of the scenario. Thus, there is random variation in the accessibility numbers. We use a statistical bootstrapping technique to estimate this variation and produce a _p_-value that a change at a particular origin is due to the scenario, rather than simply random variation. We can use that _p_-value to determine which changes are statistically significant. For instance, if the slider is set at 0.98, only changes that we are 98% sure are not due to random variation will be shown. Note that, given the large number of cells in a regional analysis, it is likely that a small number of cells may show as having a 98% probability of change even when there is in fact no change. Generally, changes that are in fact due to the scenario rather than due to random variation will appear geographically clustered.
 
 For more information, see the [methodology](/analysis/methodology) page.
 
 # Measuring aggregate accessibility
+These regional analyses present a wealth of information, and maps of regional accessibility are frequently the best way to communicate the accessibility impacts of a transit plan. However, in some cases there is a need to summarize accessibility in a single metric for the purposes of setting measurable goals in planning practice. Conveyal Analysis allows aggregating the results of a regional analysis to a larger area, for example a neighborhood, city or region. The result of this aggregation is a histogram of the accessibility experienced by residents of the aggregation area, as well as quantiles
+of the level of accessibility experienced by the population (e.g. 80% of residents have access to at least 500,000 jobs within a 45 minute transit commute). This latter metric can be used a single number to set goals in transportation planning.
 
-These regional analyses present a wealth of information, and maps of regional accessibility are
-frequently the best way to communicate the accessibility impacts of a transit plan. However, in some
-cases there is a need to summarize accessibility in a single metric for the purposes of setting measurable
-goals in planning practice. Conveyal Analysis allows aggregating the results of a regional analysis
-to a larger area, for example a neighborhood, city or region. The result of this aggregation is a
-histogram of the accessibility experienced by residents of the aggregation area, as well as quantiles
-of the level of accessibility experienced by the population (e.g. 80% of residents have access to at least
-  500,000 jobs within a 45 minute transit commute). This latter metric can be used a single number
-  to set goals in transportation planning.
-
-In order to accomplish this aggregation, you first need to choose a region, code it as a polygon Shapefile,
-and upload it to Conveyal Analysis. The choice of region can have a significant impact on the final
-metric. If a very large region is chosen, where much of the region does not have transit service,
-there will be a large number of people with very low job access via transit, deflating the aggregate
-numbers. Conversely, if a small region is chosen, segments of the population that should be served by
-transit will be excluded from the aggregate metrics.
+In order to accomplish this aggregation, you first need to choose a region and code it as a polygon Shapefile. The choice of region can have a significant impact on the final metric. If a very large region is chosen, where much of the region does not have transit service, there will be a large number of people with very low job access via transit, deflating the aggregate numbers. Conversely, if a small region is chosen, segments of the population that should be served by transit will be excluded from the aggregate metrics.
 
 Once you have created a Shapefile of your aggregation area, you need to upload it to Conveyal Analysis.
 This can be done within the regional analysis view by selecting "Upload new aggregation area" under
@@ -79,47 +39,20 @@ the "Aggregate to" heading:
   <figcaption>Uploading an aggregation area</figcaption>
 </figure>
 
-You can then name your aggregation area and select the files to upload. Be sure to select all components
-of the Shapefile (i.e. .shp, .dbf, .shx, .prj, etc.). It may take some time to upload the files and process
-them, depending on their size and complexity. If there are multiple polygons in the input file, they
-will be merged into a single aggregation area.
+You can then name your aggregation area and select the files to upload. Be sure to select all components of the Shapefile (i.e. .shp, .dbf, .shx, .prj, etc.). It may take some time to upload the files and process them, depending on their size and complexity. If there are multiple polygons in the input file, they will be merged into a single aggregation area.
 
-Once the aggregation area is uploaded, you can perform the aggregation. You will select the area you
-want to aggregate to, as well as what you want to weight by. For example, if you select "Workers total,""
-your histogram will represent how many workers experience different levels of accessibility. If instead you
-select "Workers with earnings $1250 per month or less," you will see how accessibility is distributed
-among low income workers. Any opportunity dataset you have uploaded is available for use as weights.
+Once the aggregation area is uploaded, you can perform the aggregation. You will select the area you want to aggregate to, as well as what you want to weight by. For example, if you select "Workers total,"" your histogram will represent how many workers experience different levels of accessibility. If instead you select "Workers with earnings $1250 per month or less," you will see how accessibility is distributed among low income workers. Any opportunity dataset you have uploaded is available for use as weights.
 
-Once you have an aggregation area and weight selected, you will see a display similar to this, showing
-a histogram of how many of the units you weighted by experience a particular level of access.
+Once you have an aggregation area and weight selected, you will see a display similar to this, showing a histogram of how many of the units you weighted by experience a particular level of access.
 
 <figure>
   <img src="../../img/aggregate-accessibility.png" />
   <figcaption>Aggregate accessibility in Brooklyn, New York, USA</figcaption>
 </figure>
 
-The plot is a histogram of the number jobs accessible within the full opportunity dataset (not just Brooklyn)
-for workers residing in Brooklyn (since this is a regional
-  analysis of access to jobs, aggregated to Brooklyn, and weighted by workers). We can see that the
-  distribution is bimodal. There are a large number of workers with relatively lower accessibility values (the left peak),
-  most likely residing in outer Brooklyn further from the subway and from job centers . There are also
-  a number of workers with a higher level of accessibility, probably those residing in downtown Brooklyn
-  and near Manhattan. This plot is conceptually similar to academic work on accessibility by population
-  percentile (e.g. [Grengs et al. 2010](http://journals.sagepub.com/doi/10.1177/0739456X10363278)).
+The plot is a histogram of the number jobs accessible within the full opportunity dataset (not just Brooklyn) for workers residing in Brooklyn (since this is a regional analysis of access to jobs, aggregated to Brooklyn, and weighted by workers). We can see that the distribution is bimodal. There are a large number of workers with relatively lower accessibility values (the left peak),  most likely residing in outer Brooklyn further from the subway and from job centers . There are also  a number of workers with a higher level of accessibility, probably those residing in downtown Brooklyn  and near Manhattan. This plot is conceptually similar to academic work on accessibility by population percentile (e.g. [Grengs et al. 2010](http://journals.sagepub.com/doi/10.1177/0739456X10363278)).
 
-Below the histogram is a readout of the metric mentioned above: how many opportunities are accessible
-to a certain quantile of the population; in this case, 90% of workers residing in Brooklyn have access
-to more than 267,000 jobs. You can adjust the percentile by dragging the slider. The area of the histogram
-above the cutoff is highlighted. By setting it below 100%, you are effectively choosing what percentage
-of your region it is not practical to serve with transit, and not penalizing transit accessibility metrics
-for the lack of access in those areas.
+Below the histogram is a readout of the metric mentioned above: how many opportunities are accessible to a certain quantile of the population; in this case, 90% of workers residing in Brooklyn have access to more than 267,000 jobs. You can adjust the percentile by dragging the slider. The area of the histogram above the cutoff is highlighted. By setting it below 100%, you are effectively choosing what percentage
+of your region it is not practical to serve with transit, and not penalizing transit accessibility metrics for the lack of access in those areas.
 
-The last metric is the weighted mean accessibility. This is a popular metric, and one used by Conveyal
-in the past. This represents the average accessibility experienced by all residents (or whatever unit
-  you have weighted by) in the aggregation area. However, since it uses the mean, it is strongly affected
-  by outliers, and is not representative of the full range of accessibility experienced. In the Brooklyn
-  case, it falls between the two peaks, and does not reflect that many people have accessibility below that.
-  Since aggregate accessibility frequently has a long right tail, with many residents with low to
-  medium accessibility and few with very high accessibility, the mean is often higher than the accessibility
-  experienced by a majority of the population. For these reasons, we do not recommend the use of this
-  metric in new projects.
+The last metric is the weighted mean accessibility. This is a popular metric, and one used by Conveyal in the past. This represents the average accessibility experienced by all residents (or whatever unit you have weighted by) in the aggregation area. However, since it uses the mean, it is strongly affected  by outliers, and is not representative of the full range of accessibility experienced. In the Brooklyn case, it falls between the two peaks, and does not reflect that many people have accessibility below that. Since aggregate accessibility frequently has a long right tail, with many residents with low to medium accessibility and few with very high accessibility, the mean is often higher than the accessibility experienced by a majority of the population. For these reasons, we do not recommend the use of this metric.

--- a/docs/analysis/upload-opportunity-data.md
+++ b/docs/analysis/upload-opportunity-data.md
@@ -1,20 +1,13 @@
-In the United States, we automatically populate opportunity data from [LODES](https://lehd.ces.census.gov/data/#lodes),
-which contains location information about jobs and worker residences. If you wish to compute accessibility
-using other information, or if you are outside the US, you will need to upload opportunity data. You can
-do this by selecting the "Opportunity Datasets" <i class="fa fa-th"></i> button on the sidebar.
+In the United States, we automatically populate opportunity data from [LODES](https://lehd.ces.census.gov/data/#lodes), which contains location information about jobs and worker residences. If you wish to compute accessibility using other information, or if you are outside the US, you will need to upload opportunity data. You can do this by selecting the "Opportunity Datasets" <i class="fa fa-th"></i> button on the sidebar.
 
-If you are uploading a shapefile, it should not be zipped. Select all of the files in the Shapefile
-when uploading (at the very least, `.shp`, `.shx`, `.dbf` and `.prj`). How you select multiple files
-depends on your browser and operating system, but generally will involve shift-clicking,
-control-clicking or command-clicking.
+If you are uploading a shapefile, it should not be zipped. Select all of the files in the Shapefile when uploading (at the very least, `.shp`, `.shx`, `.dbf` and `.prj`). How you select multiple files depends on your browser and operating system, but generally will involve shift-clicking, control-clicking or command-clicking.
 
 <figure>
   <img src="../../img/upload-shapefile.png" />
   <figcaption>Uploading a Shapefile by selecting all constituent files</figcaption>
 </figure>
 
-If you upload a CSV file, two extra fields will appear, in which you must type the field names of the
-latitude and longitude fields (we currently only support CSV files in WGS 84 Latitude/Longitude coordinates).
+If you upload a CSV file, two extra fields will appear, in which you must type the field names of the latitude and longitude fields (we currently only support CSV files in WGS 84 Latitude/Longitude coordinates).
 
 <figure>
   <img src="../../img/upload-csv.png" />

--- a/docs/edit-scenario.md
+++ b/docs/edit-scenario.md
@@ -4,19 +4,16 @@ Transport scenarios in Scenario Editor are made up of a series of modifications 
 are strung together, they represent a new state of the transport system in a region. This page describes the available modification
 types; each type also has an individual page describing the specifics of how to use it.
 
-After uploading a bundle and creating a project, you will arrive at the screen below, where you can
-create a scenario, which is a set of changes to a particular transportation network specified by choosing
-a bundle.
+After uploading a bundle and creating a project, you will arrive at the screen below, where you can create different scenarios that may represent
 
 <figure>
   <img src="../img/create-scenario.png" />
   <figcaption>Creating a new scenario</figcaption>
 </figure>
 
-A transport scenario is made up of many modifications, each of which represents a single operation on the transit network (for example adding a line, or adjusting
+A transport scenario is made up of many modifications, each of which represents a single operation on the baseline transit network (for example adding a line, or adjusting
 the speed of an existing line). All modifications are listed in the left-hand bar. Each modification has an eye icon next to it, which controls whether it is currently
-displayed on the map. Clicking on the title of a modification will open it and allow you to edit it. To create a new modification of a particular type,
-click the "Create" button next to the name of that modification type.
+displayed on the map. Clicking on the title of a modification will open it and allow you to edit it.
 
 You can return to the Edit Scenario page by clicking on the pencil icon in the sidebar.
 
@@ -25,18 +22,17 @@ You can return to the Edit Scenario page by clicking on the pencil icon in the s
   <figcaption>Editing a scenario</figcaption>
 </figure>
 
-Oftentimes, there will be several scenarios that are very similar, differing only in a few minor aspects. In particular, one scenario is often
-a superset of another (for instance, there is a base scenario which involves building six new rail lines, and another scenario which additionally
-involves building four more). Instead of having to code each scenario separately, we support the concept of scenario variants. You can create variants
-by clicking the "Create" button under "Variants," and entering a name for each variant. The buttons to the right of a variant name allow, respectively, exporting the
-variant to Transport Analyst, viewing a printer-friendly summary of the modifications in the variant, and showing the variant on the map.
+Oftentimes, there will be several project alternatives that are very similar, differing only in a few minor aspects. In particular, one project is often
+a superset of another (for instance, there is a project which involves building six new rail lines, and another alternative which additionally
+involves building four more). Instead of having to code modifications multiple times for each alternative, you can activate modifications in different scenarios. You can create scenarios
+by clicking the "Create" button to the right of "Scenarios" and entering a name. The buttons at the right of the list of scenarios allow renaming the scenarios and showing or hiding them on a map.
+
+Scenarios can be exported as .json by clicking the download icon next to modifications, or in a printer-friendly format by clicking the printer icon.
 
 <figure>
   <img src="../img/variant-editor.png" />
   <figcaption>Editing the variants of a scenario</figcaption>
 </figure>
-
-Within each modification you can then choose which variants it is active in:
 
 <figure>
   <img src="../img/variant-chooser.png" />

--- a/docs/edit-scenario.md
+++ b/docs/edit-scenario.md
@@ -1,31 +1,22 @@
 # Editing transport scenarios
 
-Transport scenarios in Scenario Editor are made up of a series of modifications of various types. When all the modifications
-are strung together, they represent a new state of the transport system in a region. This page describes the available modification
-types; each type also has an individual page describing the specifics of how to use it.
+Transport scenarios in Conveyal Analysis are made up of a series of modifications of various types. When all the modifications are strung together, they represent a new state of the transport system in a region. This page describes the available modification types; each type also has an individual page describing the specifics of how to use it.
 
-After uploading a bundle and creating a project, you will arrive at the screen below, where you can create different scenarios that may represent
+After uploading a GTFS Bundle and creating a project, you will arrive at the screen below, where you can manage scenarios and modifications.
 
 <figure>
   <img src="../img/create-scenario.png" />
   <figcaption>Creating a new scenario</figcaption>
 </figure>
 
-A transport scenario is made up of many modifications, each of which represents a single operation on the baseline transit network (for example adding a line, or adjusting
-the speed of an existing line). All modifications are listed in the left-hand bar. Each modification has an eye icon next to it, which controls whether it is currently
-displayed on the map. Clicking on the title of a modification will open it and allow you to edit it.
+You can create scenarios by clicking the "Create" button to the right of "Scenarios" and entering a name. The buttons at the right of the list of scenarios allow renaming the scenarios and showing or hiding them on a map.
 
-You can return to the Edit Scenario page by clicking on the pencil icon in the sidebar.
+A transport scenario is made up of many modifications, each of which represents a single operation on the baseline transit network (for example adding a line, or adjusting the speed of an existing line). All modifications are listed in the left panel. Each modification has an eye icon next to it, which controls whether it is currently displayed on the map. Clicking on the title of a modification will open it and allow you to edit it.  On the detail panel for each modification, you can choose the scenarios in which it will be active.
 
 <figure>
   <img src="../img/edit-scenario.png" />
   <figcaption>Editing a scenario</figcaption>
 </figure>
-
-Oftentimes, there will be several project alternatives that are very similar, differing only in a few minor aspects. In particular, one project is often
-a superset of another (for instance, there is a project which involves building six new rail lines, and another alternative which additionally
-involves building four more). Instead of having to code modifications multiple times for each alternative, you can activate modifications in different scenarios. You can create scenarios
-by clicking the "Create" button to the right of "Scenarios" and entering a name. The buttons at the right of the list of scenarios allow renaming the scenarios and showing or hiding them on a map.
 
 Scenarios can be exported as .json by clicking the download icon next to modifications, or in a printer-friendly format by clicking the printer icon.
 
@@ -51,21 +42,15 @@ Scenarios can be exported as .json by clicking the download icon next to modific
 
 ## Importing modifications from another scenario
 
-Occasionally, you may want to copy all of the modifications from one scenario into another. This may
-be useful to make a copy of a scenario, or to combine scenarios developed by different team members
-into a single scenario (for instance, one team member working on rail changes and another on bus changes).
-To do this, click the arrow icon to the right of the scenario name <i class="fa fa-upload"></i>.
+Occasionally, you may want to copy all of the modifications from one project into another. This may be useful to make a copy of a project, or to combine modifications developed by different team members into a single project (for instance, one team member working on rail changes and another on bus changes).
+To do this, click the arrow icon to the right of the project name <i class="fa fa-upload"></i>.
 
 <figure>
   <img src="../img/select-import-modifications.png" />
   <figcaption>Selecting that you want to import modifications from another scenario.</figcaption>
 </figure>
 
-You can then
-choose the scenario you wish to import modifications from. Only scenarios which use the same bundle
-(base GTFS data) will be available. All modifications will be imported; when there are multiple variants,
-the variants in the scenario being imported will be mapped directly to the variants in the scenario being
-imported to (i.e. modifications in the first variant will remain in the first variant in the new scenario).
+You can then choose the project from which to import modifications. Only projects which use the same GTFS bundle will be available. All modifications will be imported; when there are multiple scenarios, the scenarios in the project being imported will be mapped directly to the scenarios in the receiving project (i.e. modifications in the first scenario will remain in the first scenario in the new project).
 
 <figure>
   <img src="../img/import-modifications.png" />
@@ -74,12 +59,7 @@ imported to (i.e. modifications in the first variant will remain in the first va
 
 ## Importing modifications from Shapefiles
 
-In general, it is best to create all modifications directly in this editing tool as it allows full control
-over all aspects of transit network design. However, on occasion, it may be desirable to import modifications
-from a GIS shapefile. If you have a Shapefile containing lines, you can upload it to Conveyal Analysis
-and have it turned into a set of Add Trips modifications. You first need to zip the components of the
-shapefile, then you can select the "Import shapefile" <i class="fa fa-globe"></i> button to the right
-of the scenario name.
+In general, it is best to create all modifications directly in this editing tool as it allows full control over all aspects of transit network design. However, on occasion, it may be desirable to import modifications from a GIS shapefile. If you have a Shapefile containing lines, you can upload it to Conveyal Analysis and have it turned into a set of Add Trips modifications. You first need to zip the components of the shapefile, then you can select the "Import shapefile" <i class="fa fa-globe"></i> button to the right of the scenario name.
 
 <figure>
   <img src="../img/select-import-modifications-from-shapefile.png" />
@@ -93,9 +73,4 @@ Once you have entered the Import Shapefile view and selected a zipped Shapefile,
   <figcaption>Importing modifications from a Shapefile</figcaption>
 </figure>
 
-There are several fields that must be filled in. The name of each modification is set from an attribute in the
-Shapefile; the attribute used may be selected here. Additional, the speed (in km/h) and frequency (in minutes)
-should be attributes in the Shapefile. Finally, since Shapefiles only contain the route geometry and
-not the stop locations, stops will be created automatically. The stop spacing should be specified.
-The generated stop positions may be individually edited after import, for example to place a stop at
-a major transfer point.
+There are several fields that must be filled in. The name of each modification is set from an attribute in the Shapefile; the attribute used may be selected here. Additional, the speed (in km/h) and frequency (in minutes) should be attributes in the Shapefile. Finally, since Shapefiles only contain the route geometry and not the stop locations, stops will be created automatically. The stop spacing should be specified. The generated stop positions may be individually edited after import, for example to place a stop at a major transfer point.

--- a/docs/export.md
+++ b/docs/export.md
@@ -1,12 +1,5 @@
 # Exporting to Transport Analyst
 
-Once you have finished your scenario, you can export it to Transport Analyst in order to perform accessibility analyses. To export a variant, click on the
-download icon next to it:
+Once you have finished your scenario, you can export it as a .json file.
 
-<img src="../img/export.png" alt="Export to transport analyst" />
-
-Your browser will download a JSON file, which can be imported into Transport Analyst. To use the scenario in Transport Analyst, first upload the same GTFS
-you used in scenario editor (if you had more than one, you can ZIP them together for upload to Analyst), and then select Data -> Transport Scenarios, click New,
-select the bundle you just created in Analyst, and upload the scenario JSON file you got from Scenario Editor. The scenario will then be available in Analyst.
-
-<img src="../img/import-analyst.png" alt="importing a scenario into Analyst" />
+<img src="../img/export.png" alt="Export as JSON" />

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,5 @@
 # Conveyal Analysis
 
-This is [Conveyal](http://conveyal.com)'s tool for creating, editing and analyzing future public transport scenarios.
+This is [Conveyal](http://conveyal.com)'s tool for creating, editing and analyzing public transport scenarios.
 
-To use it, you'll first have to [prepare data inputs](prepare-inputs). Once you've done that, you can [create your scenario](edit-scenario).
-Finally, you can use your scenario in [accessibility analysis](analysis), or export a [report](report) summarizing all the modifications
-you have made.
+To use it, you'll first have to [prepare data inputs](prepare-inputs). Once you've done that, you can [create your scenario](edit-scenario). Finally, you can use your scenario in [accessibility analysis](analysis), or export a [report](report) summarizing all the modifications you have made.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: scenario-editor
-site_url: https://scenario-editor.readthedocs.org
-repo_url: https://github.com/conveyal/scenario-editor
+site_url: http://docs.analysis.conveyal.com
+repo_url: https://github.com/conveyal/analysis-ui
 site_dir: ../target/mkdocs
 docs_dir: ../docs
 theme: readthedocs

--- a/docs/modifications/add-trips.md
+++ b/docs/modifications/add-trips.md
@@ -23,6 +23,8 @@ segment is correct when used to calculate the travel times between stops. If you
 make the route follow the streets. This only applies to segments that are actively being edited, and will not cause already drawn segments to follow the streets,
 allowing you to draw part of a route on street and part off-street.
 
+Blue stops have been snapped to existing transit stops.  Black stops are new ones.
+
 To insert a stop into the middle of an alignment, first drag the alignment to the appropriate location, then click on the created control point and choose "make stop." You can also convert undesired stops into control points, or delete them, in this view.
 
 <img src="../../img/make-stop.png" alt="make a new stop" />

--- a/docs/prepare-inputs.md
+++ b/docs/prepare-inputs.md
@@ -1,37 +1,13 @@
 # Preparing data inputs for Scenario Editor
 
-Scenario editor uses [GTFS](https://developers.google.com/transit/gtfs/) files as its input. These files contain information
-about the existing transit service provided by an agency. Most transit agencies produce them to power customer-facing trip
-planning applications, but they are also useful for analysis. A first step is to gather GTFS files for the transit agencies whose
-service will be changing in your scenarios.
+Conveyal Analysis relies on [GTFS](https://developers.google.com/transit/gtfs/) feeds, .zip files with information about transit networks and schedules. Most transit agencies produce GTFS feeds to power customer-facing trip planning applications, but they are also useful for analysis. A first step is to gather GTFS files for the transit agencies whose service will be modified in your scenarios.
 
-In order to create scenarios that will work in Transport Analyst, it is critical that all of your feeds have [`feed_id`s](https://groups.google.com/d/msg/gtfs-changes/zVjEoNIPr_Y/4ngWCajPoS0J).
-Many agencies already include a `feed_id` in their `feed_info.txt` file, but if yours doesn't it is relatively easy to add. If there is already a `feed_info.txt`
-file in your GTFS feed, simply extract it, add the `feed_id` column, and add the modified file back to the feed. Otherwise, create a new `feed_info.txt` like so:
+Once you've gathered GTFS data, you can log into Conveyal Analysis.
 
-    feed_id
-    <feed_id>
+First, set up a new region by clicking on the green button, or go to an existing region for which you already have projects.
 
-of course replacing the second line with the `feed_id` you'd like to use, which should be a short, unique string which contains no colons. Zip this file into the feed.
+When setting up a new region, you specify a name as well as boundaries. Based on the specified boundaries, population and employment data will be automatically downloaded (for US cities) from the Census Bureau's LEHD LODES, and road network data will be automatically downloaded from OpenStreetMap. It is also possible to upload custom OpenStreetMap in this view.
 
-Once you've gathered GTFS data, you can log into scenario editor.
+After the shared settings for a region are configured, you can upload the GTFS feeds you prepared above. Select "Create a new Project." Here you can create projects based on a bundle of GTFS feeds uploaded for your region. Since you have not yet uploaded any GTFS, choose "Create a bundle." Note that, if you have multiple GTFS feeds, you can upload all of them at once (just make sure you have added unique feed IDs to all of them). Click "Create a bundle" to upload your feeds. "Uploading..." will appear; it may take several minutes to upload the bundle. Once it's complete, you will be returned to the "Create a Project" page, where you can select the bundle you just uploaded and give your project a name, and then click "Create new Project."
 
-First, you will select an existing project, or create one using the "create a new project" button:
-
-<img src="../img/select-project.png" alt="selecting a project in scenario editor" />
-
-When creating a new project, you specify a name as well as geographic bounds, which will in the future be used to fetch appropriate OpenStreetMap
-and Census data. When done, click "Save Project." It is also possible to upload custom OpenStreetMap
-in this view.
-
-<img src="../img/create-project.png" alt="creating a new project in scenario editor" />
-
-Once you have done that, you can upload your GTFS to the project. Select "Create a new Scenario." Here you can create scenarios based on the
-GTFS feeds uploaded to your project. Since you have not yet uploaded any GTFS, choose "Create a bundle." You can give your bundle a name and upload your GTFS.
-Note that, if you have multiple GTFS feeds, you can upload all of them at once (just make sure you have added unique feed IDs to all of them). Click "Create a bundle" to
-upload your feeds. "Uploading..." will appear; it may take several minutes to upload the bundle. Once it's complete, you will be returned to the "Create a Scenario" page, where
-you can select the bundle you just uploaded and give your scenario a name, and then click "Create new Scenario."
-
-<img src="../img/create-bundle.png" alt="creating a new bundle" />
-
-You are now ready to move on to <a href="/edit-scenario/">editing your scenario</a>
+You are now ready to move on to <a href="/edit-scenario/">editing your scenarios</a>

--- a/docs/report.md
+++ b/docs/report.md
@@ -1,7 +1,4 @@
-You can generate a report summarizing all of the modifications you have made to a network, for printing
-or reference. To access the report, click on the printer icon next to the name of a variant, and all
-of the modifications in that variant will be displayed. Keep in mind that some browsers may not print
-more than 30 pages or so of a very long report.
+You can generate a report summarizing all of the modifications you have made to a network, for printing or reference. To access the report, click on the printer icon next to the name of a project, then you will be able to choose which scenario to export. Keep in mind that some browsers may not print more than 30 pages or so of a very long report.
 
 <figure>
   <img src="../img/select-report.png" />

--- a/lib/__tests__/__snapshots__/routes.js.snap
+++ b/lib/__tests__/__snapshots__/routes.js.snap
@@ -1100,7 +1100,7 @@ exports[`Routes should render 1`] = `
                     className="Sidebar-logo"
                     onlyActiveOnIndex={false}
                     style={Object {}}
-                    title="Projects"
+                    title="Regions"
                     to="/"
                   >
                     <a
@@ -1108,7 +1108,7 @@ exports[`Routes should render 1`] = `
                       href="/"
                       onClick={[Function]}
                       style={Object {}}
-                      title="Projects"
+                      title="Regions"
                     />
                   </Link>
                   <div>
@@ -1120,7 +1120,7 @@ exports[`Routes should render 1`] = `
                       }
                       href="/projects/1"
                       icon="cubes"
-                      text="Project Scenarios"
+                      text="Projects"
                     >
                       <div
                         className="Sidebar-navItem active"
@@ -1141,7 +1141,7 @@ exports[`Routes should render 1`] = `
                           >
                             <ItemContents
                               icon="cubes"
-                              text="Project Scenarios"
+                              text="Projects"
                             >
                               <span>
                                 <Icon
@@ -1155,7 +1155,7 @@ exports[`Routes should render 1`] = `
                                   className="Sidebar-navItem-text"
                                 >
                                    
-                                  Project Scenarios
+                                  Projects
                                 </span>
                               </span>
                             </ItemContents>
@@ -1167,7 +1167,7 @@ exports[`Routes should render 1`] = `
                       active={null}
                       href="/projects/1/edit"
                       icon="gear"
-                      text="Project Settings"
+                      text="Shared Settings"
                     >
                       <div
                         className="Sidebar-navItem"
@@ -1188,7 +1188,7 @@ exports[`Routes should render 1`] = `
                           >
                             <ItemContents
                               icon="gear"
-                              text="Project Settings"
+                              text="Shared Settings"
                             >
                               <span>
                                 <Icon
@@ -1202,7 +1202,7 @@ exports[`Routes should render 1`] = `
                                   className="Sidebar-navItem-text"
                                 >
                                    
-                                  Project Settings
+                                  Shared Settings
                                 </span>
                               </span>
                             </ItemContents>
@@ -1310,7 +1310,7 @@ exports[`Routes should render 1`] = `
                       active={null}
                       href="/scenarios/1"
                       icon="pencil"
-                      text="Edit Scenario"
+                      text="Edit Scenarios"
                     >
                       <div
                         className="Sidebar-navItem"
@@ -1331,7 +1331,7 @@ exports[`Routes should render 1`] = `
                           >
                             <ItemContents
                               icon="pencil"
-                              text="Edit Scenario"
+                              text="Edit Scenarios"
                             >
                               <span>
                                 <Icon
@@ -1345,7 +1345,7 @@ exports[`Routes should render 1`] = `
                                   className="Sidebar-navItem-text"
                                 >
                                    
-                                  Edit Scenario
+                                  Edit Scenarios
                                 </span>
                               </span>
                             </ItemContents>
@@ -1357,7 +1357,7 @@ exports[`Routes should render 1`] = `
                       active={null}
                       href="/scenarios/1/analysis"
                       icon="area-chart"
-                      text="Analyze Scenario"
+                      text="Analyze Scenarios"
                     >
                       <div
                         className="Sidebar-navItem"
@@ -1378,7 +1378,7 @@ exports[`Routes should render 1`] = `
                           >
                             <ItemContents
                               icon="area-chart"
-                              text="Analyze Scenario"
+                              text="Analyze Scenarios"
                             >
                               <span>
                                 <Icon
@@ -1392,7 +1392,7 @@ exports[`Routes should render 1`] = `
                                   className="Sidebar-navItem-text"
                                 >
                                    
-                                  Analyze Scenario
+                                  Analyze Scenarios
                                 </span>
                               </span>
                             </ItemContents>
@@ -2475,7 +2475,7 @@ exports[`Routes should render 1`] = `
                                     />
                                   </Icon>
                                    
-                                  Create a new Project
+                                  Set up a new region
                                 </a>
                               </Button>
                             </div>
@@ -2488,7 +2488,7 @@ exports[`Routes should render 1`] = `
                                 }
                               }
                             >
-                              or go to an existing project
+                              or go to an existing region
                             </p>
                             <div
                               className="list-group"
@@ -2497,7 +2497,7 @@ exports[`Routes should render 1`] = `
                                 className="list-group-item"
                                 onlyActiveOnIndex={false}
                                 style={Object {}}
-                                title="Go to Project"
+                                title="Go to region"
                                 to="/projects/1"
                               >
                                 <a
@@ -2505,7 +2505,7 @@ exports[`Routes should render 1`] = `
                                   href="/projects/1"
                                   onClick={[Function]}
                                   style={Object {}}
-                                  title="Go to Project"
+                                  title="Go to region"
                                 >
                                   <div>
                                     <p>

--- a/lib/components/__tests__/__snapshots__/create-grid.js.snap
+++ b/lib/components/__tests__/__snapshots__/create-grid.js.snap
@@ -7,7 +7,7 @@ exports[`Component > EditBundle renders correctly 1`] = `
   <div
     className="panel-heading clearfix "
   >
-    Upload new opportunity dataset
+    Upload a new opportunity dataset
     <a
       data-tip="Upload a .csv with lat/lon columns, or the files making up a shapefile (unzipped .shp .shx .dbf and .prj)"
     >
@@ -71,7 +71,7 @@ exports[`Component > EditBundle renders correctly 1`] = `
         className="btn btn-block btn-success"
         disabled={true}
         type="submit"
-        value="Upload new opportunity dataset"
+        value="Upload a new opportunity dataset"
       />
     </form>
   </div>
@@ -92,7 +92,7 @@ exports[`Component > EditBundle renders csv upload correctly 1`] = `
         <div
           className="panel-heading clearfix "
         >
-          Upload new opportunity dataset
+          Upload a new opportunity dataset
           <a
             data-tip="Upload a .csv with lat/lon columns, or the files making up a shapefile (unzipped .shp .shx .dbf and .prj)"
           >
@@ -299,7 +299,7 @@ exports[`Component > EditBundle renders csv upload correctly 1`] = `
               className="btn btn-block btn-success"
               disabled={true}
               type="submit"
-              value="Upload new opportunity dataset"
+              value="Upload a new opportunity dataset"
             />
           </form>
         </div>
@@ -323,7 +323,7 @@ exports[`Component > EditBundle renders shapefile upload correctly 1`] = `
         <div
           className="panel-heading clearfix "
         >
-          Upload new opportunity dataset
+          Upload a new opportunity dataset
           <a
             data-tip="Upload a .csv with lat/lon columns, or the files making up a shapefile (unzipped .shp .shx .dbf and .prj)"
           >
@@ -446,7 +446,7 @@ exports[`Component > EditBundle renders shapefile upload correctly 1`] = `
               className="btn btn-block btn-success"
               disabled={true}
               type="submit"
-              value="Upload new opportunity dataset"
+              value="Upload a new opportunity dataset"
             />
           </form>
         </div>

--- a/lib/components/__tests__/__snapshots__/edit-bundle.js.snap
+++ b/lib/components/__tests__/__snapshots__/edit-bundle.js.snap
@@ -33,7 +33,7 @@ exports[`Component > EditBundle renders correctly 1`] = `
       className="fa fa-save fa-fw "
     />
      
-    Save bundle
+    Edit bundle
   </a>
   <a
     className="btn btn-danger btn-block"

--- a/lib/components/__tests__/__snapshots__/edit-project.js.snap
+++ b/lib/components/__tests__/__snapshots__/edit-project.js.snap
@@ -219,7 +219,7 @@ exports[`Component > EditProject renders correctly 1`] = `
         className="btn btn-success btn-block"
         disabled={false}
         href="#"
-        name="Save project"
+        name="Save changes"
         onClick={[Function]}
         tabIndex={0}
       >

--- a/lib/components/__tests__/__snapshots__/edit-project.js.snap
+++ b/lib/components/__tests__/__snapshots__/edit-project.js.snap
@@ -14,16 +14,16 @@ exports[`Component > EditProject renders correctly 1`] = `
         className="form-group"
       >
         <label
-          htmlFor="project-name-input-0"
+          htmlFor="region-name-input-0"
         >
-          Project Name*
+          Region Name*
         </label>
         <input
           className="form-control"
-          id="project-name-input-0"
-          name="Project Name"
+          id="region-name-input-0"
+          name="Region Name"
           onChange={[Function]}
-          placeholder="Project Name*"
+          placeholder="Region Name*"
           type="text"
           value="Test Scenario"
         />
@@ -119,7 +119,7 @@ exports[`Component > EditProject renders correctly 1`] = `
         </div>
       </div>
       <h5>
-        OSM Bounds
+        OpenStreetMap bounds
       </h5>
       <div
         className="form-group"
@@ -219,11 +219,11 @@ exports[`Component > EditProject renders correctly 1`] = `
         className="btn btn-success btn-block"
         disabled={false}
         href="#"
-        name="Save Project"
+        name="Save project"
         onClick={[Function]}
         tabIndex={0}
       >
-        Save project
+        Save changes
       </a>
       <a
         className="btn btn-danger btn-block"
@@ -235,7 +235,7 @@ exports[`Component > EditProject renders correctly 1`] = `
           className="fa fa-trash fa-fw "
         />
          
-        DANGER: Delete this project
+        DANGER: Delete this region
       </a>
     </div>
   </div>

--- a/lib/components/__tests__/__snapshots__/edit-scenario.js.snap
+++ b/lib/components/__tests__/__snapshots__/edit-scenario.js.snap
@@ -7,9 +7,9 @@ exports[`Component > EditScenario renders correctly 1`] = `
   <div
     className="panel-heading clearfix "
   >
-    Create a new Scenario
+    Create new Project
     <a
-      data-tip="Each scenario can include variants with modifications that are applied to the same GTFS bundle."
+      data-tip="Each project can include scenarios with modifications that are applied to the same GTFS bundle."
     >
       <i
         className="fa fa-question-circle-o fa-fw fa-lg pull-right"
@@ -83,7 +83,7 @@ exports[`Component > EditScenario renders correctly 1`] = `
       onClick={[Function]}
       tabIndex={0}
     >
-      Create a new Scenario
+      Create new Project
     </a>
   </div>
 </div>

--- a/lib/components/__tests__/__snapshots__/import-modifications.js.snap
+++ b/lib/components/__tests__/__snapshots__/import-modifications.js.snap
@@ -22,7 +22,7 @@ exports[`Component > ImportModifications renders correctly 1`] = `
         <div
           className="panel-heading clearfix "
         >
-          Import modifications from another scenario
+          Import modifications from another project
         </div>
       </Heading>
       <Body>
@@ -72,7 +72,7 @@ exports[`Component > ImportModifications renders correctly 1`] = `
                 ]
               }
               pageSize={5}
-              placeholder="Select a scenario..."
+              placeholder="Select a project…"
               required={false}
               scrollMenuIntoView={true}
               searchable={true}
@@ -99,7 +99,7 @@ exports[`Component > ImportModifications renders correctly 1`] = `
                     <div
                       className="Select-placeholder"
                     >
-                      Select a scenario...
+                      Select a project…
                     </div>
                     <mockConstructor
                       aria-activedescendant="react-select-2--value"

--- a/lib/components/__tests__/__snapshots__/project.js.snap
+++ b/lib/components/__tests__/__snapshots__/project.js.snap
@@ -4,7 +4,7 @@ exports[`Component > Project renders correctly 1`] = `
 <div
   className="panel-body"
 >
-  Loading project...
+  Loading region…
 </div>
 `;
 
@@ -12,6 +12,6 @@ exports[`Component > Project renders unsupported message correctly 1`] = `
 <div
   className="panel-body"
 >
-  Loading project...
+  Loading region…
 </div>
 `;

--- a/lib/components/__tests__/__snapshots__/scenario.js.snap
+++ b/lib/components/__tests__/__snapshots__/scenario.js.snap
@@ -4,6 +4,6 @@ exports[`Component > Scenario renders correctly 1`] = `
 <div
   className="panel-body"
 >
-  Loading scenario...
+  Loading project…
 </div>
 `;

--- a/lib/components/__tests__/__snapshots__/select-project.js.snap
+++ b/lib/components/__tests__/__snapshots__/select-project.js.snap
@@ -39,7 +39,7 @@ exports[`Component > SelectProject renders correctly 1`] = `
           className="fa fa-cubes fa-fw "
         />
          
-        Create a new Project
+        Set up a new region
       </a>
     </div>
     <div>
@@ -50,7 +50,7 @@ exports[`Component > SelectProject renders correctly 1`] = `
           }
         }
       >
-        or go to an existing project
+        or go to an existing region
       </p>
       <div
         className="list-group"
@@ -59,7 +59,7 @@ exports[`Component > SelectProject renders correctly 1`] = `
           className="list-group-item"
           onClick={[Function]}
           style={Object {}}
-          title="Go to Project"
+          title="Go to region"
         >
           <div>
             <p>
@@ -76,7 +76,7 @@ exports[`Component > SelectProject renders correctly 1`] = `
           className="list-group-item"
           onClick={[Function]}
           style={Object {}}
-          title="Go to Project"
+          title="Go to region"
         >
           <div>
             <p>

--- a/lib/components/__tests__/__snapshots__/select-scenario.js.snap
+++ b/lib/components/__tests__/__snapshots__/select-scenario.js.snap
@@ -11,25 +11,25 @@ exports[`Component > SelectScenario renders correctly 1`] = `
       className="btn btn-block btn-success"
       onClick={[Function]}
       style={Object {}}
-      title="Create a new Scenario"
+      title="Create new Project"
     >
       <i
         className="fa fa-cube fa-fw "
       />
        
-      Create a new Scenario
+      Create new Project
     </a>
     <a
       className="btn btn-block btn-success"
       onClick={[Function]}
       style={Object {}}
-      title="Upload new GTFS Bundle"
+      title="Upload a new GTFS Bundle"
     >
       <i
         className="fa fa-database fa-fw "
       />
        
-      Upload new GTFS Bundle
+      Upload a new GTFS Bundle
     </a>
     <a
       className="btn btn-block btn-success"
@@ -47,20 +47,20 @@ exports[`Component > SelectScenario renders correctly 1`] = `
       className="btn btn-block btn-warning"
       onClick={[Function]}
       style={Object {}}
-      title="Configure project settings"
+      title="Configure shared settings for region"
     >
       <i
         className="fa fa-gear fa-fw "
       />
        
-      Configure project settings
+      Configure shared settings for region
     </a>
   </div>
   <div>
     <p
       className="center"
     >
-      or go to an existing scenario
+      or go to an existing project
     </p>
     <div
       className="list-group"
@@ -69,7 +69,7 @@ exports[`Component > SelectScenario renders correctly 1`] = `
         className="list-group-item"
         onClick={[Function]}
         style={Object {}}
-        title="Go to Scenario"
+        title="Go to project"
       >
         <i
           className="fa fa-cube fa-fw "
@@ -81,7 +81,7 @@ exports[`Component > SelectScenario renders correctly 1`] = `
         className="list-group-item"
         onClick={[Function]}
         style={Object {}}
-        title="Go to Scenario"
+        title="Go to project"
       >
         <i
           className="fa fa-cube fa-fw "

--- a/lib/components/__tests__/__snapshots__/variant-editor.js.snap
+++ b/lib/components/__tests__/__snapshots__/variant-editor.js.snap
@@ -8,12 +8,12 @@ exports[`Component > VariantEditor renders correctly 1`] = `
     <i
       className="fa fa-clone fa-fw "
     />
-     Variants
+    Scenarios
     <a
       className="pull-right"
       onClick={[Function]}
       tabIndex={0}
-      title="Create a new variant"
+      title="Create new scenario"
     >
       <i
         className="fa fa-plus fa-fw "
@@ -23,6 +23,8 @@ exports[`Component > VariantEditor renders correctly 1`] = `
   </div>
   <div
     className="Variants"
-  />
+  >
+    <ol />
+  </div>
 </div>
 `;

--- a/lib/components/analysis/index.js
+++ b/lib/components/analysis/index.js
@@ -322,7 +322,7 @@ export default class SinglePointAnalysis extends Pure {
               </div>}
 
             <div className='row'>
-              <Group label='Variant' className='col-xs-6'>
+              <Group label={messages.common.scenario} className='col-xs-6'>
                 <Select
                   clearable={false}
                   disabled={isFetchingIsochrone}
@@ -335,7 +335,7 @@ export default class SinglePointAnalysis extends Pure {
                 />
               </Group>
 
-              <Group label='Opportunity Data' className='col-xs-6'>
+              <Group label={messages.analysis.grid} className='col-xs-6'>
                 <Select
                   clearable={false}
                   disabled={isFetchingIsochrone}
@@ -530,7 +530,7 @@ export default class SinglePointAnalysis extends Pure {
 
     return (
       <div className='row'>
-        <Group label='Comparison scenario' className='col-xs-6'>
+        <Group label={messages.analysis.comparison + ' ' + messages.common.project} className='col-xs-6'>
           <Select
             disabled={isFetchingIsochrone}
             name={messages.common.project}
@@ -541,7 +541,7 @@ export default class SinglePointAnalysis extends Pure {
           />
         </Group>
 
-        <Group label='Comparison variant' className='col-xs-6'>
+        <Group label={messages.analysis.comparison + ' ' + messages.common.scenario} className='col-xs-6'>
           <Select
             disabled={!comparisonScenarioId}
             clearable={false}

--- a/lib/components/analysis/index.js
+++ b/lib/components/analysis/index.js
@@ -545,7 +545,7 @@ export default class SinglePointAnalysis extends Pure {
           <Select
             disabled={!comparisonScenarioId}
             clearable={false}
-            name={messages.common.variant}
+            name={messages.common.scenario}
             onChange={this.setComparisonVariant}
             options={variantOptions}
             placeholder={messages.analysis.selectComparisonScenarioVariant}

--- a/lib/components/analysis/index.js
+++ b/lib/components/analysis/index.js
@@ -533,7 +533,7 @@ export default class SinglePointAnalysis extends Pure {
         <Group label='Comparison scenario' className='col-xs-6'>
           <Select
             disabled={isFetchingIsochrone}
-            name={messages.common.scenario}
+            name={messages.common.project}
             onChange={this._setComparisonScenario}
             options={scenarioOptions}
             placeholder={messages.analysis.selectComparisonScenario}

--- a/lib/components/edit-project.js
+++ b/lib/components/edit-project.js
@@ -219,7 +219,7 @@ export default class EditProject extends Component<void, Props, State> {
         <Panel>
           <Body>
             <Text
-              label={messages.region.name+"*"}
+              label={messages.region.name + '*'}
               name={messages.region.name}
               onChange={this.onChangeName}
               value={name}
@@ -259,7 +259,7 @@ export default class EditProject extends Component<void, Props, State> {
               block
               disabled={!readyToCreate || saving}
               onClick={this._createOrSave}
-              name='Save Project'
+              name={messages.project.editAction}
               style='success'
             >
               {buttonText}

--- a/lib/components/edit-project.js
+++ b/lib/components/edit-project.js
@@ -174,7 +174,7 @@ export default class EditProject extends Component<void, Props, State> {
   }
 
   _delete = () => {
-    if (window.confirm(messages.project.deleteConfirmation)) {
+    if (window.confirm(messages.region.deleteConfirmation)) {
       this._hasBeenDeleted = true
       this.props.deleteProject()
     }
@@ -187,7 +187,7 @@ export default class EditProject extends Component<void, Props, State> {
       return (
         <div>
           <div className='ApplicationDockTitle'>
-            <Icon type='cubes' /> Create a new project
+            <Icon type='cubes' /> {messages.region.createAction}
           </div>
           {this.renderBody()}
         </div>
@@ -210,35 +210,35 @@ export default class EditProject extends Component<void, Props, State> {
     const buttonText = saving
       ? <span>
         <Icon className='fa-spin' type='spinner' />{' '}
-        {messages.project.loadStatus[loadStatus]}
+        {messages.region.loadStatus[loadStatus]}
       </span>
-      : isEditing ? messages.project.editAction : messages.project.createAction
+      : isEditing ? messages.region.editAction : messages.region.createAction
 
     return (
       <div className='InnerDock'>
         <Panel>
           <Body>
             <Text
-              label='Project Name*'
-              name='Project Name'
+              label={messages.region.name+"*"}
+              name={messages.region.name}
               onChange={this.onChangeName}
               value={name}
             />
             <Text
-              label='Description'
-              name='Description'
+              label={messages.region.description}
+              name={messages.region.description}
               onChange={this.onChangeDescription}
               value={description}
             />
             <R5Version
-              label={messages.project.r5Version}
-              name={messages.project.r5Version}
+              label={messages.region.r5Version}
+              name={messages.region.r5Version}
               onChange={this.onChangeR5Version}
               value={r5Version}
               allVersions={allVersions}
               releaseVersions={releaseVersions}
             />
-            <h5>OSM Bounds</h5>
+            <h5>{messages.region.osmBounds}</h5>
             {cardinalDirections.map(direction => (
               <Text
                 key={`bound-${direction}`}
@@ -250,7 +250,7 @@ export default class EditProject extends Component<void, Props, State> {
             ))}
 
             <File
-              label={messages.project.customOpenStreetMapData}
+              label={messages.region.customOpenStreetMapData}
               name='customOpenStreetMapData'
               onChange={this._changeCustomOsm}
             />
@@ -267,7 +267,7 @@ export default class EditProject extends Component<void, Props, State> {
 
             {isEditing &&
               <Button block onClick={this._delete} style='danger'>
-                <Icon type='trash' /> {messages.project.deleteAction}
+                <Icon type='trash' /> {messages.region.deleteAction}
               </Button>}
           </Body>
         </Panel>

--- a/lib/components/edit-project.js
+++ b/lib/components/edit-project.js
@@ -259,7 +259,7 @@ export default class EditProject extends Component<void, Props, State> {
               block
               disabled={!readyToCreate || saving}
               onClick={this._createOrSave}
-              name={messages.project.editAction}
+              name={messages.region.editAction}
               style='success'
             >
               {buttonText}

--- a/lib/components/edit-scenario.js
+++ b/lib/components/edit-scenario.js
@@ -68,10 +68,10 @@ export default class EditScenario extends PureComponent {
     return (
       <Panel>
         <Heading>
-          {isEditing && messages.scenario.editTitle}
-          {!isEditing && messages.scenario.createAction}
+          {isEditing && messages.project.editTitle}
+          {!isEditing && messages.project.createAction}
           {!isEditing &&
-            <a data-tip={messages.scenario.createActionTooltip}>
+            <a data-tip={messages.project.createActionTooltip}>
               <Icon type='question-circle-o' className='fa-lg pull-right' />
               <ReactTooltip className='help-tooltip' place='right' />
             </a>}
@@ -114,8 +114,8 @@ export default class EditScenario extends PureComponent {
             style='success'
           >
             {isEditing
-              ? messages.scenario.editAction
-              : messages.scenario.createAction}
+              ? messages.project.editAction
+              : messages.project.createAction}
           </Button>
         </Body>
       </Panel>

--- a/lib/components/import-modifications.js
+++ b/lib/components/import-modifications.js
@@ -6,7 +6,6 @@ import {Button} from './buttons'
 import {Body, Heading, Panel} from './panel'
 import messages from '../utils/messages'
 
-
 type Props = {
   candidateScenarioOptions: Array<{
     label: string,

--- a/lib/components/import-modifications.js
+++ b/lib/components/import-modifications.js
@@ -4,6 +4,8 @@ import Select from 'react-select'
 
 import {Button} from './buttons'
 import {Body, Heading, Panel} from './panel'
+import messages from '../utils/messages'
+
 
 type Props = {
   candidateScenarioOptions: Array<{
@@ -48,13 +50,13 @@ export default class ImportModifications
     const {importScenarioId} = this.state
     return (
       <Panel>
-        <Heading>Import modifications from another scenario</Heading>
+        <Heading>{messages.project.importModifications}</Heading>
         <Body>
           <div className='form-group'>
             <Select
               onChange={this._setImportScenarioId}
               options={candidateScenarioOptions}
-              placeholder='Select a scenario...'
+              placeholder={messages.project.select}
               value={importScenarioId}
             />
           </div>
@@ -64,7 +66,7 @@ export default class ImportModifications
             onClick={this._copyModificationsFromScenario}
             style='success'
           >
-            Import modifications
+            {messages.project.importAction}
           </Button>
         </Body>
       </Panel>

--- a/lib/components/modification/__tests__/__snapshots__/list.js.snap
+++ b/lib/components/modification/__tests__/__snapshots__/list.js.snap
@@ -23,7 +23,7 @@ exports[`Component > Modification > ModificationsList renders correctly 1`] = `
       className="pull-right"
       onClick={[Function]}
       style={Object {}}
-      title="Import modifications from another scenario"
+      title="Import modifications from another project"
     >
       <i
         className="fa fa-download fa-fw "
@@ -40,12 +40,12 @@ exports[`Component > Modification > ModificationsList renders correctly 1`] = `
         <i
           className="fa fa-clone fa-fw "
         />
-         Variants
+        Scenarios
         <a
           className="pull-right"
           onClick={[Function]}
           tabIndex={0}
-          title="Create a new variant"
+          title="Create new scenario"
         >
           <i
             className="fa fa-plus fa-fw "
@@ -56,31 +56,36 @@ exports[`Component > Modification > ModificationsList renders correctly 1`] = `
       <div
         className="Variants"
       >
-        <div
-          className="Variant"
-        >
-          Default
-          <a
-            className="pull-right"
-            onClick={[Function]}
-            tabIndex={0}
-            title="Show modifications for this variant on the map"
+        <ol>
+          <div
+            className="Variant"
           >
-            <i
-              className="fa fa-eye fa-fw "
-            />
-          </a>
-          <a
-            className="pull-right"
-            onClick={[Function]}
-            tabIndex={0}
-            title="Edit this variant name"
-          >
-            <i
-              className="fa fa-pencil fa-fw "
-            />
-          </a>
-        </div>
+            <li>
+               
+              Default
+              <a
+                className="pull-right"
+                onClick={[Function]}
+                tabIndex={0}
+                title="Show modifications for this scenario on the map"
+              >
+                <i
+                  className="fa fa-eye fa-fw "
+                />
+              </a>
+              <a
+                className="pull-right"
+                onClick={[Function]}
+                tabIndex={0}
+                title="Rename this scenario"
+              >
+                <i
+                  className="fa fa-pencil fa-fw "
+                />
+              </a>
+            </li>
+          </div>
+        </ol>
       </div>
     </div>
     <br />

--- a/lib/components/modification/editor.js
+++ b/lib/components/modification/editor.js
@@ -161,7 +161,7 @@ export default class ModificationEditor extends Component<void, Props, State> {
 function Variants ({activeVariants, allVariants, modificationId, setVariant}) {
   return (
     <div>
-      <h5>Active in variants</h5>
+      <h5>{messages.scenario.activeIn}</h5>
       <div className='form-inline'>
         {allVariants.map((v, i) => (
           <Checkbox

--- a/lib/components/modification/list.js
+++ b/lib/components/modification/list.js
@@ -168,7 +168,7 @@ export default class ModificationsList extends Component {
           <Link
             className='pull-right'
             to={`/scenarios/${scenarioId}/import-modifications`}
-            title={messages.scenario.importModifications}
+            title={messages.project.importModifications}
           >
             <Icon type='download' />
           </Link>

--- a/lib/components/project.js
+++ b/lib/components/project.js
@@ -42,9 +42,9 @@ export default class Project extends Component<void, Props, void> {
         {r5VersionUnsupported &&
         <div className='panel-body'>
           <div className='alert alert-danger' role='alert'>
-            {messages.project.versionOutdated}{' '}
+            {messages.region.versionOutdated}{' '}
             <Link to={`/projects/${project.id}/edit`}>
-              {messages.project.editProject}
+              {messages.region.editProject}
             </Link>
           </div>
         </div>}
@@ -52,7 +52,7 @@ export default class Project extends Component<void, Props, void> {
         {children}
       </div>
       : <PanelBody>
-        {messages.project.loadingProject}
+        {messages.region.loadingProject}
       </PanelBody>
   }
 }

--- a/lib/components/r5-version.js
+++ b/lib/components/r5-version.js
@@ -81,13 +81,13 @@ export default class R5Version extends Component<void, Props, State> {
             }}
             title={
               showAllVersions
-                ? messages.project.showReleaseVersions
-                : messages.project.showAllVersions
+                ? messages.region.showReleaseVersions
+                : messages.region.showAllVersions
             }
             aria-label={
               showAllVersions
-                ? messages.project.showReleaseVersions
-                : messages.project.showAllVersions
+                ? messages.region.showReleaseVersions
+                : messages.region.showAllVersions
             }
             onClick={this.toggleAllVersions}
           />
@@ -97,7 +97,7 @@ export default class R5Version extends Component<void, Props, State> {
 
         {!latestReleaseVersionSelected &&
           <div className='alert alert-warning'>
-            {messages.project.latestReleaseVersionNotSelected}
+            {messages.region.latestReleaseVersionNotSelected}
           </div>}
       </div>
     )

--- a/lib/components/report/adjust-dwell-time.js
+++ b/lib/components/report/adjust-dwell-time.js
@@ -39,7 +39,7 @@ export default class AdjustDwellTime extends Component {
     return (
       <div>
         <h3>
-          {messages.scenario.route}:{' '}
+          {messages.project.route}:{' '}
           {!!route.route_short_name && route.route_short_name}{' '}
           {!!route.route_long_name && route.route_long_name}
         </h3>

--- a/lib/components/report/adjust-frequency.js
+++ b/lib/components/report/adjust-frequency.js
@@ -38,7 +38,7 @@ export default class AdjustFrequency extends Component {
     return (
       <div>
         <h3>
-          {messages.scenario.route}:{' '}
+          {messages.project.route}:{' '}
           {!!route.route_short_name && route.route_short_name}{' '}
           {!!route.route_long_name && route.route_long_name}
         </h3>

--- a/lib/components/report/adjust-speed.js
+++ b/lib/components/report/adjust-speed.js
@@ -37,7 +37,7 @@ export default class AdjustSpeed extends Component {
     return (
       <div>
         <h3>
-          {messages.scenario.route}:{' '}
+          {messages.project.route}:{' '}
           {!!route.route_short_name && route.route_short_name}{' '}
           {!!route.route_long_name && route.route_long_name}
         </h3>

--- a/lib/components/report/remove-stops.js
+++ b/lib/components/report/remove-stops.js
@@ -39,7 +39,7 @@ export default class RemoveStops extends Component {
     return (
       <div>
         <h3>
-          {messages.scenario.route}:{' '}
+          {messages.project.route}:{' '}
           {!!route.route_short_name && route.route_short_name}{' '}
           {!!route.route_long_name && route.route_long_name}
         </h3>

--- a/lib/components/report/remove-trips.js
+++ b/lib/components/report/remove-trips.js
@@ -27,7 +27,7 @@ export default class RemoveTrips extends PureComponent {
     return (
       <div>
         <h3>
-          {messages.scenario.route}:{' '}
+          {messages.project.route}:{' '}
           {!!route.route_short_name && route.route_short_name}{' '}
           {!!route.route_long_name && route.route_long_name}
         </h3>

--- a/lib/components/report/reroute.js
+++ b/lib/components/report/reroute.js
@@ -43,7 +43,7 @@ export default class Reroute extends Component {
     return (
       <div>
         <h3>
-          {messages.scenario.route}:{' '}
+          {messages.project.route}:{' '}
           {!!route.route_short_name && route.route_short_name}{' '}
           {!!route.route_long_name && route.route_long_name}
         </h3>

--- a/lib/components/scenario.js
+++ b/lib/components/scenario.js
@@ -148,7 +148,7 @@ function SelectVariant ({action, label, onHide, variants}) {
   return (
     <Modal onRequestClose={onHide}>
       <ModalTitle>
-        Select variant to {label}:
+        {messages.scenario.export} {label}:
       </ModalTitle>
       <ModalBody>
         <ul>

--- a/lib/components/scenario.js
+++ b/lib/components/scenario.js
@@ -52,7 +52,7 @@ export default class Scenario extends Component {
   }
 
   _deleteScenario = () => {
-    if (window.confirm(messages.scenario.deleteConfirmation)) {
+    if (window.confirm(messages.project.deleteConfirmation)) {
       this.props.deleteScenario()
     }
   }
@@ -78,14 +78,14 @@ export default class Scenario extends Component {
             className='pull-right'
             onClick={this._deleteScenario}
             tabIndex={0}
-            title={messages.scenario.delete}
+            title={messages.project.delete}
             type='button'
             >
             <Icon type='trash' />
           </a>
           <Link
             className='pull-right'
-            title={messages.scenario.editName}
+            title={messages.project.editName}
             to={`/scenarios/${id}/edit`}
             >
             <Icon type='gear' />
@@ -93,7 +93,7 @@ export default class Scenario extends Component {
           <Link
             className='pull-right'
             to={`/scenarios/${id}/import-shapefile`}
-            title={messages.scenario.importShapefile}
+            title={messages.project.importShapefile}
             >
             <Icon type='globe' />
           </Link>
@@ -134,12 +134,12 @@ export default class Scenario extends Component {
             ? children
             : <div className='InnerDock'>
               <PanelBody>
-                {messages.scenario.loadingGTFS}
+                {messages.project.loadingGTFS}
               </PanelBody>
             </div>}
       </div>
       : <PanelBody>
-        {messages.scenario.loading}
+        {messages.project.loading}
       </PanelBody>
   }
 }

--- a/lib/components/select-project.js
+++ b/lib/components/select-project.js
@@ -26,7 +26,7 @@ export default class SelectProject extends Component<void, Props, void> {
         <Body>
           <div className='WelcomeTitle'>
             <p style={{textAlign: 'center'}}>
-              {messages.project.welcome}
+              {messages.region.welcome}
             </p>
             <span className='logo' to='/'>
               conveyal analysis
@@ -38,13 +38,13 @@ export default class SelectProject extends Component<void, Props, void> {
               onClick={() => push(`/projects/create`)}
               style='success'
             >
-              <Icon type='cubes' /> {messages.project.createAction}
+              <Icon type='cubes' /> {messages.region.createAction}
             </Button>
           </Group>
           {projects.length > 0 &&
             <div>
               <p style={{textAlign: 'center'}}>
-                {messages.project.goToExisting}
+                {messages.region.goToExisting}
               </p>
               <div className='list-group'>
                 {projects.map(project => (
@@ -52,7 +52,7 @@ export default class SelectProject extends Component<void, Props, void> {
                     className='list-group-item'
                     key={project.id}
                     to={`/projects/${project.id}`}
-                    title={messages.project.goToProject}
+                    title={messages.region.goToProject}
                   >
                     {project.loadStatus === 'DONE'
                       ? <span><Icon type='cubes' /> {project.name}</span>
@@ -63,7 +63,7 @@ export default class SelectProject extends Component<void, Props, void> {
                           {project.name}
                         </p>
                         <em>
-                          {messages.project.loadStatus[project.loadStatus]}
+                          {messages.region.loadStatus[project.loadStatus]}
                         </em>
                       </div>}
                   </Link>

--- a/lib/components/select-scenario.js
+++ b/lib/components/select-scenario.js
@@ -22,37 +22,37 @@ export default class SelectScenario extends Component<void, Props, void> {
           <Link
             className={`${btn}-success`}
             to={`/projects/${projectId}/scenarios/create`}
-            title={messages.scenario.createAction}
+            title={messages.project.createAction}
           >
-            <Icon type='cube' /> {messages.scenario.createAction}
+            <Icon type='cube' /> {messages.project.createAction}
           </Link>
           <Link
             className={`${btn}-success`}
             to={`/projects/${projectId}/bundles/create`}
-            title={messages.scenario.uploadBundle}
+            title={messages.project.uploadBundle}
           >
-            <Icon type='database' /> {messages.scenario.uploadBundle}
+            <Icon type='database' /> {messages.project.uploadBundle}
           </Link>
           <Link
             className={`${btn}-success`}
             to={`/projects/${projectId}/grids/create`}
-            title={messages.scenario.uploadOpportunityDataset}
+            title={messages.project.uploadOpportunityDataset}
           >
-            <Icon type='th' /> {messages.scenario.uploadOpportunityDataset}
+            <Icon type='th' /> {messages.project.uploadOpportunityDataset}
           </Link>
           <Link
             className={`${btn}-warning`}
             to={`/projects/${projectId}/edit`}
-            title={messages.project.configure}
+            title={messages.region.configure}
           >
-            <Icon type='gear' /> {messages.project.configure}
+            <Icon type='gear' /> {messages.region.configure}
           </Link>
         </Group>
 
         {scenarios.length > 0 &&
           <div>
             <p className='center'>
-              {messages.scenario.goToExisting}
+              {messages.project.goToExisting}
             </p>
             <div className='list-group'>
               {scenarios.map(scenario => (
@@ -60,7 +60,7 @@ export default class SelectScenario extends Component<void, Props, void> {
                   className='list-group-item'
                   key={scenario.id}
                   to={`/scenarios/${scenario.id}`}
-                  title={messages.scenario.goToScenario}
+                  title={messages.project.goToScenario}
                 >
                   <Icon type='cube' /> {scenario.name}
                 </Link>

--- a/lib/components/variant-editor.js
+++ b/lib/components/variant-editor.js
@@ -2,6 +2,7 @@
 import Icon from '@conveyal/woonerf/components/icon'
 import memoize from 'lodash/memoize'
 import React, {Component} from 'react'
+import messages from '../utils/messages'
 
 type Props = {
   createVariant: (name: string) => void,
@@ -15,8 +16,8 @@ export default class Variants extends Component<void, Props, void> {
   _create = () => {
     const {createVariant, variants} = this.props
     const variantName = window.prompt(
-      'Enter a variant name:',
-      `Variant ${variants.length + 1}`
+      `${messages.scenario.enterName}`,
+      `${messages.common.scenario} ${variants.length + 1}`
     )
     if (variantName) createVariant(variantName)
   }
@@ -26,7 +27,7 @@ export default class Variants extends Component<void, Props, void> {
     const name = variants[index]
     if (
       window.confirm(
-        `Are you sure you want to delete variant ${name}? This will clear all references to this variant from each modification.`
+        `${messages.scenario.deleteConfirmation}`
       )
     ) {
       deleteVariant(index)
@@ -37,7 +38,7 @@ export default class Variants extends Component<void, Props, void> {
     const {editVariantName, variants} = this.props
     const variantName = variants[index]
     const newVariantName = window.prompt(
-      'Enter a new variant name:',
+      `${messages.scenario.enterName}`,
       variantName
     )
     if (newVariantName) editVariantName({index, name: newVariantName})
@@ -52,12 +53,12 @@ export default class Variants extends Component<void, Props, void> {
     return (
       <div>
         <div className='DockTitle'>
-          <Icon type='clone' /> Variants
+          <Icon type='clone' /> {messages.scenario.plural}
           <a
             className='pull-right'
             onClick={this._create}
             tabIndex={0}
-            title='Create a new variant'
+            title={messages.scenario.createAction}
           >
             <Icon type='plus' /> Create
           </a>
@@ -65,12 +66,12 @@ export default class Variants extends Component<void, Props, void> {
         <div className='Variants'>
           {variants.map((name, index) => (
             <div className='Variant' key={`variant-${index}`}>
-              {name}
+              {index +1}. {name}
               <a
                 className='pull-right'
                 onClick={this._showVariant(index)}
                 tabIndex={0}
-                title='Show modifications for this variant on the map'
+                title={messages.scenario.showModifications}
               >
                 <Icon type='eye' />
               </a>
@@ -78,7 +79,7 @@ export default class Variants extends Component<void, Props, void> {
                 className='pull-right'
                 onClick={this._editVariantName(index)}
                 tabIndex={0}
-                title='Edit this variant name'
+                title={messages.scenario.editName}
               >
                 <Icon type='pencil' />
               </a>
@@ -87,7 +88,7 @@ export default class Variants extends Component<void, Props, void> {
                   className='pull-right'
                   onClick={this._deleteVariant(index)}
                   tabIndex={0}
-                  title='Delete this variant'
+                  title={messages.scenario.delete}
                 >
                   <Icon type='trash' />
                 </a>}

--- a/lib/components/variant-editor.js
+++ b/lib/components/variant-editor.js
@@ -52,7 +52,7 @@ export default class Variants extends Component<void, Props, void> {
     return (
       <div>
         <div className='DockTitle'>
-          <Icon type='clone' /> {messages.scenario.plural}
+          <Icon type='clone' />{messages.scenario.plural}
           <a
             className='pull-right'
             onClick={this._create}

--- a/lib/components/variant-editor.js
+++ b/lib/components/variant-editor.js
@@ -63,36 +63,39 @@ export default class Variants extends Component<void, Props, void> {
           </a>
         </div>
         <div className='Variants'>
-          {variants.map((name, index) => (
-            <div className='Variant' key={`variant-${index}`}>
-              {index + 1}. {name}
-              <a
-                className='pull-right'
-                onClick={this._showVariant(index)}
-                tabIndex={0}
-                title={messages.scenario.showModifications}
-              >
-                <Icon type='eye' />
-              </a>
-              <a
-                className='pull-right'
-                onClick={this._editVariantName(index)}
-                tabIndex={0}
-                title={messages.scenario.editName}
-              >
-                <Icon type='pencil' />
-              </a>
-              {index !== 0 &&
-                <a
-                  className='pull-right'
-                  onClick={this._deleteVariant(index)}
-                  tabIndex={0}
-                  title={messages.scenario.delete}
-                >
-                  <Icon type='trash' />
-                </a>}
-            </div>
-          ))}
+          <ol>
+            {variants.map((name, index) => (
+              <div className='Variant' key={`variant-${index}`}>
+                <li> {name}
+                  <a
+                    className='pull-right'
+                    onClick={this._showVariant(index)}
+                    tabIndex={0}
+                    title={messages.scenario.showModifications}
+                  >
+                    <Icon type='eye' />
+                  </a>
+                  <a
+                    className='pull-right'
+                    onClick={this._editVariantName(index)}
+                    tabIndex={0}
+                    title={messages.scenario.editName}
+                  >
+                    <Icon type='pencil' />
+                  </a>
+                  {index !== 0 &&
+                    <a
+                      className='pull-right'
+                      onClick={this._deleteVariant(index)}
+                      tabIndex={0}
+                      title={messages.scenario.delete}
+                    >
+                      <Icon type='trash' />
+                    </a>}
+                  </li>
+              </div>
+            ))}
+          </ol>
         </div>
       </div>
     )

--- a/lib/components/variant-editor.js
+++ b/lib/components/variant-editor.js
@@ -92,7 +92,7 @@ export default class Variants extends Component<void, Props, void> {
                     >
                       <Icon type='trash' />
                     </a>}
-                  </li>
+                </li>
               </div>
             ))}
           </ol>

--- a/lib/components/variant-editor.js
+++ b/lib/components/variant-editor.js
@@ -23,8 +23,7 @@ export default class Variants extends Component<void, Props, void> {
   }
 
   _deleteVariant = memoize((index: number) => () => {
-    const {deleteVariant, variants} = this.props
-    const name = variants[index]
+    const {deleteVariant} = this.props
     if (
       window.confirm(
         `${messages.scenario.deleteConfirmation}`
@@ -66,7 +65,7 @@ export default class Variants extends Component<void, Props, void> {
         <div className='Variants'>
           {variants.map((name, index) => (
             <div className='Variant' key={`variant-${index}`}>
-              {index +1}. {name}
+              {index + 1}. {name}
               <a
                 className='pull-right'
                 onClick={this._showVariant(index)}

--- a/lib/containers/__tests__/__snapshots__/application.js.snap
+++ b/lib/containers/__tests__/__snapshots__/application.js.snap
@@ -11,7 +11,7 @@ exports[`Container > Application renders correctly 1`] = `
       className="Sidebar-logo"
       onClick={[Function]}
       style={Object {}}
-      title="Projects"
+      title="Regions"
     />
     <div>
       <div
@@ -33,7 +33,7 @@ exports[`Container > Application renders correctly 1`] = `
               className="Sidebar-navItem-text"
             >
                
-              Project Scenarios
+              Projects
             </span>
           </span>
         </a>
@@ -57,7 +57,7 @@ exports[`Container > Application renders correctly 1`] = `
               className="Sidebar-navItem-text"
             >
                
-              Project Settings
+              Shared Settings
             </span>
           </span>
         </a>
@@ -131,7 +131,7 @@ exports[`Container > Application renders correctly 1`] = `
               className="Sidebar-navItem-text"
             >
                
-              Edit Scenario
+              Edit Scenarios
             </span>
           </span>
         </a>
@@ -155,7 +155,7 @@ exports[`Container > Application renders correctly 1`] = `
               className="Sidebar-navItem-text"
             >
                
-              Analyze Scenario
+              Analyze Scenarios
             </span>
           </span>
         </a>

--- a/lib/containers/__tests__/__snapshots__/modification-editor.js.snap
+++ b/lib/containers/__tests__/__snapshots__/modification-editor.js.snap
@@ -1633,7 +1633,7 @@ exports[`Container > Modification Editor render just the title if not loaded 1`]
               >
                 <div>
                   <h5>
-                    Active in variants
+                    Active in scenario numbers
                   </h5>
                   <div
                     className="form-inline"
@@ -3288,7 +3288,7 @@ exports[`Container > Modification Editor render the description if present 1`] =
               >
                 <div>
                   <h5>
-                    Active in variants
+                    Active in scenario numbers
                   </h5>
                   <div
                     className="form-inline"
@@ -5271,7 +5271,7 @@ exports[`Container > Modification Editor renders correctly 2`] = `
               >
                 <div>
                   <h5>
-                    Active in variants
+                    Active in scenario numbers
                   </h5>
                   <div
                     className="form-inline"

--- a/lib/containers/__tests__/__snapshots__/report.js.snap
+++ b/lib/containers/__tests__/__snapshots__/report.js.snap
@@ -20,7 +20,7 @@ exports[`Container > Report renders correctly 1`] = `
         Mock Scenario
       </h1>
       <h2>
-        Variant: Default
+        Scenario: Default
       </h2>
       Using bundle: Mock Bundle
       <div

--- a/lib/containers/__tests__/__snapshots__/single-point-analysis.js.snap
+++ b/lib/containers/__tests__/__snapshots__/single-point-analysis.js.snap
@@ -580,15 +580,15 @@ exports[`Components > Analysis > Single Point should render correctly 1`] = `
             >
               <Group
                 className="col-xs-6"
-                label="Variant"
+                label="Scenario"
               >
                 <div
                   className="form-group col-xs-6"
                 >
                   <label
-                    htmlFor="variant-input-0"
+                    htmlFor="scenario-input-0"
                   >
-                    Variant
+                    Scenario
                   </label>
                   <Select
                     addLabelText="Add \\"{label}\\"?"
@@ -756,7 +756,7 @@ exports[`Components > Analysis > Single Point should render correctly 1`] = `
                     optionComponent={[Function]}
                     options={Array []}
                     pageSize={5}
-                    placeholder="Select an opportunity dataset..."
+                    placeholder="Select an opportunity dataset…"
                     required={false}
                     scrollMenuIntoView={true}
                     searchable={true}
@@ -783,7 +783,7 @@ exports[`Components > Analysis > Single Point should render correctly 1`] = `
                           <div
                             className="Select-placeholder"
                           >
-                            Select an opportunity dataset...
+                            Select an opportunity dataset…
                           </div>
                           <mockConstructor
                             aria-activedescendant="react-select-3--value"
@@ -820,15 +820,15 @@ exports[`Components > Analysis > Single Point should render correctly 1`] = `
             >
               <Group
                 className="col-xs-6"
-                label="Comparison scenario"
+                label="Comparison Project"
               >
                 <div
                   className="form-group col-xs-6"
                 >
                   <label
-                    htmlFor="comparison-scenario-input-2"
+                    htmlFor="comparison-project-input-2"
                   >
-                    Comparison scenario
+                    Comparison Project
                   </label>
                   <Select
                     addLabelText="Add \\"{label}\\"?"
@@ -856,7 +856,7 @@ exports[`Components > Analysis > Single Point should render correctly 1`] = `
                     menuBuffer={0}
                     menuRenderer={[Function]}
                     multi={false}
-                    name="Scenario"
+                    name="Project"
                     noResultsText="No results found"
                     onBlurResetsInput={true}
                     onChange={[Function]}
@@ -871,7 +871,7 @@ exports[`Components > Analysis > Single Point should render correctly 1`] = `
                       ]
                     }
                     pageSize={5}
-                    placeholder="Select comparison scenario..."
+                    placeholder="Select comparison project…"
                     required={false}
                     scrollMenuIntoView={true}
                     searchable={true}
@@ -898,7 +898,7 @@ exports[`Components > Analysis > Single Point should render correctly 1`] = `
                           <div
                             className="Select-placeholder"
                           >
-                            Select comparison scenario...
+                            Select comparison project…
                           </div>
                           <mockConstructor
                             aria-activedescendant="react-select-4--value"
@@ -931,15 +931,15 @@ exports[`Components > Analysis > Single Point should render correctly 1`] = `
               </Group>
               <Group
                 className="col-xs-6"
-                label="Comparison variant"
+                label="Comparison Scenario"
               >
                 <div
                   className="form-group col-xs-6"
                 >
                   <label
-                    htmlFor="comparison-variant-input-3"
+                    htmlFor="comparison-scenario-input-3"
                   >
-                    Comparison variant
+                    Comparison Scenario
                   </label>
                   <Select
                     addLabelText="Add \\"{label}\\"?"
@@ -967,7 +967,7 @@ exports[`Components > Analysis > Single Point should render correctly 1`] = `
                     menuBuffer={0}
                     menuRenderer={[Function]}
                     multi={false}
-                    name="Variant"
+                    name="Scenario"
                     noResultsText="No results found"
                     onBlurResetsInput={true}
                     onChange={[Function]}
@@ -975,7 +975,7 @@ exports[`Components > Analysis > Single Point should render correctly 1`] = `
                     optionComponent={[Function]}
                     options={Array []}
                     pageSize={5}
-                    placeholder="Select comparison scenario variant..."
+                    placeholder="Select comparison scenario…"
                     required={false}
                     scrollMenuIntoView={true}
                     searchable={true}
@@ -1002,7 +1002,7 @@ exports[`Components > Analysis > Single Point should render correctly 1`] = `
                           <div
                             className="Select-placeholder"
                           >
-                            Select comparison scenario variant...
+                            Select comparison scenario…
                           </div>
                           <div
                             aria-activedescendant="react-select-5--value"
@@ -2438,7 +2438,7 @@ exports[`Components > Analysis > Single Point should render correctly 1`] = `
                       options={
                         Array [
                           Object {
-                            "label": "Same as project",
+                            "label": "Entire region",
                             "value": "__PROJECT",
                           },
                         ]
@@ -2476,7 +2476,7 @@ exports[`Components > Analysis > Single Point should render correctly 1`] = `
                               onClick={null}
                               value={
                                 Object {
-                                  "label": "Same as project",
+                                  "label": "Entire region",
                                   "value": "__PROJECT",
                                 }
                               }
@@ -2490,7 +2490,7 @@ exports[`Components > Analysis > Single Point should render correctly 1`] = `
                                   id="react-select-7--value-item"
                                   role="option"
                                 >
-                                  Same as project
+                                  Entire region
                                 </span>
                               </div>
                             </Value>

--- a/lib/containers/__tests__/edit-project.js
+++ b/lib/containers/__tests__/edit-project.js
@@ -23,10 +23,10 @@ describe('Container > Edit Project', () => {
     )
 
     wrapper
-      .find('input[name="Project Name"]')
+      .find('input[name="Region Name"]')
       .simulate('change', {target: {value: 'New Project Name'}})
 
-    wrapper.find('a[name="Save Project"]').simulate('click')
+    wrapper.find('a[name="Save changes"]').simulate('click')
 
     setTimeout(() => {
       expect(postNock.isDone()).toBeTruthy()

--- a/lib/styles.css
+++ b/lib/styles.css
@@ -67,6 +67,7 @@ ul, ol {
 }
 
 .btn-primary {
+  color: #fff!important;
   background-color: #337ab7;
   border-color: color(#337ab7 shade(20%));
 }
@@ -74,6 +75,10 @@ ul, ol {
 .btn-primary:active, .btn-primary.active, .btn-primary:hover {
   background-color: color(#337ab7 shade(20%));
   border-color: color(#337ab7 shade(40%));
+}
+
+.btn-danger {
+  color: #fff!important;
 }
 
 .form-group {


### PR DESCRIPTION
User feedback has convinced us that "variant" is a confusing term.

We are moving toward a new hierarchy, and this PR mostly implements an intermediate set of changes in the UI, renaming variants to scenarios, scenarios to projects, and projects to regions.

This leaves us in the unfortunate position of having the user-facing nomenclature not match our file names.  But we'll be eliminating some level of the hierarchy soon, and that will be a good chance to rename files etc.

This PR also includes a start at associated changes to the user manual, and a couple miscellaneous fixes for readability/legibility/consistency.

