### PR TITLE
Reroute Fixes

### DIFF
--- a/lib/components/modification/reroute.js
+++ b/lib/components/modification/reroute.js
@@ -70,7 +70,7 @@ export default class RerouteComponent extends Component<void, Props, void> {
   }
 
   _selectFromStop = () => {
-    const{modification} = this.props
+    const {modification} = this.props
     this.props.setMapState({
       allowExtend: modification.toStop === null,
       extendFromEnd: true,
@@ -79,7 +79,7 @@ export default class RerouteComponent extends Component<void, Props, void> {
   }
 
   _selectToStop = () => {
-    const{modification} = this.props
+    const {modification} = this.props
     this.props.setMapState({
       allowExtend: modification.fromStop === null,
       extendFromEnd: false,

--- a/lib/components/modification/reroute.js
+++ b/lib/components/modification/reroute.js
@@ -33,9 +33,22 @@ type Props = {
 }
 
 /**
- * Reroute an existing line. Takes a start and end stop ID, and replaces all
- * stops between those with the specified routing/set of stops
+ * Reroute or extend an existing line.
+ *
+ * A reroute is specified with both a fromStop and toStop. Stops between those
+ * stops in the baseline pattern will be replaced by the stops added through the
+ * edit alignment functions in MAP_STATE_TRANSIT_EDITOR.  In the transit editor,
+ * allowExtend is set to false, because the start and end of the reroute are
+ * already set by fromStop and toStop.
+ *
+ * An extension is specified with either a fromStop or toStop. Stops added
+ * through the edit alignment functions in MAP_STATE_TRANSIT_EDITOR will be
+ * added to the baseline pattern.  If fromStop is set, extendFromEnd is set to
+ * true, and stops are appended to the end of the baseline pattern.  If
+ * toStop is set, extendFromEnd is set to false, and stops are prepended to
+ * the beginning of the baseline pattern.  In both cases, allowExtend is true.
  */
+
 export default class RerouteComponent extends Component<void, Props, void> {
   _onSelectorChange = ({
     feed,
@@ -72,7 +85,9 @@ export default class RerouteComponent extends Component<void, Props, void> {
   _selectFromStop = () => {
     const {modification} = this.props
     this.props.setMapState({
+      // don't allow extend if both fromStop and toStop are set.
       allowExtend: modification.toStop === null,
+      // append stops to end of pattern
       extendFromEnd: true,
       state: MAP_STATE_SELECT_FROM_STOP
     })
@@ -81,7 +96,9 @@ export default class RerouteComponent extends Component<void, Props, void> {
   _selectToStop = () => {
     const {modification} = this.props
     this.props.setMapState({
+      // don't allow extend if both fromStop and toStop are set.
       allowExtend: modification.fromStop === null,
+      // prepend stops to beginning of pattern
       extendFromEnd: false,
       state: MAP_STATE_SELECT_TO_STOP
     })

--- a/lib/components/modification/reroute.js
+++ b/lib/components/modification/reroute.js
@@ -70,13 +70,19 @@ export default class RerouteComponent extends Component<void, Props, void> {
   }
 
   _selectFromStop = () => {
+    const{modification} = this.props
     this.props.setMapState({
+      allowExtend: modification.toStop === null,
+      extendFromEnd: true,
       state: MAP_STATE_SELECT_FROM_STOP
     })
   }
 
   _selectToStop = () => {
+    const{modification} = this.props
     this.props.setMapState({
+      allowExtend: modification.fromStop === null,
+      extendFromEnd: false,
       state: MAP_STATE_SELECT_TO_STOP
     })
   }


### PR DESCRIPTION
Small fixes for #578 

-If only "Start of reroute/extension" (`fromStop`) is set, `extendFromEnd` should be true.
-If only "End of reroute/extension" (`toStop`) is set, `extendFromEnd` should be false (because we want to extend backwards from the start of the reroute segment).
-If both are selected, `allowExtend` should be false.