### PR TITLE
Reroute modifications

### DIFF
--- a/configurations/default/messages.yml
+++ b/configurations/default/messages.yml
@@ -4,6 +4,10 @@ common:
   help: help # stylized as lowercase since it's next to the conveyal analysis which is lowercase
   yes: yes
   no: no
+  select: Select
+  clear: Clear
+  addTo: Add to
+  removeFrom: Remove from
 authentication:
   logIn: Log in
   logOut: Log out
@@ -111,6 +115,8 @@ transitEditor:
   stopSpacingMeters: Stop spacing
   autoCreateStops: Create stops automatically
   extendFromEnd: Extend from end
+  fromStopLabel: Start of reroute/extension (existing stop on pattern)
+  toStopLabel: End of reroute/extension (existing stop on pattern)
 shapefile:
   invalidMultiLineString: MultiLineString feature in input shapefile has disjoint segments, cannot process.
   invalidShapefileType: Shapefile type must be LineString or MultiLineString

--- a/lib/components/modification/__tests__/__snapshots__/add-trip-pattern.js.snap
+++ b/lib/components/modification/__tests__/__snapshots__/add-trip-pattern.js.snap
@@ -5,6 +5,7 @@ exports[`Component > Modification > AddTripPattern renders correctly 1`] = `
   <div>
     <a
       className="btn btn-warning btn-block"
+      disabled={false}
       href="#"
       onClick={[Function]}
       tabIndex={0}

--- a/lib/components/modification/__tests__/__snapshots__/edit-alignment.js.snap
+++ b/lib/components/modification/__tests__/__snapshots__/edit-alignment.js.snap
@@ -4,6 +4,7 @@ exports[`Component > Modification > Edit Alignment renders correctly 1`] = `
 <div>
   <a
     className="btn btn-warning btn-block"
+    disabled={false}
     href="#"
     onClick={[Function]}
     tabIndex={0}

--- a/lib/components/modification/__tests__/__snapshots__/reroute.js.snap
+++ b/lib/components/modification/__tests__/__snapshots__/reroute.js.snap
@@ -113,6 +113,7 @@ exports[`Component > Modification > Reroute renders correctly 1`] = `
   <div>
     <a
       className="btn btn-warning btn-block"
+      disabled={true}
       href="#"
       onClick={[Function]}
       tabIndex={0}

--- a/lib/components/modification/add-trip-pattern.js
+++ b/lib/components/modification/add-trip-pattern.js
@@ -49,6 +49,7 @@ export default ({
       modification={modification}
       setMapState={setMapState}
       update={update}
+      disabled={false}
     />
 
     <Timetables

--- a/lib/components/modification/adjust-speed.js
+++ b/lib/components/modification/adjust-speed.js
@@ -87,10 +87,10 @@ export default class AdjustSpeedComponent extends Component<void, Props, void> {
           <FormGroup>
             <label htmlFor='Segment'>Segment</label>
             <Group justified>
-              <Button onClick={this.newSelection}>Select</Button>
-              <Button onClick={this.addToSelection}>Add to</Button>
-              <Button onClick={this.removeFromSelection}>Remove from</Button>
-              <Button onClick={this.clearSegment}>Clear</Button>
+              <Button onClick={this.newSelection}>{messages.common.select}</Button>
+              <Button onClick={this.addToSelection}>{messages.common.addTo}</Button>
+              <Button onClick={this.removeFromSelection}>{messages.common.removeFrom}</Button>
+              <Button onClick={this.clearSegment}>{messages.common.clear}</Button>
             </Group>
           </FormGroup>}
 

--- a/lib/components/modification/edit-alignment.js
+++ b/lib/components/modification/edit-alignment.js
@@ -19,6 +19,7 @@ type Props = {
   extendFromEnd: boolean,
   mapState: MapState,
   modification: any,
+  disabled: boolean,
 
   setMapState(any): void,
   update(any): void
@@ -145,7 +146,10 @@ export default class EditAlignment extends PureComponent<void, Props, State> {
     return (
       <div>
         {!isEditing
-          ? <Button block onClick={this._editOnMap} style='warning'>
+          ? <Button block
+            onClick={this._editOnMap}
+            style='warning'
+            disabled={this.props.disabled}>
             <Icon type='pencil' /> {messages.transitEditor.startEdit}
           </Button>
           : <Button block onClick={this._stopEditingOnMap} style='warning'>

--- a/lib/components/modification/edit-alignment.js
+++ b/lib/components/modification/edit-alignment.js
@@ -149,7 +149,7 @@ export default class EditAlignment extends PureComponent<void, Props, State> {
           ? <Button block
             onClick={this._editOnMap}
             style='warning'
-            disabled={this.props.disabled}>
+            disabled={this.props.disabled ? this.props.disabled : false}>
             <Icon type='pencil' /> {messages.transitEditor.startEdit}
           </Button>
           : <Button block onClick={this._stopEditingOnMap} style='warning'>

--- a/lib/components/modification/reroute.js
+++ b/lib/components/modification/reroute.js
@@ -10,6 +10,7 @@ import {
   MAP_STATE_SELECT_TO_STOP
 } from '../../constants'
 import {Group} from '../input'
+import messages from '../../utils/messages'
 
 import EditAlignment from './edit-alignment'
 import SelectFeedRouteAndPatterns from './select-feed-route-and-patterns'
@@ -93,8 +94,8 @@ export default class RerouteComponent extends Component<void, Props, void> {
       update
     } = this.props
     const hasFeedAndRoutes = selectedFeed && modification.routes
-    const fromStopLabel = `From stop: ${modification.fromStop && selectedFeed ? selectedFeed.stopsById[modification.fromStop].stop_name : '(none)'}`
-    const toStopLabel = `To stop: ${modification.toStop && selectedFeed ? selectedFeed.stopsById[modification.toStop].stop_name : '(none)'}`
+    const fromStopValue = `${modification.fromStop && selectedFeed ? selectedFeed.stopsById[modification.fromStop].stop_name : '(none)'}`
+    const toStopValue = `${modification.toStop && selectedFeed ? selectedFeed.stopsById[modification.toStop].stop_name : '(none)'}`
 
     let numberOfStops = stops.length
     // don't include dwells at first and last stops

--- a/lib/components/modification/reroute.js
+++ b/lib/components/modification/reroute.js
@@ -2,14 +2,14 @@
 import Icon from '@conveyal/woonerf/components/icon'
 import React, {Component} from 'react'
 
-import {Button} from '../buttons'
+import {Button, Group} from '../buttons'
 import {
   MAP_STATE_HIGHLIGHT_SEGMENT,
   MAP_STATE_HIGHLIGHT_STOP,
   MAP_STATE_SELECT_FROM_STOP,
   MAP_STATE_SELECT_TO_STOP
 } from '../../constants'
-import {Group} from '../input'
+import {Group as FormGroup} from '../input'
 import messages from '../../utils/messages'
 
 import EditAlignment from './edit-alignment'
@@ -80,6 +80,26 @@ export default class RerouteComponent extends Component<void, Props, void> {
     })
   }
 
+  _clearFromStop = () => {
+    const {update, modification} = this.props
+    if (modification.fromStop !== null) {
+      modification.segments.shift()
+      modification.fromStop = null
+      if (modification.segments.length === 0) { modification.toStop = null }
+      update(modification)
+    }
+  }
+
+  _clearToStop = () => {
+    const {update, modification} = this.props
+    if (modification.toStop !== null) {
+      modification.segments.pop()
+      if (modification.segments.length === 0) { modification.fromStop = null }
+      modification.toStop = null
+      update(modification)
+    }
+  }
+
   render () {
     const {
       feeds,
@@ -114,18 +134,29 @@ export default class RerouteComponent extends Component<void, Props, void> {
         />
 
         {hasFeedAndRoutes &&
-          <div>
-            <Group label={fromStopLabel}>
+          <FormGroup>
+            <label htmlFor='From Stop'>{messages.transitEditor.fromStopLabel}</label>
+            {fromStopValue}
+            <Group justified>
               <Button block onClick={this._selectFromStop} style='info'>
-                <Icon type='crosshairs' /> Select
+                <Icon type='crosshairs' /> {messages.common.select}
+              </Button>
+              <Button block onClick={this._clearFromStop} style='danger'>
+                <Icon type='times' /> {messages.common.clear}
               </Button>
             </Group>
-            <Group label={toStopLabel}>
+            <label htmlFor='To Stop'>{messages.transitEditor.toStopLabel}</label>
+            {toStopValue}
+            <Group justified>
               <Button block onClick={this._selectToStop} style='info'>
-                <Icon type='crosshairs' /> Select
+                <Icon type='crosshairs' /> {messages.common.select}
+              </Button>
+              <Button block onClick={this._clearToStop} style='danger'>
+                <Icon type='times' /> {messages.common.clear}
               </Button>
             </Group>
-          </div>}
+          </FormGroup>
+        }
 
         <EditAlignment
           extendFromEnd={modification.toStop == null}

--- a/lib/components/modification/reroute.js
+++ b/lib/components/modification/reroute.js
@@ -7,7 +7,8 @@ import {
   MAP_STATE_HIGHLIGHT_SEGMENT,
   MAP_STATE_HIGHLIGHT_STOP,
   MAP_STATE_SELECT_FROM_STOP,
-  MAP_STATE_SELECT_TO_STOP
+  MAP_STATE_SELECT_TO_STOP,
+  MAP_STATE_TRANSIT_EDITOR
 } from '../../constants'
 import {Group as FormGroup} from '../input'
 import messages from '../../utils/messages'
@@ -80,23 +81,34 @@ export default class RerouteComponent extends Component<void, Props, void> {
     })
   }
 
-  _clearFromStop = () => {
+  _updateAfterClearingStop = () => {
     const {update, modification} = this.props
+    update(modification)
+    this.props.setMapState({
+      allowExtend: modification.toStop === null || modification.fromStop === null,
+      extendFromEnd: modification.toStop === null,
+      spacing: 0,
+      state: MAP_STATE_TRANSIT_EDITOR
+    })
+  }
+
+  _clearFromStop = () => {
+    const {modification} = this.props
     if (modification.fromStop !== null) {
       modification.segments.shift()
       modification.fromStop = null
       if (modification.segments.length === 0) { modification.toStop = null }
-      update(modification)
+      this._updateAfterClearingStop()
     }
   }
 
   _clearToStop = () => {
-    const {update, modification} = this.props
+    const {modification} = this.props
     if (modification.toStop !== null) {
       modification.segments.pop()
       if (modification.segments.length === 0) { modification.fromStop = null }
       modification.toStop = null
-      update(modification)
+      this._updateAfterClearingStop()
     }
   }
 
@@ -159,6 +171,7 @@ export default class RerouteComponent extends Component<void, Props, void> {
         }
 
         <EditAlignment
+          allowExtend={modification.toStop == null || modification.fromStop == null}
           extendFromEnd={modification.toStop == null}
           mapState={mapState}
           modification={modification}

--- a/lib/components/modification/reroute.js
+++ b/lib/components/modification/reroute.js
@@ -164,6 +164,7 @@ export default class RerouteComponent extends Component<void, Props, void> {
           modification={modification}
           setMapState={setMapState}
           update={update}
+          disabled={modification.segments.length < 1}
         />
 
         <SegmentSpeeds

--- a/lib/components/scenario-map/index.js
+++ b/lib/components/scenario-map/index.js
@@ -311,8 +311,7 @@ export default class ScenarioMap extends Component<any, Props, any> {
                 })
               })
               setMapState({
-                state: null,
-                modification: null
+                state: MAP_STATE_TRANSIT_EDITOR
               })
             }}
             selectedColor={colors.ACTIVE}

--- a/lib/containers/__tests__/__snapshots__/modification-editor.js.snap
+++ b/lib/containers/__tests__/__snapshots__/modification-editor.js.snap
@@ -608,6 +608,7 @@ exports[`Container > Modification Editor render just the title if not loaded 1`]
                     >
                       <div>
                         <EditAlignment
+                          disabled={false}
                           extendFromEnd={true}
                           mapState={
                             Object {
@@ -703,11 +704,13 @@ exports[`Container > Modification Editor render just the title if not loaded 1`]
                           <div>
                             <Button
                               block={true}
+                              disabled={false}
                               onClick={[Function]}
                               style="warning"
                             >
                               <a
                                 className="btn btn-warning btn-block"
+                                disabled={false}
                                 href="#"
                                 onClick={[Function]}
                                 tabIndex={0}
@@ -2771,6 +2774,7 @@ exports[`Container > Modification Editor renders correctly 1`] = `
                     >
                       <div>
                         <EditAlignment
+                          disabled={false}
                           extendFromEnd={true}
                           mapState={
                             Object {
@@ -2866,11 +2870,13 @@ exports[`Container > Modification Editor renders correctly 1`] = `
                           <div>
                             <Button
                               block={true}
+                              disabled={false}
                               onClick={[Function]}
                               style="warning"
                             >
                               <a
                                 className="btn btn-warning btn-block"
+                                disabled={false}
                                 href="#"
                                 onClick={[Function]}
                                 tabIndex={0}

--- a/lib/utils/update-add-stops-terminus.js
+++ b/lib/utils/update-add-stops-terminus.js
@@ -53,7 +53,7 @@ export default function updateAddStopsTerminus ({
         }
       ]
     }
-  } else { // there is already at least one segment in the reroute
+  } else { // there is already at least one segment entry in the reroute
     const coordinates = [newStop.stop_lon, newStop.stop_lat]
     // TODO use the async functions in addStopToSegments?
 
@@ -73,25 +73,33 @@ export default function updateAddStopsTerminus ({
       // the new toStop will be added after a segment that precedes it
       const precSeg = modification.segments[modification.segments.length - 1]
       newSegment.geometry.type = 'LineString'
-      newSegment.geometry.coordinates.push(precSeg.geometry.coordinates[1])
+      if (precSeg.geometry.type === 'Point') {
+        newSegment.geometry.coordinates.push(precSeg.geometry.coordinates)
+        modification.segments.pop()
+      } else {
+        newSegment.geometry.coordinates.push(
+          precSeg.geometry.coordinates.slice(-1)[0]
+        )
+      }
       newSegment.geometry.coordinates.push(coordinates)
       newSegment.fromStopId = precSeg.toStopId
+      newSegment.stopAtStart = precSeg.stopAtEnd
       newSegment.toStopId = `${modification.feed}:${toStop.stop_id}`
-      if (precSeg.geometry.type === 'Point') {
-        modification.segments.pop()
-      }
       modification.segments.push(newSegment)
     } else {
       // the new fromStop will be added before a segment that succeeds it
       const succSeg = modification.segments[0]
       newSegment.geometry.type = 'LineString'
-      newSegment.geometry.coordinates.push(coordinates)
-      newSegment.geometry.coordinates.push(succSeg.geometry.coordinates[0])
-      newSegment.toStopId = succSeg.fromStopId
-      newSegment.fromStopId = `${modification.feed}:${fromStop.stop_id}`
       if (succSeg.geometry.type === 'Point') {
-        modification.segments.shift()
+        newSegment.geometry.coordinates.push(succSeg.geometry.coordinates)
+        modification.segments.pop()
+      } else {
+        newSegment.geometry.coordinates.push(succSeg.geometry.coordinates[0])
       }
+      newSegment.geometry.coordinates.unshift(coordinates)
+      newSegment.toStopId = succSeg.fromStopId
+      newSegment.stopAtEnd = succSeg.stopAtStart
+      newSegment.fromStopId = `${modification.feed}:${fromStop.stop_id}`
       modification.segments.unshift(newSegment)
     }
   }

--- a/lib/utils/update-add-stops-terminus.js
+++ b/lib/utils/update-add-stops-terminus.js
@@ -23,51 +23,77 @@ export default function updateAddStopsTerminus ({
 
   debug(`fromStop: ${fromStop}, toStop: ${toStop}`)
 
-  if (fromStop == null) {
-    modification.segments = [
-      {
-        geometry: {
-          type: 'Point',
-          coordinates: [toStop.stop_lon, toStop.stop_lat]
-        },
-        stopAtStart: true,
-        stopAtEnd: true,
-        fromStopId: `${modification.feed}:${toStop.stop_id}`,
-        toStopId: `${modification.feed}:${toStop.stop_id}`,
-        spacing: 0
+  if (modification.segments.length === 0) {
+    if (which === 'toStop') {
+      modification.segments = [
+        {
+          geometry: {
+            type: 'Point',
+            coordinates: [toStop.stop_lon, toStop.stop_lat]
+          },
+          stopAtStart: true,
+          stopAtEnd: true,
+          fromStopId: `${modification.feed}:${toStop.stop_id}`,
+          toStopId: `${modification.feed}:${toStop.stop_id}`,
+          spacing: 0
+        }
+      ]
+    } else {
+      modification.segments = [
+        {
+          geometry: {
+            type: 'Point',
+            coordinates: [fromStop.stop_lon, fromStop.stop_lat]
+          },
+          stopAtStart: true,
+          stopAtEnd: true,
+          fromStopId: `${modification.feed}:${fromStop.stop_id}`,
+          toStopId: `${modification.feed}:${fromStop.stop_id}`,
+          spacing: 0
+        }
+      ]
+    }
+  } else { // there is already at least one segment in the reroute
+    const coordinates = [newStop.stop_lon, newStop.stop_lat]
+    // TODO use the async functions in addStopToSegments?
+
+    const newSegment = {
+      fromStopId: null,
+      geometry: {
+        type: 'LineString',
+        coordinates: []
+      },
+      spacing: 0,
+      stopAtEnd: true,
+      stopAtStart: true,
+      toStopId: null
+    }
+
+    if (which === 'toStop') {
+      // the new toStop will be added after a segment that precedes it
+      const precSeg = modification.segments[modification.segments.length - 1]
+      newSegment.geometry.type = 'LineString'
+      newSegment.geometry.coordinates.push(precSeg.geometry.coordinates[1])
+      newSegment.geometry.coordinates.push(coordinates)
+      newSegment.fromStopId = precSeg.toStopId
+      newSegment.toStopId = `${modification.feed}:${toStop.stop_id}`
+      if (precSeg.geometry.type === 'Point') {
+        modification.segments.pop()
       }
-    ]
-  } else if (toStop == null) {
-    modification.segments = [
-      {
-        geometry: {
-          type: 'Point',
-          coordinates: [fromStop.stop_lon, fromStop.stop_lat]
-        },
-        stopAtStart: true,
-        stopAtEnd: true,
-        fromStopId: `${modification.feed}:${fromStop.stop_id}`,
-        toStopId: `${modification.feed}:${fromStop.stop_id}`,
-        spacing: 0
+      modification.segments.push(newSegment)
+    } else {
+      // the new fromStop will be added before a segment that succeeds it
+      const succSeg = modification.segments[0]
+      newSegment.geometry.type = 'LineString'
+      newSegment.geometry.coordinates.push(coordinates)
+      newSegment.geometry.coordinates.push(succSeg.geometry.coordinates[0])
+      newSegment.toStopId = succSeg.fromStopId
+      newSegment.fromStopId = `${modification.feed}:${fromStop.stop_id}`
+      if (succSeg.geometry.type === 'Point') {
+        modification.segments.shift()
       }
-    ]
-  } else {
-    modification.segments = [
-      {
-        geometry: {
-          type: 'LineString',
-          coordinates: [
-            [fromStop.stop_lon, fromStop.stop_lat],
-            [toStop.stop_lon, toStop.stop_lat]
-          ]
-        },
-        stopAtStart: true,
-        stopAtEnd: true,
-        fromStopId: `${modification.feed}:${fromStop.stop_id}`,
-        toStopId: `${modification.feed}:${toStop.stop_id}`,
-        spacing: 0
-      }
-    ]
+      modification.segments.unshift(newSegment)
+    }
   }
 
   modification.fromStop = fromStop != null ? fromStop.stop_id : null


### PR DESCRIPTION
This PR attempts to make reroute modifications more intuitive for users.  

1. From Stop and To Stop selection buttons are relabeled, clarifying that these are existing stops on the currently selected pattern.  
2. Edit alignment is disabled until fromStop or toStop has been selected
3. Users can now clear fromStop and toStop, and select different ones (resolving #105)

This is different approach than suggested in #104, but it may be usable enough to close that issue.

 