### PR TITLE
Simplify edit bundle and modify it to edit feed names

### DIFF
--- a/configurations/default/messages.yml
+++ b/configurations/default/messages.yml
@@ -12,7 +12,7 @@ bundle:
   create: Create a bundle
   delete: Delete this bundle
   deleteConfirmation: Are you sure you would like to delete this bundle? Scenarios using this bundle will no longer work.
-  edit: Edit bundle
+  edit: Save bundle
 map:
   northAbbr: N # Local abbreviation for north, used to label north arrow
 nav:

--- a/lib/components/__tests__/__snapshots__/edit-bundle.js.snap
+++ b/lib/components/__tests__/__snapshots__/edit-bundle.js.snap
@@ -3,7 +3,7 @@
 exports[`Component > EditBundle renders correctly 1`] = `
 <div>
   <h5>
-    Edit bundle
+    Edit Bundle
   </h5>
   <div
     className="form-group"
@@ -33,7 +33,7 @@ exports[`Component > EditBundle renders correctly 1`] = `
       className="fa fa-save fa-fw "
     />
      
-    Edit bundle
+    Save bundle
   </a>
   <a
     className="btn btn-danger btn-block"

--- a/lib/components/__tests__/edit-bundle.js
+++ b/lib/components/__tests__/edit-bundle.js
@@ -7,23 +7,19 @@ describe('Component > EditBundle', () => {
 
   it('renders correctly', () => {
     const props = {
-      addBundle: jest.fn(),
       bundle: {
-        feeds: []
+        feeds: [],
+        name: 'Test Bundle'
       },
       bundleId: '1',
       deleteBundle: jest.fn(),
-      fetch: jest.fn(),
-      fetchFeeds: jest.fn(),
-      name: 'Test Bundle',
-      projectId: '1',
       saveBundle: jest.fn()
     }
 
     // mount component
     const tree = renderer.create(<EditBundle {...props} />).toJSON()
     expect(tree).toMatchSnapshot()
-    const noCalls = ['addBundle', 'deleteBundle', 'saveBundle']
+    const noCalls = ['deleteBundle', 'saveBundle']
     noCalls.forEach(fn => {
       expect(props[fn]).not.toBeCalled()
     })

--- a/lib/components/edit-bundle.js
+++ b/lib/components/edit-bundle.js
@@ -89,6 +89,8 @@ export default class EditBundle extends Component {
 
         {bundle.feeds.map(feed => (
           <Text
+            disabled
+            title='Editing temporarily disabled'
             key={feed.feedId}
             label={`Feed #${feed.checksum}`}
             name='Feed'

--- a/lib/components/edit-bundle.js
+++ b/lib/components/edit-bundle.js
@@ -4,94 +4,99 @@ import memoize from 'lodash/memoize'
 import React, {Component} from 'react'
 
 import {Button} from './buttons'
-import {Group, Text} from './input'
+import {Text} from './input'
 import messages from '../utils/messages'
 
-import type {Bundle, Feed} from '../types'
+import type {Bundle} from '../types'
 
 type Props = {
   bundle: Bundle,
   bundleId: string,
-  feeds: Feed[],
-  name: string,
-  projectId: string,
 
   deleteBundle: () => void,
-  fetchFeeds: () => void,
-  saveBundle: Bundle => void
+  loadBundle: () => void,
+  saveBundle: (bundle: Bundle) => void
 }
 
 export default class EditBundle extends Component {
   props: Props
-
-  state = {
-    feeds: this.props.bundle.feeds,
-    name: this.props.name
+  state: {
+    bundle: Bundle
   }
 
-  componentDidMount () {
-    this.props.fetchFeeds()
+  state = {
+    bundle: this.props.bundle
   }
 
   componentWillReceiveProps (nextProps: Props) {
-    if (nextProps.bundle !== this.props.bundle) {
-      this.setState({feeds: nextProps.bundle.feeds})
+    if (nextProps.bundleId !== this.props.bundleId) {
+      this.setState({
+        bundle: nextProps.bundle
+      })
     }
-    if (nextProps.name !== this.props.name) {
-      this.setState({name: nextProps.name})
-    }
-    if (nextProps.bundleId !== this.props.bundleId) nextProps.fetchFeeds()
   }
 
   _submit = () => {
-    const {bundle, saveBundle} = this.props
-    const {feeds, name} = this.state
-    if (bundle && name) {
-      saveBundle({...bundle, feeds, name})
-    }
+    this.props.saveBundle(this.state.bundle)
   }
 
   _deleteBundle = () =>
     window.confirm(messages.bundle.deleteConfirmation) &&
     this.props.deleteBundle()
 
-  _setName = (e: Event & {target: HTMLInputElement}) =>
-    this.setState({name: e.target.value})
+  _setName = (e: Event & {target: HTMLInputElement}) => {
+    if (e.target.value && e.target.value.length > 0) {
+      this.setState({
+        bundle: {
+          ...this.state.bundle,
+          name: `${e.target.value}`
+        }
+      })
+    }
+  }
 
-  _setFeedName = memoize(feedId => (e: Event & {target: HTMLInputElement}) =>
-    this.setState({
-      feeds: this.state.feeds.map(
-        feed =>
-          (feed.feedId === feedId ? {...feed, name: e.target.value} : feed)
-      )
-    }))
+  _setFeedName = memoize(feedId => (e: Event & {target: HTMLInputElement}) => {
+    const {bundle} = this.state
+    if (e.target.value && e.target.value.length > 0) {
+      this.setState({
+        bundle: {
+          ...bundle,
+          feeds: bundle.feeds.map((f) => {
+            if (f.feedId === feedId) {
+              return {
+                ...f,
+                name: e.target.value
+              }
+            }
+            return f
+          })
+        }
+      })
+    }
+  })
 
   render () {
-    const {bundle, feeds} = this.props
-    const {name} = this.state
+    const {bundle} = this.props
     return (
       <div>
-        <h5>
-          {messages.bundle.edit}
-        </h5>
+        <h5>Edit Bundle</h5>
         <Text
           label='Bundle name'
           name='Name'
           onChange={this._setName}
           placeholder='Bundle name'
-          value={name}
+          value={bundle.name}
         />
 
         {bundle.feeds.map(feed => (
-          <Group label={`Feed #${feed.checksum}`} key={feed.feedId}>
-            <Text
-              name='Feed'
-              onChange={this._setFeedName(feed.feedId)}
-              placeholder='Feed name'
-              value={feed.name}
-            />
-            <FeedInfo feed={feeds.find(f => f.id === feed.feedId)} />
-          </Group>
+          <Text
+            key={feed.feedId}
+            label={`Feed #${feed.checksum}`}
+            name='Feed'
+            onChange={this._setFeedName(feed.feedId)}
+            placeholder='Feed name'
+            value={feed.name}
+          />
         ))}
 
         <Button block onClick={this._submit} style='success'>
@@ -104,17 +109,4 @@ export default class EditBundle extends Component {
       </div>
     )
   }
-}
-
-function FeedInfo ({feed}) {
-  return feed
-    ? <div className='row'>
-      <div className='col-xs-6'>
-        <strong>Routes:</strong> {feed.routes.length}
-      </div>
-      <div className='col-xs-6'>
-        <strong>Stops: </strong> {feed.stops.length}
-      </div>
-    </div>
-    : <span />
 }

--- a/lib/components/edit-bundle.js
+++ b/lib/components/edit-bundle.js
@@ -14,7 +14,6 @@ type Props = {
   bundleId: string,
 
   deleteBundle: () => void,
-  loadBundle: () => void,
   saveBundle: (bundle: Bundle) => void
 }
 

--- a/lib/containers/edit-bundle.js
+++ b/lib/containers/edit-bundle.js
@@ -1,39 +1,27 @@
+// @flow
 import {connect} from 'react-redux'
 import {push} from 'react-router-redux'
 
-import {deleteBundle, saveBundle} from '../actions'
-import getFeedRoutesAndStops from '../actions/get-feeds-routes-and-stops'
+import {deleteBundle, loadBundle, saveBundle} from '../actions'
 import EditBundle from '../components/edit-bundle'
 
-function mapStateToProps (state, props) {
-  const {scenario} = state
-  const {params} = props
-  const {bundleId, projectId} = params
-  const {bundles} = scenario
-  const bundle = bundles.find(b => b.id === bundleId)
+function mapStateToProps (state, ownProps) {
+  const bundleId = ownProps.params.bundleId
   return {
-    bundle,
-    bundleId,
-    feeds: scenario.feeds,
-    name: bundle && bundle.name,
-    projectId
+    bundle: state.scenario.bundles
+      .find(b => b.id === bundleId),
+    bundleId
   }
 }
 
-function mapDispatchToProps (dispatch, props) {
+function mapDispatchToProps (dispatch: Dispatch, props) {
   return {
     deleteBundle: () => [
       dispatch(deleteBundle(props.params.bundleId)),
       dispatch(push(`/projects/${props.params.projectId}/bundles`))
     ],
-    fetchFeeds: opts =>
-      dispatch(
-        getFeedRoutesAndStops({
-          bundleId: props.params.bundleId,
-          forceCompleteUpdate: true
-        })
-      ),
-    saveBundle: (...args) => dispatch(saveBundle(...args))
+    loadBundle: () => dispatch(loadBundle(props.params.bundleId)),
+    saveBundle: (bundle) => dispatch(saveBundle(bundle))
   }
 }
 

--- a/lib/containers/edit-bundle.js
+++ b/lib/containers/edit-bundle.js
@@ -2,7 +2,7 @@
 import {connect} from 'react-redux'
 import {push} from 'react-router-redux'
 
-import {deleteBundle, loadBundle, saveBundle} from '../actions'
+import {deleteBundle, saveBundle} from '../actions'
 import EditBundle from '../components/edit-bundle'
 
 function mapStateToProps (state, ownProps) {
@@ -20,7 +20,6 @@ function mapDispatchToProps (dispatch: Dispatch, props) {
       dispatch(deleteBundle(props.params.bundleId)),
       dispatch(push(`/projects/${props.params.projectId}/bundles`))
     ],
-    loadBundle: () => dispatch(loadBundle(props.params.bundleId)),
     saveBundle: (bundle) => dispatch(saveBundle(bundle))
   }
 }

--- a/lib/containers/scenario.js
+++ b/lib/containers/scenario.js
@@ -2,7 +2,6 @@
 import {connect} from 'react-redux'
 import {push} from 'react-router-redux'
 
-import {loadBundle} from '../actions'
 import {addComponent} from '../actions/map'
 import {getForScenario as loadModifications} from '../actions/modifications'
 import {
@@ -39,7 +38,6 @@ function mapDispatchToProps (dispatch: Dispatch, ownProps) {
     downloadVariant: index => dispatch(downloadVariant(index)),
     printVariant: index => dispatch(printVariant(index)),
     load: id => dispatch(load(id)),
-    loadBundle: id => dispatch(loadBundle(id)),
     loadModifications: opts => dispatch(loadModifications(opts))
   }
 }


### PR DESCRIPTION
This fixes the currently broken "edit bundle" form. Initial implementation took a different approach to display more information about the feed while editing.