### PR TITLE
Reloading the regions incorrectly overwrote the bundles

### DIFF
--- a/lib/__tests__/__snapshots__/routes.js.snap
+++ b/lib/__tests__/__snapshots__/routes.js.snap
@@ -2713,6 +2713,7 @@ exports[`Routes should render 1`] = `
                   }
                 >
                   <SelectRegion
+                    clearCurrentRegion={[Function]}
                     loadAllRegions={[Function]}
                     location={
                       Object {

--- a/lib/components/__tests__/select-region.js
+++ b/lib/components/__tests__/select-region.js
@@ -1,11 +1,10 @@
-/* global describe, it, expect, jest */
-
 describe('Component > SelectRegion', () => {
   const renderer = require('react-test-renderer')
   const React = require('react')
   const SelectRegion = require('../select-region')
 
   it('renders correctly', () => {
+    const clearCurrentRegion = jest.fn()
     const createFn = jest.fn()
     const mockRegions = [{_id: 1, name: 'P1'}, {_id: 2, name: 'P2'}]
     const pushFn = jest.fn()
@@ -14,6 +13,7 @@ describe('Component > SelectRegion', () => {
       .create(
         <SelectRegion
           create={createFn}
+          clearCurrentRegion={clearCurrentRegion}
           loadAllRegions={loadAllRegions}
           regions={mockRegions}
           push={pushFn}
@@ -24,5 +24,6 @@ describe('Component > SelectRegion', () => {
     expect(createFn).not.toBeCalled()
     expect(pushFn).not.toBeCalled()
     expect(loadAllRegions).toBeCalled()
+    expect(clearCurrentRegion).toBeCalled()
   })
 })

--- a/lib/components/region.js
+++ b/lib/components/region.js
@@ -1,6 +1,6 @@
 // @flow
 import Icon from '@conveyal/woonerf/components/icon'
-import React, {Component} from 'react'
+import React from 'react'
 
 import messages from '../utils/messages'
 
@@ -9,30 +9,16 @@ import type {Region} from '../types'
 type Props = {
   children: ?any,
   region?: Region,
-
-  clearCurrentRegion: () => void,
 }
 
-export default class RegionComponent extends Component {
-  props: Props
+export default ({children, region}: Props) => region
+  ? <div>
+    <div className='ApplicationDockTitle'>
+      <Icon type='cubes' /> {region.name}
+    </div>
 
-  componentWillUnmount () {
-    this.props.clearCurrentRegion()
-  }
-
-  render () {
-    const {children, region} = this.props
-
-    return region
-      ? <div>
-        <div className='ApplicationDockTitle'>
-          <Icon type='cubes' /> {region.name}
-        </div>
-
-        {children}
-      </div>
-      : <div className='block'>
-        {messages.region.loadingRegion}
-      </div>
-  }
-}
+    {children}
+  </div>
+  : <div className='block'>
+    {messages.region.loadingRegion}
+  </div>

--- a/lib/components/select-region.js
+++ b/lib/components/select-region.js
@@ -9,13 +9,15 @@ import {Group} from './input'
 import messages from '../utils/messages'
 
 type Props = {
-  loadAllRegions(): void,
+  clearCurrentRegion: () => void,
+  loadAllRegions: () => void,
   regions: Array<{_id: string, name: string}>,
-  push(string): void
+  push: (string) => void
 }
 
 export default class SelectRegion extends Component<void, Props, void> {
   componentDidMount () {
+    this.props.clearCurrentRegion()
     this.props.loadAllRegions()
   }
 

--- a/lib/containers/region.js
+++ b/lib/containers/region.js
@@ -1,7 +1,7 @@
 // @flow
 import {connect} from 'react-redux'
 
-import {clearCurrentRegion, load} from '../actions/region'
+import {load} from '../actions/region'
 import Region from '../components/region'
 
 import selectCurrentRegion from '../selectors/current-region'
@@ -12,7 +12,4 @@ function mapStateToProps (state, props) {
   }
 }
 
-export default connect(mapStateToProps, {
-  clearCurrentRegion,
-  load
-})(Region)
+export default connect(mapStateToProps, {load})(Region)

--- a/lib/containers/select-region.js
+++ b/lib/containers/select-region.js
@@ -1,7 +1,7 @@
 import {connect} from 'react-redux'
 import {push} from 'react-router-redux'
 
-import {loadAll as loadAllRegions} from '../actions/region'
+import {clearCurrentRegion, loadAll as loadAllRegions} from '../actions/region'
 import SelectRegion from '../components/select-region'
 import selectRegions from '../selectors/regions'
 
@@ -11,4 +11,8 @@ function mapStateToProps (state, ownProps) {
   }
 }
 
-export default connect(mapStateToProps, {loadAllRegions, push})(SelectRegion)
+export default connect(mapStateToProps, {
+  clearCurrentRegion,
+  loadAllRegions,
+  push
+})(SelectRegion)


### PR DESCRIPTION
We were reloading the region when switching to a project unnecessarily and it sometimes overwrote
the project bundle if the data came back in the wrong order. This commit only "unloads" the region
fully when switching to the region selector.

closes #591