### PR TITLE
Add front-end options to set access/egress parameters

### DIFF
--- a/lib/components/analysis/__tests__/__snapshots__/profile-request-editor.js.snap
+++ b/lib/components/analysis/__tests__/__snapshots__/profile-request-editor.js.snap
@@ -65,15 +65,15 @@ exports[`Components > Analysis > Profile Request Editor should render correctly 
       setProfileRequest={[Function]}
     >
       <Group
-        label="Modes"
+        label="Access and Transit Modes"
       >
         <div
           className="form-group"
         >
           <label
-            htmlFor="modes-input-0"
+            htmlFor="access-and-transit-modes-input-0"
           >
-            Modes
+            Access and Transit Modes
           </label>
           <br />
           <Group
@@ -105,11 +105,13 @@ exports[`Components > Analysis > Profile Request Editor should render correctly 
               </Button>
               <Button
                 active={false}
+                disabled={true}
                 onClick={[Function]}
                 title="Bike"
               >
                 <a
                   className="btn btn-default"
+                  disabled={true}
                   href="#"
                   onClick={[Function]}
                   tabIndex={0}
@@ -164,7 +166,6 @@ exports[`Components > Analysis > Profile Request Editor should render correctly 
               </Button>
               <Button
                 active={true}
-                onClick={[Function]}
                 title="Transit"
               >
                 <a
@@ -188,6 +189,238 @@ exports[`Components > Analysis > Profile Request Editor should render correctly 
         </div>
       </Group>
     </ModeSelector>
+    <div
+      className="row"
+    >
+      <div
+        className="col-xs-4"
+      >
+        <EgressModeSelector
+          disabled={true}
+          profileRequest={
+            Object {
+              "accessModes": "WALK",
+              "bikeSafe": 1,
+              "bikeSlope": 1,
+              "bikeSpeed": 4.166666666666667,
+              "bikeTime": 1,
+              "bikeTrafficStress": 4,
+              "carSpeed": 20,
+              "date": "2016-01-16",
+              "directModes": "WALK",
+              "egressModes": "WALK",
+              "fromTime": 25200,
+              "maxBikeTime": 20,
+              "maxCarTime": 45,
+              "maxRides": 4,
+              "maxWalkTime": 20,
+              "minBikeTime": 10,
+              "minCarTime": 10,
+              "monteCarloDraws": 200,
+              "reachabilityThreshold": 0,
+              "streetTime": 90,
+              "suboptimalMinutes": 5,
+              "toTime": 32400,
+              "transitModes": "TRANSIT",
+              "walkSpeed": 1.3888888888888888,
+            }
+          }
+          setProfileRequest={[Function]}
+        >
+          <Group
+            label="Egress Modes"
+          >
+            <div
+              className="form-group"
+            >
+              <label
+                htmlFor="egress-modes-input-1"
+              >
+                Egress Modes
+              </label>
+              <br />
+              <Group
+                disabled={true}
+              >
+                <div
+                  className="btn-group"
+                  disabled={true}
+                >
+                  <Button
+                    active={true}
+                    onClick={[Function]}
+                    title="Walk"
+                  >
+                    <a
+                      className="btn btn-default active"
+                      href="#"
+                      onClick={[Function]}
+                      tabIndex={0}
+                      title="Walk"
+                    >
+                      <Icon
+                        type="male"
+                      >
+                        <i
+                          className="fa fa-male fa-fw "
+                        />
+                      </Icon>
+                    </a>
+                  </Button>
+                  <Button
+                    active={false}
+                    disabled={true}
+                    onClick={[Function]}
+                    title="Bike"
+                  >
+                    <a
+                      className="btn btn-default"
+                      disabled={true}
+                      href="#"
+                      onClick={[Function]}
+                      tabIndex={0}
+                      title="Bike"
+                    >
+                      <Icon
+                        type="bicycle"
+                      >
+                        <i
+                          className="fa fa-bicycle fa-fw "
+                        />
+                      </Icon>
+                    </a>
+                  </Button>
+                </div>
+              </Group>
+            </div>
+          </Group>
+        </EgressModeSelector>
+      </div>
+      <div
+        className="col-xs-4"
+      >
+        <Number
+          label="Walk Speed (km/h)"
+          max={15}
+          min={3}
+          name="walkSpeed"
+          onChange={[Function]}
+          step={0.1}
+          value={5}
+        >
+          <Group
+            id="walk-speed-input-2"
+            label="Walk Speed (km/h)"
+            max={15}
+            min={3}
+            name="walkSpeed"
+            onChange={[Function]}
+            step={0.1}
+            value={5}
+          >
+            <div
+              className="form-group"
+            >
+              <label
+                htmlFor="walk-speed-input-2"
+              >
+                Walk Speed (km/h)
+              </label>
+              <Input
+                id="walk-speed-input-2"
+                label="Walk Speed (km/h)"
+                max={15}
+                min={3}
+                name="walkSpeed"
+                onChange={[Function]}
+                onWheel={[Function]}
+                step={0.1}
+                type="number"
+                value={5}
+              >
+                <input
+                  className="form-control"
+                  id="walk-speed-input-2"
+                  max={15}
+                  min={3}
+                  name="walkSpeed"
+                  onChange={[Function]}
+                  onWheel={[Function]}
+                  placeholder="Walk Speed (km/h)"
+                  step={0.1}
+                  type="number"
+                  value={5}
+                />
+              </Input>
+            </div>
+          </Group>
+        </Number>
+      </div>
+      <div
+        className="col-xs-4"
+      >
+        <Number
+          disabled={true}
+          label="Bike Speed (km/h)"
+          max={20}
+          min={5}
+          name="bikeSpeed"
+          onChange={[Function]}
+          step={0.1}
+          value={15}
+        >
+          <Group
+            disabled={true}
+            id="bike-speed-input-3"
+            label="Bike Speed (km/h)"
+            max={20}
+            min={5}
+            name="bikeSpeed"
+            onChange={[Function]}
+            step={0.1}
+            value={15}
+          >
+            <div
+              className="form-group"
+            >
+              <label
+                htmlFor="bike-speed-input-3"
+              >
+                Bike Speed (km/h)
+              </label>
+              <Input
+                disabled={true}
+                id="bike-speed-input-3"
+                label="Bike Speed (km/h)"
+                max={20}
+                min={5}
+                name="bikeSpeed"
+                onChange={[Function]}
+                onWheel={[Function]}
+                step={0.1}
+                type="number"
+                value={15}
+              >
+                <input
+                  className="form-control"
+                  disabled={true}
+                  id="bike-speed-input-3"
+                  max={20}
+                  min={5}
+                  name="bikeSpeed"
+                  onChange={[Function]}
+                  onWheel={[Function]}
+                  placeholder="Bike Speed (km/h)"
+                  step={0.1}
+                  type="number"
+                  value={15}
+                />
+              </Input>
+            </div>
+          </Group>
+        </Number>
+      </div>
+    </div>
     <div
       className="row"
     >
@@ -710,7 +943,7 @@ exports[`Components > Analysis > Profile Request Editor should render correctly 
             value="07:00"
           >
             <Group
-              id="from-time-input-1"
+              id="from-time-input-4"
               label="From time"
               name="fromTime"
               onChange={[Function]}
@@ -723,12 +956,12 @@ exports[`Components > Analysis > Profile Request Editor should render correctly 
                 className="form-group"
               >
                 <label
-                  htmlFor="from-time-input-1"
+                  htmlFor="from-time-input-4"
                 >
                   From time
                 </label>
                 <Input
-                  id="from-time-input-1"
+                  id="from-time-input-4"
                   label="From time"
                   name="fromTime"
                   onChange={[Function]}
@@ -742,7 +975,7 @@ exports[`Components > Analysis > Profile Request Editor should render correctly 
                   >
                     <input
                       className="form-control"
-                      id="from-time-input-1"
+                      id="from-time-input-4"
                       name="fromTime"
                       onChange={[Function]}
                       onWheel={[Function]}
@@ -781,7 +1014,7 @@ exports[`Components > Analysis > Profile Request Editor should render correctly 
             value="09:00"
           >
             <Group
-              id="to-time-input-2"
+              id="to-time-input-5"
               label="To time"
               name="toTime"
               onChange={[Function]}
@@ -794,12 +1027,12 @@ exports[`Components > Analysis > Profile Request Editor should render correctly 
                 className="form-group"
               >
                 <label
-                  htmlFor="to-time-input-2"
+                  htmlFor="to-time-input-5"
                 >
                   To time
                 </label>
                 <Input
-                  id="to-time-input-2"
+                  id="to-time-input-5"
                   label="To time"
                   name="toTime"
                   onChange={[Function]}
@@ -813,7 +1046,7 @@ exports[`Components > Analysis > Profile Request Editor should render correctly 
                   >
                     <input
                       className="form-control"
-                      id="to-time-input-2"
+                      id="to-time-input-5"
                       name="toTime"
                       onChange={[Function]}
                       onWheel={[Function]}
@@ -850,7 +1083,7 @@ exports[`Components > Analysis > Profile Request Editor should render correctly 
           value={3}
         >
           <Group
-            id="max-transfers-input-3"
+            id="max-transfers-input-6"
             label="Maximum transfers"
             max={7}
             min={0}
@@ -863,12 +1096,12 @@ exports[`Components > Analysis > Profile Request Editor should render correctly 
               className="form-group"
             >
               <label
-                htmlFor="max-transfers-input-3"
+                htmlFor="max-transfers-input-6"
               >
                 Maximum transfers
               </label>
               <Input
-                id="max-transfers-input-3"
+                id="max-transfers-input-6"
                 label="Maximum transfers"
                 max={7}
                 min={0}
@@ -881,7 +1114,7 @@ exports[`Components > Analysis > Profile Request Editor should render correctly 
               >
                 <input
                   className="form-control"
-                  id="max-transfers-input-3"
+                  id="max-transfers-input-6"
                   max={7}
                   min={0}
                   name="maxTransfers"
@@ -910,7 +1143,7 @@ exports[`Components > Analysis > Profile Request Editor should render correctly 
           value={200}
         >
           <Group
-            id="monte-carlo-draws-input-4"
+            id="monte-carlo-draws-input-7"
             label="Number of simulated schedules"
             max={10000}
             min={1}
@@ -923,12 +1156,12 @@ exports[`Components > Analysis > Profile Request Editor should render correctly 
               className="form-group"
             >
               <label
-                htmlFor="monte-carlo-draws-input-4"
+                htmlFor="monte-carlo-draws-input-7"
               >
                 Number of simulated schedules
               </label>
               <Input
-                id="monte-carlo-draws-input-4"
+                id="monte-carlo-draws-input-7"
                 label="Number of simulated schedules"
                 max={10000}
                 min={1}
@@ -941,7 +1174,7 @@ exports[`Components > Analysis > Profile Request Editor should render correctly 
               >
                 <input
                   className="form-control"
-                  id="monte-carlo-draws-input-4"
+                  id="monte-carlo-draws-input-7"
                   max={10000}
                   min={1}
                   name="monteCarloDraws"

--- a/lib/components/analysis/__tests__/__snapshots__/profile-request-editor.js.snap
+++ b/lib/components/analysis/__tests__/__snapshots__/profile-request-editor.js.snap
@@ -166,10 +166,13 @@ exports[`Components > Analysis > Profile Request Editor should render correctly 
               </Button>
               <Button
                 active={true}
+                disabled={true}
+                onClick={[Function]}
                 title="Transit"
               >
                 <a
                   className="btn btn-default active"
+                  disabled={true}
                   href="#"
                   onClick={[Function]}
                   tabIndex={0}

--- a/lib/components/analysis/egress-mode-selector.js
+++ b/lib/components/analysis/egress-mode-selector.js
@@ -51,6 +51,7 @@ export default class EgressModeSelector extends PureComponent {
           </Button>
           <Button
             active={nonTransitMode === BICYCLE}
+            disabled
             onClick={this._selectEgressMode(BICYCLE)}
             title={messages.analysis.modes.bicycle}
           >

--- a/lib/components/analysis/egress-mode-selector.js
+++ b/lib/components/analysis/egress-mode-selector.js
@@ -1,0 +1,63 @@
+// @flow
+import Icon from '@conveyal/woonerf/components/icon'
+import memoize from 'lodash/memoize'
+import React, {PureComponent} from 'react'
+
+import {Button, Group as ButtonGroup} from '../buttons'
+import {Group} from '../input'
+import messages from '../../utils/messages'
+
+import type {ProfileRequest} from '../../types'
+
+type Props = {
+  disabled: boolean,
+  profileRequest: ProfileRequest,
+  setProfileRequest(ProfileRequest): void
+}
+
+const WALK = 'WALK'
+const BICYCLE = 'BICYCLE'
+
+/** Select modes of travel */
+export default class EgressModeSelector extends PureComponent {
+  props: Props
+
+  _selectEgressMode = memoize(newMode => () => {
+    const {profileRequest, setProfileRequest} = this.props
+    setProfileRequest({
+      ...profileRequest,
+      egressModes: newMode
+    })
+  })
+
+  render () {
+    const {disabled, profileRequest} = this.props
+
+    const transit = profileRequest.transitModes !== ''
+    const nonTransitMode = transit
+      ? profileRequest.egressModes
+      : profileRequest.directModes
+
+    return (
+      <Group label='Egress Modes'>
+        <br />
+        <ButtonGroup disabled={disabled}>
+          <Button
+            active={nonTransitMode === WALK}
+            onClick={this._selectEgressMode(WALK)}
+            title={messages.analysis.modes.walk}
+          >
+            <Icon type='male' />
+          </Button>
+          <Button
+            active={nonTransitMode === BICYCLE}
+            onClick={this._selectEgressMode(BICYCLE)}
+            title={messages.analysis.modes.bicycle}
+          >
+            <Icon type='bicycle' />
+          </Button>
+        </ButtonGroup>
+      </Group>
+    )
+  }
+}

--- a/lib/components/analysis/mode-selector.js
+++ b/lib/components/analysis/mode-selector.js
@@ -90,8 +90,9 @@ export default class ModeSelector extends PureComponent {
             <strong>P</strong>
           </Button>
           <Button
+            disabled
             active={!!transit}
-            // uncomment to allow transit toggling onClick={this._toggleTransit}
+            onClick={this._toggleTransit}
             title={messages.analysis.modes.transit}
           >
             <Icon type='bus' />

--- a/lib/components/analysis/mode-selector.js
+++ b/lib/components/analysis/mode-selector.js
@@ -57,7 +57,7 @@ export default class ModeSelector extends PureComponent {
       : profileRequest.directModes
 
     return (
-      <Group label='Modes'>
+      <Group label='Access and Transit Modes'>
         <br />
         <ButtonGroup disabled={disabled} justified>
           <Button

--- a/lib/components/analysis/mode-selector.js
+++ b/lib/components/analysis/mode-selector.js
@@ -91,7 +91,7 @@ export default class ModeSelector extends PureComponent {
           </Button>
           <Button
             active={!!transit}
-            //uncomment to allow transit toggling onClick={this._toggleTransit}
+            // uncomment to allow transit toggling onClick={this._toggleTransit}
             title={messages.analysis.modes.transit}
           >
             <Icon type='bus' />

--- a/lib/components/analysis/mode-selector.js
+++ b/lib/components/analysis/mode-selector.js
@@ -69,6 +69,7 @@ export default class ModeSelector extends PureComponent {
           </Button>
           <Button
             active={nonTransitMode === BICYCLE}
+            disabled
             onClick={this._selectAccessMode(BICYCLE)}
             title={messages.analysis.modes.bicycle}
           >
@@ -90,7 +91,7 @@ export default class ModeSelector extends PureComponent {
           </Button>
           <Button
             active={!!transit}
-            onClick={this._toggleTransit}
+            //uncomment to allow transit toggling onClick={this._toggleTransit}
             title={messages.analysis.modes.transit}
           >
             <Icon type='bus' />

--- a/lib/components/analysis/profile-request-editor.js
+++ b/lib/components/analysis/profile-request-editor.js
@@ -7,6 +7,7 @@ import DatePicker from '../date-picker'
 import messages from '../../utils/messages'
 import {Number as InputNumber} from '../input'
 import ModeSelector from './mode-selector'
+import EgressModeSelector from './egress-mode-selector'
 
 /** Edit the parameters of a profile request */
 export default class ProfileRequestEditor extends Component {
@@ -48,6 +49,15 @@ export default class ProfileRequestEditor extends Component {
           profileRequest={profileRequest}
           setProfileRequest={setProfileRequest}
         />
+        <div className='row'>
+          <div className='col-xs-4'>
+            <EgressModeSelector
+              disabled
+              profileRequest={profileRequest}
+              setProfileRequest={setProfileRequest}
+            />
+          </div>
+        </div>
         <div className='row'>
           <div className='form-group col-xs-4'>
             <label htmlFor={messages.analysis.date}>

--- a/lib/components/analysis/profile-request-editor.js
+++ b/lib/components/analysis/profile-request-editor.js
@@ -75,6 +75,7 @@ export default class ProfileRequestEditor extends Component {
           </div>
           <div className='col-xs-4'>
             <InputNumber
+              disabled
               label='Bike Speed (km/h)'
               value={Math.round(bikeSpeed * 36)/10}
               min={5}

--- a/lib/components/analysis/profile-request-editor.js
+++ b/lib/components/analysis/profile-request-editor.js
@@ -39,9 +39,9 @@ export default class ProfileRequestEditor extends Component {
   setMonteCarloDraws = (e: Event & {target: HTMLInputElement}) =>
     this.set({monteCarloDraws: parseInt(e.target.value)})
   setWalkSpeed = (e: Event & {target: HTMLInputElement}) =>
-    this.set({walkSpeed: parseFloat(e.target.value)/3.6}) // km/h to m/s
+    this.set({walkSpeed: parseFloat(e.target.value) / 3.6}) // km/h to m/s
   setBikeSpeed = (e: Event & {target: HTMLInputElement}) =>
-    this.set({bikeSpeed: parseFloat(e.target.value)/3.6}) // km/h to m/s
+    this.set({bikeSpeed: parseFloat(e.target.value) / 3.6}) // km/h to m/s
 
   render () {
     const {disabled, profileRequest, setProfileRequest} = this.props
@@ -65,10 +65,10 @@ export default class ProfileRequestEditor extends Component {
             <InputNumber
               disabled={disabled}
               label='Walk Speed (km/h)'
-              value={Math.round(walkSpeed * 36)/10}
+              value={Math.round(walkSpeed * 36) / 10}
               min={3}
               max={15}
-              step={.1}
+              step={0.1}
               name='walkSpeed'
               onChange={this.setWalkSpeed}
             />
@@ -77,10 +77,10 @@ export default class ProfileRequestEditor extends Component {
             <InputNumber
               disabled
               label='Bike Speed (km/h)'
-              value={Math.round(bikeSpeed * 36)/10}
+              value={Math.round(bikeSpeed * 36) / 10}
               min={5}
               max={20}
-              step={.1}
+              step={0.1}
               name='bikeSpeed'
               onChange={this.setBikeSpeed}
             />

--- a/lib/components/analysis/profile-request-editor.js
+++ b/lib/components/analysis/profile-request-editor.js
@@ -38,10 +38,14 @@ export default class ProfileRequestEditor extends Component {
     this.set({maxRides: parseInt(e.target.value) + 1})
   setMonteCarloDraws = (e: Event & {target: HTMLInputElement}) =>
     this.set({monteCarloDraws: parseInt(e.target.value)})
+  setWalkSpeed = (e: Event & {target: HTMLInputElement}) =>
+    this.set({walkSpeed: parseFloat(e.target.value)/3.6}) // km/h to m/s
+  setBikeSpeed = (e: Event & {target: HTMLInputElement}) =>
+    this.set({bikeSpeed: parseFloat(e.target.value)/3.6}) // km/h to m/s
 
   render () {
     const {disabled, profileRequest, setProfileRequest} = this.props
-    const {date, fromTime, toTime, maxRides, monteCarloDraws} = profileRequest
+    const {date, walkSpeed, bikeSpeed, fromTime, toTime, maxRides, monteCarloDraws} = profileRequest
     return (
       <div>
         <ModeSelector
@@ -55,6 +59,29 @@ export default class ProfileRequestEditor extends Component {
               disabled
               profileRequest={profileRequest}
               setProfileRequest={setProfileRequest}
+            />
+          </div>
+          <div className='col-xs-4'>
+            <InputNumber
+              disabled={disabled}
+              label='Walk Speed (km/h)'
+              value={Math.round(walkSpeed * 36)/10}
+              min={3}
+              max={15}
+              step={.1}
+              name='walkSpeed'
+              onChange={this.setWalkSpeed}
+            />
+          </div>
+          <div className='col-xs-4'>
+            <InputNumber
+              label='Bike Speed (km/h)'
+              value={Math.round(bikeSpeed * 36)/10}
+              min={5}
+              max={20}
+              step={.1}
+              name='bikeSpeed'
+              onChange={this.setBikeSpeed}
             />
           </div>
         </div>

--- a/lib/components/analysis/stacked-percentile-selector.js
+++ b/lib/components/analysis/stacked-percentile-selector.js
@@ -99,7 +99,12 @@ export default class StackedPercentileSelector extends PureComponent {
               width: `${(accessibility || 1) / maxAccessibility * 100}%`
             }}
           >
-            {`${scenarioName} ${commaFormat(accessibility)}`}
+            <div className='scenario-name'>
+              {`${scenarioName} (Median)`}
+            </div>
+          </div>
+          <div className='statistic'>
+            {commaFormat(accessibility)}
           </div>
         </div>
 
@@ -115,7 +120,12 @@ export default class StackedPercentileSelector extends PureComponent {
                 width: `${comparisonAccessibility / maxAccessibility * 100}%`
               }}
             >
-              {`${comparisonScenarioName} ${commaFormat(comparisonAccessibility)}`}
+              <div className='scenario-name'>
+                {`${comparisonScenarioName} (Median)`}
+              </div>
+            </div>
+            <div className='statistic'>
+              {commaFormat(comparisonAccessibility)}
             </div>
           </div>}
 

--- a/lib/containers/__tests__/__snapshots__/single-point-analysis.js.snap
+++ b/lib/containers/__tests__/__snapshots__/single-point-analysis.js.snap
@@ -1470,15 +1470,15 @@ exports[`Components > Analysis > Single Point should render correctly 1`] = `
                   setProfileRequest={[Function]}
                 >
                   <Group
-                    label="Modes"
+                    label="Access and Transit Modes"
                   >
                     <div
                       className="form-group"
                     >
                       <label
-                        htmlFor="modes-input-5"
+                        htmlFor="access-and-transit-modes-input-5"
                       >
-                        Modes
+                        Access and Transit Modes
                       </label>
                       <br />
                       <Group
@@ -1512,11 +1512,13 @@ exports[`Components > Analysis > Single Point should render correctly 1`] = `
                           </Button>
                           <Button
                             active={false}
+                            disabled={true}
                             onClick={[Function]}
                             title="Bike"
                           >
                             <a
                               className="btn btn-default"
+                              disabled={true}
                               href="#"
                               onClick={[Function]}
                               tabIndex={0}
@@ -1571,7 +1573,6 @@ exports[`Components > Analysis > Single Point should render correctly 1`] = `
                           </Button>
                           <Button
                             active={true}
-                            onClick={[Function]}
                             title="Transit"
                           >
                             <a
@@ -1595,6 +1596,242 @@ exports[`Components > Analysis > Single Point should render correctly 1`] = `
                     </div>
                   </Group>
                 </ModeSelector>
+                <div
+                  className="row"
+                >
+                  <div
+                    className="col-xs-4"
+                  >
+                    <EgressModeSelector
+                      disabled={true}
+                      profileRequest={
+                        Object {
+                          "accessModes": "WALK",
+                          "bikeSafe": 1,
+                          "bikeSlope": 1,
+                          "bikeSpeed": 4.166666666666667,
+                          "bikeTime": 1,
+                          "bikeTrafficStress": 4,
+                          "carSpeed": 20,
+                          "date": "2016-01-16",
+                          "directModes": "WALK",
+                          "egressModes": "WALK",
+                          "fromTime": 25200,
+                          "maxBikeTime": 20,
+                          "maxCarTime": 45,
+                          "maxRides": 4,
+                          "maxWalkTime": 20,
+                          "minBikeTime": 10,
+                          "minCarTime": 10,
+                          "monteCarloDraws": 200,
+                          "reachabilityThreshold": 0,
+                          "streetTime": 90,
+                          "suboptimalMinutes": 5,
+                          "toTime": 32400,
+                          "transitModes": "TRANSIT",
+                          "walkSpeed": 1.3888888888888888,
+                        }
+                      }
+                      setProfileRequest={[Function]}
+                    >
+                      <Group
+                        label="Egress Modes"
+                      >
+                        <div
+                          className="form-group"
+                        >
+                          <label
+                            htmlFor="egress-modes-input-6"
+                          >
+                            Egress Modes
+                          </label>
+                          <br />
+                          <Group
+                            disabled={true}
+                          >
+                            <div
+                              className="btn-group"
+                              disabled={true}
+                            >
+                              <Button
+                                active={true}
+                                onClick={[Function]}
+                                title="Walk"
+                              >
+                                <a
+                                  className="btn btn-default active"
+                                  href="#"
+                                  onClick={[Function]}
+                                  tabIndex={0}
+                                  title="Walk"
+                                >
+                                  <Icon
+                                    type="male"
+                                  >
+                                    <i
+                                      className="fa fa-male fa-fw "
+                                    />
+                                  </Icon>
+                                </a>
+                              </Button>
+                              <Button
+                                active={false}
+                                disabled={true}
+                                onClick={[Function]}
+                                title="Bike"
+                              >
+                                <a
+                                  className="btn btn-default"
+                                  disabled={true}
+                                  href="#"
+                                  onClick={[Function]}
+                                  tabIndex={0}
+                                  title="Bike"
+                                >
+                                  <Icon
+                                    type="bicycle"
+                                  >
+                                    <i
+                                      className="fa fa-bicycle fa-fw "
+                                    />
+                                  </Icon>
+                                </a>
+                              </Button>
+                            </div>
+                          </Group>
+                        </div>
+                      </Group>
+                    </EgressModeSelector>
+                  </div>
+                  <div
+                    className="col-xs-4"
+                  >
+                    <Number
+                      disabled={false}
+                      label="Walk Speed (km/h)"
+                      max={15}
+                      min={3}
+                      name="walkSpeed"
+                      onChange={[Function]}
+                      step={0.1}
+                      value={5}
+                    >
+                      <Group
+                        disabled={false}
+                        id="walk-speed-input-7"
+                        label="Walk Speed (km/h)"
+                        max={15}
+                        min={3}
+                        name="walkSpeed"
+                        onChange={[Function]}
+                        step={0.1}
+                        value={5}
+                      >
+                        <div
+                          className="form-group"
+                        >
+                          <label
+                            htmlFor="walk-speed-input-7"
+                          >
+                            Walk Speed (km/h)
+                          </label>
+                          <Input
+                            disabled={false}
+                            id="walk-speed-input-7"
+                            label="Walk Speed (km/h)"
+                            max={15}
+                            min={3}
+                            name="walkSpeed"
+                            onChange={[Function]}
+                            onWheel={[Function]}
+                            step={0.1}
+                            type="number"
+                            value={5}
+                          >
+                            <input
+                              className="form-control"
+                              disabled={false}
+                              id="walk-speed-input-7"
+                              max={15}
+                              min={3}
+                              name="walkSpeed"
+                              onChange={[Function]}
+                              onWheel={[Function]}
+                              placeholder="Walk Speed (km/h)"
+                              step={0.1}
+                              type="number"
+                              value={5}
+                            />
+                          </Input>
+                        </div>
+                      </Group>
+                    </Number>
+                  </div>
+                  <div
+                    className="col-xs-4"
+                  >
+                    <Number
+                      disabled={true}
+                      label="Bike Speed (km/h)"
+                      max={20}
+                      min={5}
+                      name="bikeSpeed"
+                      onChange={[Function]}
+                      step={0.1}
+                      value={15}
+                    >
+                      <Group
+                        disabled={true}
+                        id="bike-speed-input-8"
+                        label="Bike Speed (km/h)"
+                        max={20}
+                        min={5}
+                        name="bikeSpeed"
+                        onChange={[Function]}
+                        step={0.1}
+                        value={15}
+                      >
+                        <div
+                          className="form-group"
+                        >
+                          <label
+                            htmlFor="bike-speed-input-8"
+                          >
+                            Bike Speed (km/h)
+                          </label>
+                          <Input
+                            disabled={true}
+                            id="bike-speed-input-8"
+                            label="Bike Speed (km/h)"
+                            max={20}
+                            min={5}
+                            name="bikeSpeed"
+                            onChange={[Function]}
+                            onWheel={[Function]}
+                            step={0.1}
+                            type="number"
+                            value={15}
+                          >
+                            <input
+                              className="form-control"
+                              disabled={true}
+                              id="bike-speed-input-8"
+                              max={20}
+                              min={5}
+                              name="bikeSpeed"
+                              onChange={[Function]}
+                              onWheel={[Function]}
+                              placeholder="Bike Speed (km/h)"
+                              step={0.1}
+                              type="number"
+                              value={15}
+                            />
+                          </Input>
+                        </div>
+                      </Group>
+                    </Number>
+                  </div>
+                </div>
                 <div
                   className="row"
                 >
@@ -2122,7 +2359,7 @@ exports[`Components > Analysis > Single Point should render correctly 1`] = `
                       >
                         <Group
                           disabled={false}
-                          id="from-time-input-6"
+                          id="from-time-input-9"
                           label="From time"
                           name="fromTime"
                           onChange={[Function]}
@@ -2135,13 +2372,13 @@ exports[`Components > Analysis > Single Point should render correctly 1`] = `
                             className="form-group"
                           >
                             <label
-                              htmlFor="from-time-input-6"
+                              htmlFor="from-time-input-9"
                             >
                               From time
                             </label>
                             <Input
                               disabled={false}
-                              id="from-time-input-6"
+                              id="from-time-input-9"
                               label="From time"
                               name="fromTime"
                               onChange={[Function]}
@@ -2156,7 +2393,7 @@ exports[`Components > Analysis > Single Point should render correctly 1`] = `
                                 <input
                                   className="form-control"
                                   disabled={false}
-                                  id="from-time-input-6"
+                                  id="from-time-input-9"
                                   name="fromTime"
                                   onChange={[Function]}
                                   onWheel={[Function]}
@@ -2198,7 +2435,7 @@ exports[`Components > Analysis > Single Point should render correctly 1`] = `
                       >
                         <Group
                           disabled={false}
-                          id="to-time-input-7"
+                          id="to-time-input-10"
                           label="To time"
                           name="toTime"
                           onChange={[Function]}
@@ -2211,13 +2448,13 @@ exports[`Components > Analysis > Single Point should render correctly 1`] = `
                             className="form-group"
                           >
                             <label
-                              htmlFor="to-time-input-7"
+                              htmlFor="to-time-input-10"
                             >
                               To time
                             </label>
                             <Input
                               disabled={false}
-                              id="to-time-input-7"
+                              id="to-time-input-10"
                               label="To time"
                               name="toTime"
                               onChange={[Function]}
@@ -2232,7 +2469,7 @@ exports[`Components > Analysis > Single Point should render correctly 1`] = `
                                 <input
                                   className="form-control"
                                   disabled={false}
-                                  id="to-time-input-7"
+                                  id="to-time-input-10"
                                   name="toTime"
                                   onChange={[Function]}
                                   onWheel={[Function]}
@@ -2271,7 +2508,7 @@ exports[`Components > Analysis > Single Point should render correctly 1`] = `
                     >
                       <Group
                         disabled={false}
-                        id="max-transfers-input-8"
+                        id="max-transfers-input-11"
                         label="Maximum transfers"
                         max={7}
                         min={0}
@@ -2284,13 +2521,13 @@ exports[`Components > Analysis > Single Point should render correctly 1`] = `
                           className="form-group"
                         >
                           <label
-                            htmlFor="max-transfers-input-8"
+                            htmlFor="max-transfers-input-11"
                           >
                             Maximum transfers
                           </label>
                           <Input
                             disabled={false}
-                            id="max-transfers-input-8"
+                            id="max-transfers-input-11"
                             label="Maximum transfers"
                             max={7}
                             min={0}
@@ -2304,7 +2541,7 @@ exports[`Components > Analysis > Single Point should render correctly 1`] = `
                             <input
                               className="form-control"
                               disabled={false}
-                              id="max-transfers-input-8"
+                              id="max-transfers-input-11"
                               max={7}
                               min={0}
                               name="maxTransfers"
@@ -2335,7 +2572,7 @@ exports[`Components > Analysis > Single Point should render correctly 1`] = `
                     >
                       <Group
                         disabled={false}
-                        id="monte-carlo-draws-input-9"
+                        id="monte-carlo-draws-input-12"
                         label="Number of simulated schedules"
                         max={10000}
                         min={1}
@@ -2348,13 +2585,13 @@ exports[`Components > Analysis > Single Point should render correctly 1`] = `
                           className="form-group"
                         >
                           <label
-                            htmlFor="monte-carlo-draws-input-9"
+                            htmlFor="monte-carlo-draws-input-12"
                           >
                             Number of simulated schedules
                           </label>
                           <Input
                             disabled={false}
-                            id="monte-carlo-draws-input-9"
+                            id="monte-carlo-draws-input-12"
                             label="Number of simulated schedules"
                             max={10000}
                             min={1}
@@ -2368,7 +2605,7 @@ exports[`Components > Analysis > Single Point should render correctly 1`] = `
                             <input
                               className="form-control"
                               disabled={false}
-                              id="monte-carlo-draws-input-9"
+                              id="monte-carlo-draws-input-12"
                               max={10000}
                               min={1}
                               name="monteCarloDraws"
@@ -2394,7 +2631,7 @@ exports[`Components > Analysis > Single Point should render correctly 1`] = `
                 className="form-group"
               >
                 <label
-                  htmlFor="bounds-of-analysis-input-10"
+                  htmlFor="bounds-of-analysis-input-13"
                 >
                   Bounds of analysis
                 </label>
@@ -2583,7 +2820,7 @@ exports[`Components > Analysis > Single Point should render correctly 1`] = `
             >
               <Group
                 disabled={false}
-                id="percentile-of-travel-time-reliability-regional-analysis-only-input-11"
+                id="percentile-of-travel-time-reliability-regional-analysis-only-input-14"
                 label="Percentile of travel time (reliability) -- Regional analysis only"
                 max={99}
                 min={1}
@@ -2595,20 +2832,20 @@ exports[`Components > Analysis > Single Point should render correctly 1`] = `
                   className="form-group"
                 >
                   <label
-                    htmlFor="percentile-of-travel-time-reliability-regional-analysis-only-input-11"
+                    htmlFor="percentile-of-travel-time-reliability-regional-analysis-only-input-14"
                   >
                     Percentile of travel time (reliability) -- Regional analysis only
                   </label>
                   <output
                     className="pull-right"
-                    htmlFor="percentile-of-travel-time-reliability-regional-analysis-only-input-11"
+                    htmlFor="percentile-of-travel-time-reliability-regional-analysis-only-input-14"
                   >
                     50.0
                   </output>
                   <input
                     className="form-control"
                     disabled={false}
-                    id="percentile-of-travel-time-reliability-regional-analysis-only-input-11"
+                    id="percentile-of-travel-time-reliability-regional-analysis-only-input-14"
                     label="Percentile of travel time (reliability) -- Regional analysis only"
                     max={99}
                     min={1}

--- a/lib/containers/__tests__/__snapshots__/single-point-analysis.js.snap
+++ b/lib/containers/__tests__/__snapshots__/single-point-analysis.js.snap
@@ -1081,7 +1081,16 @@ exports[`Components > Analysis > Single Point should render correctly 1`] = `
                       }
                     }
                   >
-                    Mock Scenario: Default 0
+                    <div
+                      className="scenario-name"
+                    >
+                      Mock Scenario: Default (Median)
+                    </div>
+                  </div>
+                  <div
+                    className="statistic"
+                  >
+                    0
                   </div>
                 </div>
                 <Group
@@ -1573,10 +1582,13 @@ exports[`Components > Analysis > Single Point should render correctly 1`] = `
                           </Button>
                           <Button
                             active={true}
+                            disabled={true}
+                            onClick={[Function]}
                             title="Transit"
                           >
                             <a
                               className="btn btn-default active"
+                              disabled={true}
                               href="#"
                               onClick={[Function]}
                               tabIndex={0}

--- a/lib/styles.css
+++ b/lib/styles.css
@@ -587,6 +587,17 @@ label {
   margin-bottom: 6px;
 }
 
+.progress-bar .scenario-name {
+  color: #333;
+  text-align: left;
+}
+
+.progress .statistic {
+  color: #333;
+  position: absolute;
+  right: 18px;
+}
+
 .pad-right {
   padding-right: 12px;
 }

--- a/lib/types.js
+++ b/lib/types.js
@@ -249,6 +249,7 @@ export type Modification =
 
 export type ProfileRequest = {
   accessModes: string,
+  egressModes: string,
   directModes: string,
   fromTime: number,
   toTime: number,


### PR DESCRIPTION
Users should be able to select between walking/bike for access/egress legs, and set speeds for these modes.  This PR adds related components to the front-end, but disables some of them until back-end issues are resolved.