### PR TITLE
Fix and enable bundle editing

### DIFF
--- a/configurations/default/messages.yml
+++ b/configurations/default/messages.yml
@@ -13,6 +13,7 @@ bundle:
   delete: Delete this bundle
   deleteConfirmation: Are you sure you would like to delete this bundle? Projects using this bundle will no longer work.
   edit: Edit bundle
+  save: Save bundle
 map:
   northAbbr: N # Local abbreviation for north, used to label north arrow
 nav:

--- a/lib/components/__tests__/__snapshots__/edit-bundle.js.snap
+++ b/lib/components/__tests__/__snapshots__/edit-bundle.js.snap
@@ -28,6 +28,7 @@ exports[`Component > EditBundle renders correctly 1`] = `
     href="#"
     onClick={[Function]}
     tabIndex={0}
+    title="Save bundle"
   >
     <i
       className="fa fa-save fa-fw "

--- a/lib/components/__tests__/__snapshots__/edit-bundle.js.snap
+++ b/lib/components/__tests__/__snapshots__/edit-bundle.js.snap
@@ -33,7 +33,7 @@ exports[`Component > EditBundle renders correctly 1`] = `
       className="fa fa-save fa-fw "
     />
      
-    Edit bundle
+    Save bundle
   </a>
   <a
     className="btn btn-danger btn-block"

--- a/lib/components/edit-bundle.js
+++ b/lib/components/edit-bundle.js
@@ -97,7 +97,7 @@ export default class EditBundle extends Component {
           />
         ))}
 
-        <Button block onClick={this._submit} style='success'>
+        <Button block onClick={this._submit} title={messages.bundle.save} style='success'>
           <Icon type='save' /> {messages.bundle.save}
         </Button>
 

--- a/lib/components/edit-bundle.js
+++ b/lib/components/edit-bundle.js
@@ -87,13 +87,10 @@ export default class EditBundle extends Component {
           value={bundle.name}
         />
 
-        {bundle.feeds.map(feed => (
+        {bundle.feeds.map((feed, index) => (
           <Text
-            disabled
-            title='Editing temporarily disabled'
             key={feed.feedId}
-            label={`Feed #${feed.checksum}`}
-            name='Feed'
+            label={`Feed #${index + 1}`}
             onChange={this._setFeedName(feed.feedId)}
             placeholder='Feed name'
             value={feed.name}
@@ -101,7 +98,7 @@ export default class EditBundle extends Component {
         ))}
 
         <Button block onClick={this._submit} style='success'>
-          <Icon type='save' /> {messages.bundle.edit}
+          <Icon type='save' /> {messages.bundle.save}
         </Button>
 
         <Button block style='danger' onClick={this._deleteBundle}>

--- a/lib/components/modification/remove-trips.js
+++ b/lib/components/modification/remove-trips.js
@@ -1,5 +1,7 @@
 // @flow
 import React from 'react'
+import memoize from 'lodash/memoize'
+import omit from 'lodash/omit'
 
 import SelectFeedRouteAndPatterns from './select-feed-route-and-patterns'
 
@@ -13,6 +15,10 @@ type Props = {
   update(any): void
 }
 
+const filterOutPatterns = memoize((update: (any) => void) =>
+  (modification: any) =>
+    update(omit(modification, ['patterns'])))
+
 /**
  * Select routes or trips to remove
  */
@@ -25,7 +31,7 @@ export default ({
 }: Props) => (
   <SelectFeedRouteAndPatterns
     feeds={feeds}
-    onChange={update}
+    onChange={filterOutPatterns(update)}
     routePatterns={routePatterns}
     routes={modification.routes}
     selectedFeed={selectedFeed}

--- a/lib/containers/__tests__/__snapshots__/edit-bundle.js.snap
+++ b/lib/containers/__tests__/__snapshots__/edit-bundle.js.snap
@@ -1,0 +1,141 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Container > Edit Bundle renders correctly 1`] = `
+<Provider
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+>
+  <Connect(EditBundle)
+    params={
+      Object {
+        "bundleId": "1",
+      }
+    }
+  >
+    <EditBundle
+      bundle={
+        Object {
+          "centerLat": 38.90124,
+          "centerLon": -77.015615,
+          "feeds": Array [],
+          "id": "1",
+          "name": "Mock Bundle",
+        }
+      }
+      bundleId="1"
+      deleteBundle={[Function]}
+      params={
+        Object {
+          "bundleId": "1",
+        }
+      }
+      saveBundle={[Function]}
+    >
+      <div>
+        <h5>
+          Edit Bundle
+        </h5>
+        <Text
+          label="Bundle name"
+          name="Name"
+          onChange={[Function]}
+          placeholder="Bundle name"
+          value="Mock Bundle"
+        >
+          <Group
+            id="name-input-0"
+            label="Bundle name"
+            name="Name"
+            onChange={[Function]}
+            placeholder="Bundle name"
+            value="Mock Bundle"
+          >
+            <div
+              className="form-group"
+            >
+              <label
+                htmlFor="name-input-0"
+              >
+                Bundle name
+              </label>
+              <Input
+                id="name-input-0"
+                label="Bundle name"
+                name="Name"
+                onChange={[Function]}
+                placeholder="Bundle name"
+                type="text"
+                value="Mock Bundle"
+              >
+                <input
+                  className="form-control"
+                  id="name-input-0"
+                  name="Name"
+                  onChange={[Function]}
+                  placeholder="Bundle name"
+                  type="text"
+                  value="Mock Bundle"
+                />
+              </Input>
+            </div>
+          </Group>
+        </Text>
+        <Button
+          block={true}
+          onClick={[Function]}
+          style="success"
+          title="Save bundle"
+        >
+          <a
+            className="btn btn-success btn-block"
+            href="#"
+            onClick={[Function]}
+            tabIndex={0}
+            title="Save bundle"
+          >
+            <Icon
+              type="save"
+            >
+              <i
+                className="fa fa-save fa-fw "
+              />
+            </Icon>
+             
+            Save bundle
+          </a>
+        </Button>
+        <Button
+          block={true}
+          onClick={[Function]}
+          style="danger"
+        >
+          <a
+            className="btn btn-danger btn-block"
+            href="#"
+            onClick={[Function]}
+            tabIndex={0}
+          >
+            <Icon
+              type="trash"
+            >
+              <i
+                className="fa fa-trash fa-fw "
+              />
+            </Icon>
+             
+            Delete this bundle
+          </a>
+        </Button>
+      </div>
+    </EditBundle>
+  </Connect(EditBundle)>
+</Provider>
+`;

--- a/lib/containers/__tests__/edit-bundle.js
+++ b/lib/containers/__tests__/edit-bundle.js
@@ -1,0 +1,28 @@
+/* global describe, expect, it */
+
+describe('Container > Edit Bundle', () => {
+  const {mount} = require('enzyme')
+  const {mountToJson} = require('enzyme-to-json')
+  // const nock = require('nock')
+  const React = require('react')
+  const {Provider} = require('react-redux')
+  const {makeMockStore, mockStores} = require('../../utils/mock-data')
+
+  it('renders correctly', () => {
+    const EditBundle = require('../edit-bundle')
+    const mockStore = makeMockStore(mockStores.init)
+
+    // const postNock = nock('http://mockhost.com').post(`/api/bundle`).reply(200)
+
+    // mount component
+    const wrapper = mount(
+      <Provider store={mockStore}>
+        <EditBundle params={{
+          bundleId: '1'
+        }} />
+      </Provider>
+    )
+
+    expect(mountToJson(wrapper)).toMatchSnapshot()
+  })
+})

--- a/lib/containers/adjust-dwell-time.js
+++ b/lib/containers/adjust-dwell-time.js
@@ -2,6 +2,7 @@
 import {connect} from 'react-redux'
 
 import AdjustDwellTime from '../components/modification/adjust-dwell-time'
+import selectFeedsWithBundleNames from '../selectors/feeds-with-bundle-names'
 import selectModificationFeed from '../selectors/modification-feed'
 import selectRoutePatterns from '../selectors/route-patterns'
 import selectRouteStops from '../selectors/route-stops'
@@ -14,7 +15,7 @@ function mapStateToProps (
   ownProps: {modification: Modification}
 ): any {
   return {
-    feeds: state.scenario.feeds,
+    feeds: selectFeedsWithBundleNames(state, ownProps),
     routePatterns: selectRoutePatterns(state, ownProps),
     routeStops: selectRouteStops(state, ownProps),
     selectedFeed: selectModificationFeed(state, ownProps),

--- a/lib/containers/convert-to-frequency.js
+++ b/lib/containers/convert-to-frequency.js
@@ -9,6 +9,7 @@ import selectFullyQualifiedRouteStops
   from '../selectors/fully-qualified-route-stops'
 import selectRoutePatterns from '../selectors/route-patterns'
 import selectScenarioTimetables from '../selectors/scenario-timetables'
+import selectFeedsWithBundleNames from '../selectors/feeds-with-bundle-names'
 import selectModificationFeed from '../selectors/modification-feed'
 
 import type {Modification} from '../types'
@@ -22,7 +23,7 @@ function mapStateToProps (
       state,
       ownProps
     ),
-    feeds: state.scenario.feeds,
+    feeds: selectFeedsWithBundleNames(state, ownProps),
     fullyQualifiedRouteStops: selectFullyQualifiedRouteStops(state, ownProps),
     routePatterns: selectRoutePatterns(state, ownProps),
     scenarioTimetables: selectScenarioTimetables(state, ownProps),

--- a/lib/containers/remove-stops.js
+++ b/lib/containers/remove-stops.js
@@ -5,6 +5,7 @@ import RemoveStops from '../components/modification/remove-stops'
 import selectModificationFeed from '../selectors/modification-feed'
 import selectRoutePatterns from '../selectors/route-patterns'
 import selectRouteStops from '../selectors/route-stops'
+import selectFeedsWithBundleNames from '../selectors/feeds-with-bundle-names'
 import selectSelectedStops from '../selectors/selected-stops'
 
 import type {Modification} from '../types'
@@ -14,7 +15,7 @@ function mapStateToProps (
   ownProps: {modification: Modification}
 ): any {
   return {
-    feeds: state.scenario.feeds,
+    feeds: selectFeedsWithBundleNames(state, ownProps),
     routePatterns: selectRoutePatterns(state, ownProps),
     routeStops: selectRouteStops(state, ownProps),
     selectedFeed: selectModificationFeed(state, ownProps),

--- a/lib/containers/remove-trips.js
+++ b/lib/containers/remove-trips.js
@@ -2,6 +2,7 @@
 import {connect} from 'react-redux'
 
 import RemoveTrips from '../components/modification/remove-trips'
+import selectFeedsWithBundleNames from '../selectors/feeds-with-bundle-names'
 import selectModificationFeed from '../selectors/modification-feed'
 import selectRoutePatterns from '../selectors/route-patterns'
 
@@ -12,7 +13,7 @@ function mapStateToProps (
   ownProps: {modification: Modification}
 ): any {
   return {
-    feeds: state.scenario.feeds,
+    feeds: selectFeedsWithBundleNames(state, ownProps),
     routePatterns: selectRoutePatterns(state, ownProps),
     selectedFeed: selectModificationFeed(state, ownProps)
   }

--- a/lib/containers/reroute.js
+++ b/lib/containers/reroute.js
@@ -5,6 +5,7 @@ import Reroute from '../components/modification/reroute'
 import selectModificationFeed from '../selectors/modification-feed'
 import selectQualifiedStops from '../selectors/qualified-stops-from-segments'
 import selectSegmentDistances from '../selectors/segment-distances'
+import selectFeedsWithBundleNames from '../selectors/feeds-with-bundle-names'
 import selectStopsFromModification from '../selectors/stops-from-modification'
 import selectRoutePatterns from '../selectors/route-patterns'
 
@@ -15,7 +16,7 @@ function mapStateToProps (
   ownProps: {modification: Modification}
 ): any {
   return {
-    feeds: state.scenario.feeds,
+    feeds: selectFeedsWithBundleNames(state, ownProps),
     mapState: state.mapState,
     qualifiedStops: selectQualifiedStops(state, ownProps),
     routePatterns: selectRoutePatterns(state, ownProps),

--- a/lib/reducers/__tests__/__snapshots__/scenario.js.snap
+++ b/lib/reducers/__tests__/__snapshots__/scenario.js.snap
@@ -97,9 +97,7 @@ Object {
       "id": "1",
     },
   ],
-  "currentScenario": Object {
-    "bundleId": undefined,
-  },
+  "currentScenario": Object {},
 }
 `;
 

--- a/lib/reducers/scenario.js
+++ b/lib/reducers/scenario.js
@@ -1,3 +1,6 @@
+const replace = predicate => replacement => element =>
+  predicate(element) ? replacement : element
+
 function createInitialState () {
   return {
     bundles: [],
@@ -62,21 +65,17 @@ export const reducers = {
   'log out' (state, action) {
     return createInitialState()
   },
-  'set bundle' (state, action) {
-    const currentBundle = action.payload
-    const {id} = currentBundle
-    return {
-      ...state,
-      currentScenario: {
-        ...state.currentScenario,
-        bundleId: id
-      }
-    }
-  },
   'set bundles' (state, action) {
     return {
       ...state,
       bundles: [...action.payload]
+    }
+  },
+  'set bundle' (state, action) {
+    const predicate = bundle => bundle.id === action.payload.id
+    return {
+      ...state,
+      bundles: state.bundles.map(replace(predicate)(action.payload))
     }
   },
   'set feeds' (state, action) {

--- a/lib/selectors/current-scenario-id.js
+++ b/lib/selectors/current-scenario-id.js
@@ -10,7 +10,7 @@ export default createSelector(
   (activeModification, currentScenario, routeParams) =>
     (activeModification
       ? activeModification.scenario
-      : currentScenario
+      : currentScenario && currentScenario.id
           ? currentScenario.id
           : routeParams && routeParams.scenarioId)
 )

--- a/lib/utils/mock-data.js
+++ b/lib/utils/mock-data.js
@@ -152,7 +152,8 @@ export const mockBundle = {
   name: 'Mock Bundle',
   id: '1',
   centerLat: 38.90124,
-  centerLon: -77.015615
+  centerLon: -77.015615,
+  feeds: []
 }
 
 export const mockProfileRequest = {


### PR DESCRIPTION
Fix mismatches when editing bundles and navigating to projects afterwards.

NOTE: This does not modify/fix how we name feeds (from the agency list) aka the Amtrak -> Martz Trailways problem that @ansoncfit noticed. I initially went down the path of updating that but due to discussions of possibly changing how we handle bundles/feeds in the future I didn't end up wanting to muck around with that too much. 

So you can just manually change it to the appropriate name for now 👍 

