### PR TITLE
Outdated r5 warning

### DIFF
--- a/configurations/default/messages.yml
+++ b/configurations/default/messages.yml
@@ -49,16 +49,16 @@ region:
   deleteConfirmation: Are you sure you would like to delete this region? This will delete all associated scenarios and modifications.
   editAction: Save changes
   editTitle: Edit region
-  versionOutdated: The chosen analysis backend version of this region is outdated.
+  versionOutdated: This region's Analysis backend is outdated and may cause errors.
   editProject: Edit region
   loadingProject: Loading region…
   osmBounds: OpenStreetMap bounds
   r5Version: Analysis backend version
-  latestReleaseVersionNotSelected: There is a more recent version of the analysis backend available.
-    Changing backend versions may enable new features or increased performance, but may also cause
-    existing analysis results to change slightly.
-  showAllVersions: Show all analysis backend versions (advanced)
-  showReleaseVersions: Show only release backend versions
+  latestReleaseVersionNotSelected: There is an updated version of the Analysis backend available.
+    Changing versions may enable new features or increased performance, but may also cause
+    results to change slightly.
+  showAllVersions: Show all backend versions (advanced)
+  showReleaseVersions: Show only stable backend versions
   loadStatus:
     UPLOADING_OSM: Uploading OpenStreetMap data…
     DOWNLOADING_OSM: Downloading OpenStreetMap data…

--- a/configurations/default/messages.yml
+++ b/configurations/default/messages.yml
@@ -72,6 +72,7 @@ project:
   createAction: Create new Project
   createActionTooltip: Each project can include scenarios with modifications that are applied to the same GTFS bundle.
   delete: Delete project
+  name: Project name
   deleteConfirmation: Are you sure you would like to delete this project?
   editAction: Save project
   editTitle: Edit project

--- a/lib/components/__tests__/__snapshots__/edit-project.js.snap
+++ b/lib/components/__tests__/__snapshots__/edit-project.js.snap
@@ -56,7 +56,7 @@ exports[`Component > EditProject renders correctly 1`] = `
             Analysis backend version
           </label>
           <i
-            aria-label="Show all analysis backend versions (advanced)"
+            aria-label="Show all backend versions (advanced)"
             className="fa fa-flask fa-fw "
             onClick={[Function]}
             style={
@@ -65,7 +65,7 @@ exports[`Component > EditProject renders correctly 1`] = `
                 "cursor": "pointer",
               }
             }
-            title="Show all analysis backend versions (advanced)"
+            title="Show all backend versions (advanced)"
           />
           <div
             className="Select Select--single is-searchable has-value"

--- a/lib/components/__tests__/__snapshots__/edit-scenario.js.snap
+++ b/lib/components/__tests__/__snapshots__/edit-scenario.js.snap
@@ -30,10 +30,10 @@ exports[`Component > EditScenario renders correctly 1`] = `
     >
       <input
         className="form-control"
-        id="scenario-name-input-0"
-        name="Scenario name"
+        id="project-name-input-0"
+        name="Project name"
         onChange={[Function]}
-        placeholder="Scenario name"
+        placeholder="Project name"
         type="text"
         value="Mock Scenario"
       />

--- a/lib/components/__tests__/__snapshots__/r5-version.js.snap
+++ b/lib/components/__tests__/__snapshots__/r5-version.js.snap
@@ -11,7 +11,7 @@ exports[`Component > R5Version renders correctly 1`] = `
       Label
     </label>
     <i
-      aria-label="Show all analysis backend versions (advanced)"
+      aria-label="Show all backend versions (advanced)"
       className="fa fa-flask fa-fw "
       onClick={[Function]}
       style={
@@ -20,7 +20,7 @@ exports[`Component > R5Version renders correctly 1`] = `
           "cursor": "pointer",
         }
       }
-      title="Show all analysis backend versions (advanced)"
+      title="Show all backend versions (advanced)"
     />
     <div
       className="Select Select--single is-searchable has-value"
@@ -86,7 +86,7 @@ exports[`Component > R5Version should show flask for non-release versions 1`] = 
       Label
     </label>
     <i
-      aria-label="Show only release backend versions"
+      aria-label="Show only stable backend versions"
       className="fa fa-flask fa-fw "
       onClick={[Function]}
       style={
@@ -95,7 +95,7 @@ exports[`Component > R5Version should show flask for non-release versions 1`] = 
           "cursor": "pointer",
         }
       }
-      title="Show only release backend versions"
+      title="Show only stable backend versions"
     />
     <div
       className="Select Select--single is-searchable has-value"
@@ -150,9 +150,9 @@ exports[`Component > R5Version should show flask for non-release versions 1`] = 
   <div
     className="alert alert-warning"
   >
-    There is a more recent version of the analysis backend available.
-    Changing backend versions may enable new features or increased performance, but may also cause
-    existing analysis results to change slightly.
+    There is an updated version of the Analysis backend available.
+    Changing versions may enable new features or increased performance, but may also cause
+    results to change slightly.
   </div>
 </div>
 `;
@@ -168,7 +168,7 @@ exports[`Component > R5Version should show struck-out value for unknown/unsuppor
       Label
     </label>
     <i
-      aria-label="Show all analysis backend versions (advanced)"
+      aria-label="Show all backend versions (advanced)"
       className="fa fa-flask fa-fw "
       onClick={[Function]}
       style={
@@ -177,7 +177,7 @@ exports[`Component > R5Version should show struck-out value for unknown/unsuppor
           "cursor": "pointer",
         }
       }
-      title="Show all analysis backend versions (advanced)"
+      title="Show all backend versions (advanced)"
     />
     <div
       className="Select Select--single is-searchable has-value"
@@ -240,9 +240,9 @@ exports[`Component > R5Version should show struck-out value for unknown/unsuppor
   <div
     className="alert alert-warning"
   >
-    There is a more recent version of the analysis backend available.
-    Changing backend versions may enable new features or increased performance, but may also cause
-    existing analysis results to change slightly.
+    There is an updated version of the Analysis backend available.
+    Changing versions may enable new features or increased performance, but may also cause
+    results to change slightly.
   </div>
 </div>
 `;
@@ -258,7 +258,7 @@ exports[`Component > R5Version should show warning with out of date r5 version 1
       Label
     </label>
     <i
-      aria-label="Show all analysis backend versions (advanced)"
+      aria-label="Show all backend versions (advanced)"
       className="fa fa-flask fa-fw "
       onClick={[Function]}
       style={
@@ -267,7 +267,7 @@ exports[`Component > R5Version should show warning with out of date r5 version 1
           "cursor": "pointer",
         }
       }
-      title="Show all analysis backend versions (advanced)"
+      title="Show all backend versions (advanced)"
     />
     <div
       className="Select Select--single is-searchable has-value"
@@ -322,9 +322,9 @@ exports[`Component > R5Version should show warning with out of date r5 version 1
   <div
     className="alert alert-warning"
   >
-    There is a more recent version of the analysis backend available.
-    Changing backend versions may enable new features or increased performance, but may also cause
-    existing analysis results to change slightly.
+    There is an updated version of the Analysis backend available.
+    Changing versions may enable new features or increased performance, but may also cause
+    results to change slightly.
   </div>
 </div>
 `;

--- a/lib/components/edit-scenario.js
+++ b/lib/components/edit-scenario.js
@@ -78,7 +78,7 @@ export default class EditScenario extends PureComponent {
         </Heading>
         <Body>
           <Text
-            name='Scenario name'
+            name={messages.project.name}
             onChange={e => this.setState({...this.state, name: e.target.value})}
             value={name}
           />

--- a/lib/constants/analysis.js
+++ b/lib/constants/analysis.js
@@ -4,5 +4,5 @@ export const TRAVEL_TIME_PERCENTILES = [5, 25, 50, 75, 95]
 // Bucket where R5 JARs are to be found
 export const R5_BUCKET = 'https://r5-builds.s3.amazonaws.com'
 
-// versions prior to 2.2.0 don't include the TravelTimeSurface API we use to draw isochrones
-export const MINIMUM_R5_VERSION = 'v2.2.0'
+// versions prior to 3.1.0 have supergrid/subgrid problems
+export const MINIMUM_R5_VERSION = 'v3.1.0'


### PR DESCRIPTION
Adds a strongly worded warning for projects set to use R5 < v3.1.0

The warning appears in the project selection and regional settings views.  It hasn't yet been added to the scenario editing or analysis views, but those tend not to be accessed directly.