### PR TITLE
Debounce modification saving on the modification map

### DIFF
--- a/lib/components/modification/editor.js
+++ b/lib/components/modification/editor.js
@@ -3,6 +3,7 @@ import Icon from '@conveyal/woonerf/components/icon'
 import debounce from 'lodash/debounce'
 import React, {Component} from 'react'
 
+import {UPDATE_DELAY_MS} from '../../constants'
 import {Button} from '../buttons'
 import InnerDock from '../inner-dock'
 import {IconLink} from '../link'
@@ -18,8 +19,6 @@ import {Body as PanelBody} from '../panel'
 import messages from '../../utils/messages'
 
 import type {MapState, Modification} from '../../types'
-
-const UPDATE_DELAY_MS = 300
 
 type Props = {
   allVariants: string[],

--- a/lib/components/modifications-map/index.js
+++ b/lib/components/modifications-map/index.js
@@ -1,4 +1,5 @@
 // @flow
+import debounce from 'lodash/debounce'
 import React, {Component} from 'react'
 import {FeatureGroup} from 'react-leaflet'
 
@@ -16,7 +17,8 @@ import {
   MAP_STATE_TRANSIT_EDITOR,
   REMOVE_STOPS,
   REMOVE_TRIPS,
-  REROUTE
+  REROUTE,
+  UPDATE_DELAY_MS
 } from '../../constants'
 import colors from '../../constants/colors'
 import updateAddStopsTerminus from '../../utils/update-add-stops-terminus'
@@ -52,13 +54,13 @@ type Props = {
  * A map component showing a project
  */
 export default class ModificationsMap extends Component<any, Props, any> {
-  updateModification = (properties: any) => {
+  updateModification = debounce((properties: any) => {
     const {activeModification, replaceModification} = this.props
     replaceModification({
       ...activeModification,
       ...properties
     })
-  }
+  }, UPDATE_DELAY_MS)
 
   render () {
     const {

--- a/lib/constants/index.js
+++ b/lib/constants/index.js
@@ -46,3 +46,8 @@ export const MAP_STATE_STOP_SELECTION = 'map state stop selection'
 export const MAP_STATE_SINGLE_STOP_SELECTION = 'map state single stop selection'
 export const MAP_STATE_SELECT_FROM_STOP = 'map state select from stop'
 export const MAP_STATE_SELECT_TO_STOP = 'map state select to stop'
+
+/**
+ * Update delay so that we can batch updates to the server with debounce
+ */
+export const UPDATE_DELAY_MS = 300


### PR DESCRIPTION
Similar to the fix in the modification editor, debounce updates to prevent nonce clashing.