### PR TITLE
Switch modification saving style

### DIFF
--- a/lib/components/modification/editor.js
+++ b/lib/components/modification/editor.js
@@ -61,18 +61,18 @@ export default class ModificationEditor extends Component {
     showEditName: false
   }
 
+  _savedChangesInterval: number
   _unsavedChanges = false
-  __savedChangesInterval: number
 
   componentDidMount () {
     window.addEventListener('beforeunload', this._checkForUnsavedChanges)
     this.props.setActive()
-    this.__savedChangesInterval = setInterval(this._saveChanges, AUTOSAVE_EVERY_MS)
+    this._savedChangesInterval = setInterval(this._saveChanges, AUTOSAVE_EVERY_MS)
   }
 
   componentWillUnmount () {
     window.removeEventListener('beforeunload', this._checkForUnsavedChanges)
-    clearInterval(this.__savedChangesInterval)
+    clearInterval(this._savedChangesInterval)
     this._saveChanges()
     this.props.clearActive()
   }

--- a/lib/components/modification/editor.js
+++ b/lib/components/modification/editor.js
@@ -1,9 +1,7 @@
 // @flow
 import Icon from '@conveyal/woonerf/components/icon'
-import debounce from 'lodash/debounce'
 import React, {Component} from 'react'
 
-import {UPDATE_DELAY_MS} from '../../constants'
 import {Button} from '../buttons'
 import InnerDock from '../inner-dock'
 import {IconLink} from '../link'
@@ -20,6 +18,9 @@ import messages from '../../utils/messages'
 
 import type {MapState, Modification} from '../../types'
 
+// Also autosaves on exit
+const AUTOSAVE_EVERY_MS = 10 * 1000
+
 type Props = {
   allVariants: string[],
   feedIsLoaded: boolean,
@@ -33,7 +34,8 @@ type Props = {
   setActive: () => void,
   setMapState: (MapState) => void,
   update: (modification: any) => void,
-  updateAndRetrieveFeedData: (modification: any) => void
+  updateAndRetrieveFeedData: (modification: any) => void,
+  updateLocally: (modification: any) => void
 }
 
 const modificationTypeToComponentMap = {
@@ -59,20 +61,35 @@ export default class ModificationEditor extends Component {
     showEditName: false
   }
 
+  _unsavedChanges = false
+  __savedChangesInterval: number
+
   componentDidMount () {
+    window.addEventListener('beforeunload', this._checkForUnsavedChanges)
     this.props.setActive()
+    this.__savedChangesInterval = setInterval(this._saveChanges, AUTOSAVE_EVERY_MS)
   }
 
   componentWillUnmount () {
+    window.removeEventListener('beforeunload', this._checkForUnsavedChanges)
+    clearInterval(this.__savedChangesInterval)
+    this._saveChanges()
     this.props.clearActive()
   }
 
+  _checkForUnsavedChanges = (event: Event & {returnValue: string}) => {
+    if (this._unsavedChanges) {
+      this._saveChanges()
+      event.returnValue = 'Committing unsaved changes to modification'
+    }
+  }
+
   _onNameChange = (e: Event & {currentTarget: HTMLInputElement}) => {
-    this._update({name: e.currentTarget.value})
+    this._updateLocally({name: e.currentTarget.value})
   }
 
   _onDescriptionChange = (e: Event & {currentTarget: HTMLInputElement}) => {
-    this._update({description: e.currentTarget.value})
+    this._updateLocally({description: e.currentTarget.value})
   }
 
   _onAddDescription = () => {
@@ -98,6 +115,13 @@ export default class ModificationEditor extends Component {
     }
   }
 
+  _saveChanges = () => {
+    if (this._unsavedChanges) {
+      this._unsavedChanges = false
+      this.props.update(this.props.modification)
+    }
+  }
+
   _setVariant = (variantIndex: number, active: boolean) => {
     const {modification} = this.props
     if (modification) {
@@ -110,7 +134,7 @@ export default class ModificationEditor extends Component {
 
       variants[variantIndex] = active
 
-      this._update({
+      this._updateLocally({
         variants: [...variants]
       })
     }
@@ -118,19 +142,18 @@ export default class ModificationEditor extends Component {
 
   _showEditModificationName = () => this.setState({showEditName: true})
 
-  _update = debounce((properties: any) => {
-    this.props.update({
-      ...this.props.modification,
-      ...properties
-    })
-  }, UPDATE_DELAY_MS)
-
-  _updateAndRetrieveFeedData = debounce((properties: any) => {
+  _updateAndRetrieveFeedData = (properties: any) => {
+    this._unsavedChanges = false
     this.props.updateAndRetrieveFeedData({
       ...this.props.modification,
       ...properties
     })
-  }, UPDATE_DELAY_MS)
+  }
+
+  _updateLocally = (properties: any) => {
+    this._unsavedChanges = true
+    this.props.updateLocally({...this.props.modification, ...properties})
+  }
 
   render () {
     const {
@@ -202,7 +225,7 @@ export default class ModificationEditor extends Component {
                   modification={modification}
                   setMapState={setMapState}
                   type={modification.type}
-                  update={this._update}
+                  update={this._updateLocally}
                   updateAndRetrieveFeedData={this._updateAndRetrieveFeedData}
                   />
 

--- a/lib/constants/index.js
+++ b/lib/constants/index.js
@@ -50,7 +50,7 @@ export const MAP_STATE_SELECT_TO_STOP = 'map state select to stop'
 /**
  * Update delay so that we can batch updates to the server with debounce
  */
-export const UPDATE_DELAY_MS = 300
+export const UPDATE_DELAY_MS = 1000
 
 /**
  * Percentiles of travel time to request from the backend. This is for

--- a/lib/containers/__tests__/__snapshots__/modification-editor.js.snap
+++ b/lib/containers/__tests__/__snapshots__/modification-editor.js.snap
@@ -141,6 +141,7 @@ exports[`Container > Modification Editor render just the title if not loaded 1`]
       setMapState={[Function]}
       update={[Function]}
       updateAndRetrieveFeedData={[Function]}
+      updateLocally={[Function]}
     >
       <div>
         <div
@@ -1179,24 +1180,22 @@ Array [
   },
   Object {
     "payload": Object {
-      "options": Object {
-        "body": Object {
-          "_id": "1234",
-          "accessGroup": "accessGroupName",
-          "bidirectional": false,
-          "createdAt": "2017-11-08T12:30:50.133Z",
-          "createdBy": "person@gmail.com",
-          "description": "Mock description",
-          "entries": Array [],
-          "feed": "1",
-          "name": "Test Modification",
-          "nonce": "12345",
-          "projectId": "1",
-          "routes": Array [
-            "route1",
-          ],
-          "segments": Array [
-            {
+      "_id": "1234",
+      "accessGroup": "accessGroupName",
+      "bidirectional": false,
+      "createdAt": "2017-11-08T12:30:50.133Z",
+      "createdBy": "person@gmail.com",
+      "description": "Mock description",
+      "entries": Array [],
+      "feed": "1",
+      "name": "Test Modification",
+      "nonce": "12345",
+      "projectId": "1",
+      "routes": Array [
+        "route1",
+      ],
+      "segments": Array [
+        {
   "fromStopId": "1",
   "geometry": {
     "type": "LineString",
@@ -1234,159 +1233,47 @@ Array [
   "toStopId": null,
   "type": "Feature"
 },
-          ],
-          "showOnMap": false,
-          "timetables": Array [
-            Object {
-              "_id": "timetable-id",
-              "dwellTime": 10,
-              "endTime": 57600,
-              "exactTimes": false,
-              "friday": true,
-              "headwaySecs": 900,
-              "modificationId": "1234",
-              "modificationName": "Test Modification",
-              "monday": true,
-              "name": "Test timetable",
-              "patternTrips": Array [
-                "abcd",
-              ],
-              "phaseAtStop": "",
-              "phaseFromStop": "",
-              "phaseFromTimetable": "",
-              "phaseSeconds": 300,
-              "saturday": false,
-              "segmentSpeeds": Array [],
-              "sourceTrip": "abcd",
-              "startTime": 28800,
-              "sunday": false,
-              "thursday": true,
-              "tuesday": true,
-              "wednesday": true,
-            },
-          ],
-          "trips": Array [
+      ],
+      "showOnMap": false,
+      "timetables": Array [
+        Object {
+          "_id": "timetable-id",
+          "dwellTime": 10,
+          "endTime": 57600,
+          "exactTimes": false,
+          "friday": true,
+          "headwaySecs": 900,
+          "modificationId": "1234",
+          "modificationName": "Test Modification",
+          "monday": true,
+          "name": "Test timetable",
+          "patternTrips": Array [
             "abcd",
           ],
-          "type": "add-trip-pattern",
-          "updatedAt": "2017-11-08T12:31:19.602Z",
-          "updatedBy": "person@gmail.com",
-          "variants": Array [
-            true,
-          ],
+          "phaseAtStop": "",
+          "phaseFromStop": "",
+          "phaseFromTimetable": "",
+          "phaseSeconds": 300,
+          "saturday": false,
+          "segmentSpeeds": Array [],
+          "sourceTrip": "abcd",
+          "startTime": 28800,
+          "sunday": false,
+          "thursday": true,
+          "tuesday": true,
+          "wednesday": true,
         },
-        "method": "put",
-      },
-      "url": "/api/modification/1234",
+      ],
+      "trips": Array [
+        "abcd",
+      ],
+      "type": "add-trip-pattern",
+      "updatedAt": "2017-11-08T12:31:19.602Z",
+      "updatedBy": "person@gmail.com",
+      "variants": Array [
+        true,
+      ],
     },
-    "type": "increment outstanding fetches",
-  },
-  Object {
-    "payload": Object {
-      "options": Object {
-        "body": Object {
-          "_id": "1234",
-          "accessGroup": "accessGroupName",
-          "bidirectional": false,
-          "createdAt": "2017-11-08T12:30:50.133Z",
-          "createdBy": "person@gmail.com",
-          "description": "Mock description",
-          "entries": Array [],
-          "feed": "1",
-          "name": "Test Modification",
-          "nonce": "12345",
-          "projectId": "1",
-          "routes": Array [
-            "route1",
-          ],
-          "segments": Array [
-            {
-  "fromStopId": "1",
-  "geometry": {
-    "type": "LineString",
-    "coordinates": [
-      [
-        "-122.02460000",
-        "36.97070000"
-      ],
-      [
-        "-122.02790000",
-        "37.04900000"
-      ],
-      [
-        "-121.97990000",
-        "37.22990000"
-      ],
-      [
-        "-121.94450000",
-        "37.32400000"
-      ],
-      [
-        "-121.93600000",
-        "37.35300000"
-      ],
-      [
-        "-121.92400000",
-        "37.36500000"
-      ]
-    ]
-  },
-  "properties": {},
-  "spacing": "300.00000000",
-  "stopAtEnd": false,
-  "stopAtStart": false,
-  "toStopId": null,
-  "type": "Feature"
-},
-          ],
-          "showOnMap": false,
-          "timetables": Array [
-            Object {
-              "_id": "timetable-id",
-              "dwellTime": 10,
-              "endTime": 57600,
-              "exactTimes": false,
-              "friday": true,
-              "headwaySecs": 900,
-              "modificationId": "1234",
-              "modificationName": "Test Modification",
-              "monday": true,
-              "name": "Test timetable",
-              "patternTrips": Array [
-                "abcd",
-              ],
-              "phaseAtStop": "",
-              "phaseFromStop": "",
-              "phaseFromTimetable": "",
-              "phaseSeconds": 300,
-              "saturday": false,
-              "segmentSpeeds": Array [],
-              "sourceTrip": "abcd",
-              "startTime": 28800,
-              "sunday": false,
-              "thursday": true,
-              "tuesday": true,
-              "wednesday": true,
-            },
-          ],
-          "trips": Array [
-            "abcd",
-          ],
-          "type": "add-trip-pattern",
-          "updatedAt": "2017-11-08T12:31:19.602Z",
-          "updatedBy": "person@gmail.com",
-          "variants": Array [
-            true,
-          ],
-        },
-        "method": "put",
-      },
-      "url": "/api/modification/1234",
-    },
-    "type": "decrement outstanding fetches",
-  },
-  Object {
-    "payload": Object {},
     "type": "set modification",
   },
 ]
@@ -1533,6 +1420,7 @@ exports[`Container > Modification Editor renders correctly 1`] = `
       setMapState={[Function]}
       update={[Function]}
       updateAndRetrieveFeedData={[Function]}
+      updateLocally={[Function]}
     >
       <div>
         <div

--- a/lib/containers/__tests__/modification-editor.js
+++ b/lib/containers/__tests__/modification-editor.js
@@ -1,5 +1,4 @@
 // @flow
-import nock from 'nock'
 import React from 'react'
 
 import {
@@ -22,13 +21,7 @@ describe('Container > Modification Editor', () => {
     expect(snapshot()).toMatchSnapshot()
   })
 
-  it('renders and can change the name', done => {
-    // ensure that /api/region is called during first load
-    const putMock = nock('http://mockhost.com')
-      .put(`/api/modification/${mockModification._id}`)
-      .times(1)
-      .reply(200, {})
-
+  it('renders and can change the name', () => {
     // mount component
     const {
       store,
@@ -43,11 +36,7 @@ describe('Container > Modification Editor', () => {
       .find('input[name="Modification Name"]')
       .simulate('change', {currentTarget: {value: 'New Modification Name'}})
 
-    setTimeout(() => {
-      expect(store.getActions()).toMatchSnapshot()
-      expect(putMock.isDone()).toBeTruthy()
-      done()
-    }, 400) // There is a delay when editing modifications
+    expect(store.getActions()).toMatchSnapshot()
   })
 
   it('render just the title if not loaded', () => {

--- a/lib/containers/modification-editor.js
+++ b/lib/containers/modification-editor.js
@@ -9,7 +9,8 @@ import {
   deleteModification,
   set,
   setActive,
-  setAndRetrieveData
+  setAndRetrieveData,
+  setLocally
 } from '../actions/modifications'
 import ModificationEditor from '../components/modification/editor'
 import selectActiveModification from '../selectors/active-modification'
@@ -46,7 +47,8 @@ function mapDispatchToProps (dispatch: Dispatch, ownProps) {
 
     update: modification => dispatch(set(modification)),
     updateAndRetrieveFeedData: modification =>
-      dispatch(setAndRetrieveData(modification))
+      dispatch(setAndRetrieveData(modification)),
+    updateLocally: modification => dispatch(setLocally(modification))
   }
 }
 


### PR DESCRIPTION
Move from auto-saving on each change to only saving every ten seconds or on `componentWillUnmount` (when you leave editing the modification) and only when there have been changes. closes #589

The motivation for using this style as opposed to a save button is that it would be difficult to set route or pattern data without saving it because of the way we retrieve that data from the server.