### PR TITLE
Remove probability masking

### DIFF
--- a/lib/actions/analysis/__tests__/__snapshots__/regional.js.snap
+++ b/lib/actions/analysis/__tests__/__snapshots__/regional.js.snap
@@ -13,13 +13,6 @@ Object {
 }
 `;
 
-exports[`Actions > Analysis > Regional setMinimumImprovementProbability should work 1`] = `
-Object {
-  "payload": 0.42,
-  "type": "set minimum improvement probability",
-}
-`;
-
 exports[`Actions > Analysis > Regional setRegionalAnalyses should work 1`] = `
 Object {
   "payload": Array [

--- a/lib/actions/analysis/__tests__/regional.js
+++ b/lib/actions/analysis/__tests__/regional.js
@@ -18,10 +18,6 @@ describe('Actions > Analysis > Regional', () => {
     expect(regional.setRegionalAnalysisGrids()).toMatchSnapshot()
   })
 
-  it('setMinimumImprovementProbability should work', () => {
-    expect(regional.setMinimumImprovementProbability(0.42)).toMatchSnapshot()
-  })
-
   it('deleteRegionalAnalysis should work', async () => {
     const store = makeMockStore()
     const nockHost = nock('http://mockhost.com')

--- a/lib/actions/analysis/regional.js
+++ b/lib/actions/analysis/regional.js
@@ -43,9 +43,6 @@ export const setActiveRegionalAnalyses = createAction(
 export const setRegionalAnalysisGrids = createAction(
   'set regional analysis grids'
 )
-export const setMinimumImprovementProbability = createAction(
-  'set minimum improvement probability'
-)
 const setRegionalAnalysisOriginLocally = createAction(
   'set regional analysis origin'
 )

--- a/lib/actions/analysis/regional.js
+++ b/lib/actions/analysis/regional.js
@@ -70,7 +70,7 @@ export const loadRegionalAnalysisGrids = async ({
       fetchMultipleSignedS3Urls({
         urls: [
           `${REGIONAL_URL}/${_id}/grid/grid`,
-          `${REGIONAL_URL}/${comparisonId}/grid/grid`,
+          `${REGIONAL_URL}/${comparisonId}/grid/grid`
         ],
         next ([gridResponse, comparisonGridResponse]) {
           // TODO store raw data and create grids, classifier, breaks in selectors

--- a/lib/actions/analysis/regional.js
+++ b/lib/actions/analysis/regional.js
@@ -74,15 +74,13 @@ export const loadRegionalAnalysisGrids = async ({
         urls: [
           `${REGIONAL_URL}/${_id}/grid/grid`,
           `${REGIONAL_URL}/${comparisonId}/grid/grid`,
-          `${REGIONAL_URL}/${_id}/${comparisonId}/grid`
         ],
-        next ([gridResponse, comparisonGridResponse, probabilityGridResponse]) {
+        next ([gridResponse, comparisonGridResponse]) {
           // TODO store raw data and create grids, classifier, breaks in selectors
 
           // Create the grids
           const comparisonGrid = createGrid(comparisonGridResponse.value)
           const grid = createGrid(gridResponse.value)
-          const probabilityGrid = createGrid(probabilityGridResponse.value)
 
           // Create a difference grid
           const differenceGrid = subtract(grid, comparisonGrid)
@@ -97,8 +95,7 @@ export const loadRegionalAnalysisGrids = async ({
             classifier,
             comparisonGrid,
             differenceGrid,
-            grid,
-            probabilityGrid
+            grid
           })
         }
       })

--- a/lib/components/analysis/__tests__/__snapshots__/regional.js.snap
+++ b/lib/components/analysis/__tests__/__snapshots__/regional.js.snap
@@ -183,7 +183,6 @@ exports[`Components > Analysis > Regional should handle rendering comparison 1`]
     }
     loadRegionalAnalyses={[Function]}
     loadRegionalAnalysisGrids={[Function]}
-    minimumImprovementProbability={0.83}
     opportunityDatasets={
       Array [
         Object {
@@ -326,7 +325,6 @@ exports[`Components > Analysis > Regional should handle rendering comparison 1`]
     setActiveRegionalAnalysis={[Function]}
     setAggregationArea={[Function]}
     setAggregationWeights={[Function]}
-    setMinimumImprovementProbability={[Function]}
     uploadAggregationArea={[Function]}
   >
     <div>
@@ -716,58 +714,6 @@ exports[`Components > Analysis > Regional should handle rendering comparison 1`]
           </Collapsible>
         </ProfileRequestDisplay>
       </div>
-      <MinimumImprovementProbabilitySelector
-        minimumImprovementProbability={0.83}
-        setMinimumImprovementProbability={[Function]}
-      >
-        <Slider
-          format=".2f"
-          label="Minimum probability of change"
-          max={1}
-          min={0}
-          onChange={[Function]}
-          output={true}
-          step={0.01}
-          value={0.83}
-        >
-          <Group
-            id="minimum-probability-of-change-input-7"
-            label="Minimum probability of change"
-            max={1}
-            min={0}
-            onChange={[Function]}
-            step={0.01}
-            value={0.83}
-          >
-            <div
-              className="form-group"
-            >
-              <label
-                htmlFor="minimum-probability-of-change-input-7"
-              >
-                Minimum probability of change
-              </label>
-              <output
-                className="pull-right"
-                htmlFor="minimum-probability-of-change-input-7"
-              >
-                0.55
-              </output>
-              <input
-                className="form-control"
-                id="minimum-probability-of-change-input-7"
-                label="Minimum probability of change"
-                max={1}
-                min={0}
-                onChange={[Function]}
-                step={0.01}
-                type="range"
-                value={0.55}
-              />
-            </div>
-          </Group>
-        </Slider>
-      </MinimumImprovementProbabilitySelector>
       <p>
         Total jobs within 60 minutes (average instantaneous accessibility)
       </p>
@@ -883,7 +829,7 @@ exports[`Components > Analysis > Regional should handle rendering comparison 1`]
             className="form-group"
           >
             <label
-              htmlFor="aggregate-results-to-input-5"
+              htmlFor="aggregate-results-to-input-4"
             >
               Aggregate results to
             </label>
@@ -1000,7 +946,7 @@ exports[`Components > Analysis > Regional should handle rendering comparison 1`]
           className="form-group"
         >
           <label
-            htmlFor="export-to-gis-input-6"
+            htmlFor="export-to-gis-input-5"
           >
             Export to GIS
           </label>
@@ -1030,20 +976,6 @@ exports[`Components > Analysis > Regional should handle rendering comparison 1`]
               tabIndex={0}
             >
               Download ANALYSIS 2
-            </a>
-          </Button>
-          <Button
-            block={true}
-            onClick={[Function]}
-            style="info"
-          >
-            <a
-              className="btn btn-info btn-block"
-              href="#"
-              onClick={[Function]}
-              tabIndex={0}
-            >
-              Download probability of improvement
             </a>
           </Button>
         </div>

--- a/lib/components/analysis/__tests__/__snapshots__/regional.js.snap
+++ b/lib/components/analysis/__tests__/__snapshots__/regional.js.snap
@@ -1091,7 +1091,6 @@ exports[`Components > Analysis > Regional should render correctly 1`] = `
     }
     loadRegionalAnalyses={[Function]}
     loadRegionalAnalysisGrids={[Function]}
-    minimumImprovementProbability={0.83}
     opportunityDatasets={
       Array [
         Object {
@@ -1234,7 +1233,6 @@ exports[`Components > Analysis > Regional should render correctly 1`] = `
     setActiveRegionalAnalysis={[Function]}
     setAggregationArea={[Function]}
     setAggregationWeights={[Function]}
-    setMinimumImprovementProbability={[Function]}
     uploadAggregationArea={[Function]}
   >
     <div>

--- a/lib/components/analysis/__tests__/regional.js
+++ b/lib/components/analysis/__tests__/regional.js
@@ -15,7 +15,6 @@ describe('Components > Analysis > Regional', () => {
         analysisId={mockRegionalAnalyses[0]._id}
         breaks={[100, 500, 1000, 2000]}
         opportunityDatasets={[{name: 'Total jobs', _id: 'Jobs_total'}]}
-        minimumImprovementProbability={0.83}
         regionId='MOCK_REGION_ID'
         projectId='MOCK_PROJECT_ID'
         grid={mockGrid}
@@ -29,7 +28,6 @@ describe('Components > Analysis > Regional', () => {
         setActiveRegionalAnalysis={setActiveRegionalAnalysis}
         setAggregationArea={jest.fn()}
         setAggregationWeights={jest.fn()}
-        setMinimumImprovementProbability={jest.fn()}
         uploadAggregationArea={jest.fn()}
         />
     )
@@ -39,7 +37,7 @@ describe('Components > Analysis > Regional', () => {
 
   it('should handle rendering comparison', () => {
     const setActiveRegionalAnalysis = jest.fn()
-    const {wrapper, snapshot} = mockWithProvider(
+    const {snapshot} = mockWithProvider(
       <Regional
         accessToName='Grid name'
         aggregationAreas={[]}

--- a/lib/components/analysis/__tests__/regional.js
+++ b/lib/components/analysis/__tests__/regional.js
@@ -39,7 +39,6 @@ describe('Components > Analysis > Regional', () => {
 
   it('should handle rendering comparison', () => {
     const setActiveRegionalAnalysis = jest.fn()
-    const setMinimumImprovementProbability = jest.fn()
     const {wrapper, snapshot} = mockWithProvider(
       <Regional
         accessToName='Grid name'
@@ -50,7 +49,6 @@ describe('Components > Analysis > Regional', () => {
         comparisonAnalysis={mockRegionalAnalyses[1]}
         differenceGrid={mockGrid}
         grid={mockGrid}
-        minimumImprovementProbability={0.83}
         opportunityDatasets={[{name: 'Total jobs', _id: 'Jobs_total'}]}
         projectId='MOCK_PROJECT_ID'
         regionId='MOCK_REGION_ID'
@@ -64,14 +62,9 @@ describe('Components > Analysis > Regional', () => {
         setActiveRegionalAnalysis={setActiveRegionalAnalysis}
         setAggregationArea={jest.fn()}
         setAggregationWeights={jest.fn()}
-        setMinimumImprovementProbability={setMinimumImprovementProbability}
         uploadAggregationArea={jest.fn()}
       />
     )
-
-    wrapper.find('input[type="range"]').simulate('change', {target: {value: 0.55}})
-
     expect(snapshot()).toMatchSnapshot()
-    expect(setMinimumImprovementProbability).toHaveBeenLastCalledWith(0.55)
   })
 })

--- a/lib/components/analysis/index.js
+++ b/lib/components/analysis/index.js
@@ -33,6 +33,7 @@ import StackedPercentileSelector
 import type {
   LonLat,
   ProfileRequest,
+  Project,
   Quintiles,
   ReactSelectResult
 } from '../../types'
@@ -49,7 +50,7 @@ type Props = {
   comparisonProjectId?: string,
   comparisonIsochrone: any,
   comparisonVariant?: number,
-  currentProject?: any,
+  currentProject?: Project,
   destination: LonLat,
   destinationTravelTimeDistribution?: Quintiles,
   isFetchingIsochrone: boolean,
@@ -137,22 +138,23 @@ export default class SinglePointAnalysis extends Pure {
     const {regionalAnalyses} = this.props
     const {currentProject} = this.props
     const {profileRequest} = this.props
-    const name = window.prompt(
+    if (currentProject) {
+      const name = window.prompt(
       'Enter a name and click ok to begin a regional analysis job for this project and settings:',
       `Analysis ${regionalAnalyses.length + 1}: ${currentProject.name} ` +
-      `${currentProject.variants[profileRequest.variantIndex]}`
-    )
-    if (name && name.length > 0) {
-      const {
-        createRegionalAnalysis,
-        regionBounds,
-        regionalAnalysisBounds
-      } = this.props
-      createRegionalAnalysis({
-        bounds: regionalAnalysisBounds || regionBounds,
-        name,
-        profileRequest
-      })
+      `${currentProject.variants[profileRequest.variantIndex]}`)
+      if (name && name.length > 0) {
+        const {
+          createRegionalAnalysis,
+          regionBounds,
+          regionalAnalysisBounds
+        } = this.props
+        createRegionalAnalysis({
+          bounds: regionalAnalysisBounds || regionBounds,
+          name,
+          profileRequest
+        })
+      }
     }
   }
 

--- a/lib/components/analysis/index.js
+++ b/lib/components/analysis/index.js
@@ -134,22 +134,14 @@ export default class SinglePointAnalysis extends Pure {
   }
 
   _createRegionalAnalysis = () => {
-    const {regionalAnalyses} = this.props
-    const {currentProject} = this.props
-    const {profileRequest} = this.props
+    const {createRegionalAnalysis, currentProject, regionalAnalyses, profileRequest} = this.props
     if (currentProject) {
       const name = window.prompt(
       'Enter a name and click ok to begin a regional analysis job for this project and settings:',
       `Analysis ${regionalAnalyses.length + 1}: ${currentProject.name} ` +
       `${currentProject.variants[profileRequest.variantIndex]}`)
       if (name && name.length > 0) {
-        const {
-          createRegionalAnalysis,
-          regionBounds,
-          regionalAnalysisBounds
-        } = this.props
         createRegionalAnalysis({
-          bounds: regionalAnalysisBounds || regionBounds,
           name,
           profileRequest
         })

--- a/lib/components/analysis/index.js
+++ b/lib/components/analysis/index.js
@@ -135,14 +135,16 @@ export default class SinglePointAnalysis extends Pure {
 
   _createRegionalAnalysis = () => {
     const {regionalAnalyses} = this.props
+    const {currentProject} = this.props
+    const {profileRequest} = this.props
     const name = window.prompt(
       'Enter a name and click ok to begin a regional analysis job for this project and settings:',
-      `Analysis ${regionalAnalyses.length + 1}`
+      `Analysis ${regionalAnalyses.length + 1}: ${currentProject.name} ` +
+      `${currentProject.variants[profileRequest.variantIndex]}`
     )
     if (name && name.length > 0) {
       const {
         createRegionalAnalysis,
-        profileRequest,
         regionBounds,
         regionalAnalysisBounds
       } = this.props

--- a/lib/components/analysis/regional-results.js
+++ b/lib/components/analysis/regional-results.js
@@ -10,7 +10,7 @@ import Legend from './legend'
 import colors from '../../constants/colors'
 import messages from '../../utils/messages'
 import ProfileRequestDisplay from './profile-request-display'
-import {Slider, Group, Text, File} from '../input'
+import {Group, Text, File} from '../input'
 
 import OpportunityDatasets from '../../modules/opportunity-datasets'
 
@@ -309,9 +309,7 @@ export default class RegionalResults extends Component<void, Props, State> {
       breaks,
       comparisonAnalysis,
       differenceGrid,
-      grid,
-      minimumImprovementProbability,
-      setMinimumImprovementProbability
+      grid
     } = this.props
 
     return (
@@ -397,23 +395,4 @@ export default class RegionalResults extends Component<void, Props, State> {
     const value = this.props.opportunityDatasets.find(i => i._id === _id)
     return value != null ? value.name : _id
   }
-}
-
-function MinimumImprovementProbabilitySelector ({
-  minimumImprovementProbability,
-  setMinimumImprovementProbability
-}) {
-  return (
-    <Slider
-      label={messages.analysis.minimumImprovementProbability}
-      output
-      format='.2f'
-      min={0}
-      max={1}
-      step={0.01}
-      value={minimumImprovementProbability}
-      onChange={e =>
-        setMinimumImprovementProbability(parseFloat(e.target.value))}
-    />
-  )
 }

--- a/lib/components/analysis/regional-results.js
+++ b/lib/components/analysis/regional-results.js
@@ -303,19 +303,6 @@ export default class RegionalResults extends Component<void, Props, State> {
     }
   }
 
-  downloadProbabilityGIS = (e: Event) => {
-    e.preventDefault()
-    if (this.props.analysis && this.props.comparisonAnalysis) {
-      this.downloadFromS3(
-        `/api/regional/${this.props.analysis._id}/${this.props.comparisonAnalysis._id}/tiff?redirect=false`
-      )
-    } else {
-      throw new Error(
-        'Attempt to download probability surface when both analyses have not loaded.'
-      )
-    }
-  }
-
   render () {
     const {
       analysis,
@@ -341,14 +328,6 @@ export default class RegionalResults extends Component<void, Props, State> {
               {...comparisonAnalysis.request}
               />
           </div>}
-
-        {comparisonAnalysis &&
-          <MinimumImprovementProbabilitySelector
-            minimumImprovementProbability={minimumImprovementProbability}
-            setMinimumImprovementProbability={
-              setMinimumImprovementProbability
-            }
-          />}
 
         <p>
           {analysis.travelTimePercentile !== -1 &&
@@ -407,10 +386,6 @@ export default class RegionalResults extends Component<void, Props, State> {
                 messages.analysis.downloadRegional,
                 comparisonAnalysis.name
               )}
-            </Button>}
-          {comparisonAnalysis &&
-            <Button block onClick={this.downloadProbabilityGIS} style='info'>
-              {messages.analysis.downloadRegionalProbability}
             </Button>}
         </Group>
       </div>

--- a/lib/components/analysis/regional-results.js
+++ b/lib/components/analysis/regional-results.js
@@ -32,7 +32,6 @@ type Props = {
   grid?: Grid,
   aggregationAreas: AggregationArea[],
   opportunityDatasets: OpportunityDataset[],
-  minimumImprovementProbability: number,
   regionId: string,
   projectId: string,
   regionalAnalyses?: RegionalAnalysis[],
@@ -49,7 +48,6 @@ type Props = {
   fetch: any => any,
   loadRegionalAnalysisGrids: (any) => void,
   setActiveRegionalAnalysis: any => void,
-  setMinimumImprovementProbability: number => void,
   setAggregationArea: (opts: void | {aggregationAreaId: string, regionId: string}) => void,
   uploadAggregationArea: (arg: {
     name: string,

--- a/lib/components/map/regional.js
+++ b/lib/components/map/regional.js
@@ -18,22 +18,16 @@ type Props = {
   comparisonId: string,
   differenceGrid: Grid,
   isRegionalAnalysisSamplingDistributionComponentOnMap: boolean,
-  minimumImprovementProbability: number,
   probabilityGrid: Grid,
+  removeRegionalAnalysisSamplingDistributionComponentFromMap: () => void,
   setRegionalAnalysisOrigin: Object => void
 }
 
-type DefaultProps = {
-  minimumImprovementProbability: number
-}
 
 /**
  * A layer showing a proabilistic regional comparison
  */
 export default class Regional extends Component<DefaultProps, Props, void> {
-  static defaultProps = {
-    minimumImprovementProbability: 0 // https://xkcd.com/1478/
-  }
 
   static contextTypes = {
     map: PropTypes.instanceOf(Map)
@@ -45,8 +39,16 @@ export default class Regional extends Component<DefaultProps, Props, void> {
   }
 
   componentWillUnmount () {
+    const {
+      isRegionalAnalysisSamplingDistributionComponentOnMap,
+      removeRegionalAnalysisSamplingDistributionComponentFromMap
+    } = this.props
     const {map} = this.context
     map.off('click', this.onMapClick)
+    if (isRegionalAnalysisSamplingDistributionComponentOnMap) {
+      // don't leave dest travel time distribution on map when exiting analysis mode
+      removeRegionalAnalysisSamplingDistributionComponentFromMap()
+    }
   }
 
   onMapClick = (e: MouseEvent) => {
@@ -73,7 +75,6 @@ export default class Regional extends Component<DefaultProps, Props, void> {
       comparisonId,
       differenceGrid,
       probabilityGrid,
-      minimumImprovementProbability,
       breaks
     } = this.props
 
@@ -88,16 +89,11 @@ export default class Regional extends Component<DefaultProps, Props, void> {
         />
       )
     } else {
-      // now, mask with probability; probability is put in grids as ints 0 - 100k
-      const maskedGrid = mask(
-        differenceGrid,
-        probabilityGrid,
-        minimumImprovementProbability * 1e5
-      )
+      // used to call mask() here
 
       return (
         <Gridualizer
-          grid={maskedGrid}
+          grid={differenceGrid}
           colors={colors.REGIONAL_COMPARISON_GRADIENT}
           breaks={breaks}
           noDataValue={NO_DATA}
@@ -105,47 +101,4 @@ export default class Regional extends Component<DefaultProps, Props, void> {
       )
     }
   }
-}
-
-/**
- * TODO Create this in a selector
- * Mask a grid, returning a new, masked grid
- */
-function mask (grid, probabilityGrid, cutoff) {
-  const gridsDoNotAlign =
-    grid.west !== probabilityGrid.west ||
-    grid.north !== probabilityGrid.north ||
-    grid.zoom !== probabilityGrid.zoom ||
-    grid.width !== probabilityGrid.width ||
-    grid.height !== probabilityGrid.height
-
-  if (gridsDoNotAlign) {
-    throw new Error('Grids do not align for masking')
-  }
-
-  const {north, west, zoom, width, height} = grid
-
-  const newGrid = {
-    north,
-    west,
-    zoom,
-    width,
-    height,
-    data: new Int32Array(width * height),
-    // start at zero not Infinity to avoid having to update min/max for cells where probability
-    // is less than the cutoff
-    min: 0,
-    max: 0
-  }
-
-  for (let pixel = 0; pixel < width * height; pixel++) {
-    if (probabilityGrid.data[pixel] < cutoff) newGrid.data[pixel] = 0
-    else {
-      newGrid.data[pixel] = grid.data[pixel]
-      if (newGrid.min > grid.data[pixel]) newGrid.min = grid.data[pixel]
-      if (newGrid.max < grid.data[pixel]) newGrid.max = grid.data[pixel]
-    }
-  }
-
-  return newGrid
 }

--- a/lib/components/map/regional.js
+++ b/lib/components/map/regional.js
@@ -36,16 +36,8 @@ export default class Regional extends Component<DefaultProps, Props, void> {
   }
 
   componentWillUnmount () {
-    const {
-      isRegionalAnalysisSamplingDistributionComponentOnMap,
-      removeRegionalAnalysisSamplingDistributionComponentFromMap
-    } = this.props
     const {map} = this.context
     map.off('click', this.onMapClick)
-    if (isRegionalAnalysisSamplingDistributionComponentOnMap) {
-      // don't leave dest travel time distribution on map when exiting analysis mode
-      removeRegionalAnalysisSamplingDistributionComponentFromMap()
-    }
   }
 
   onMapClick = (e: MouseEvent) => {

--- a/lib/components/map/regional.js
+++ b/lib/components/map/regional.js
@@ -18,17 +18,14 @@ type Props = {
   comparisonId: string,
   differenceGrid: Grid,
   isRegionalAnalysisSamplingDistributionComponentOnMap: boolean,
-  probabilityGrid: Grid,
   removeRegionalAnalysisSamplingDistributionComponentFromMap: () => void,
   setRegionalAnalysisOrigin: Object => void
 }
-
 
 /**
  * A layer showing a proabilistic regional comparison
  */
 export default class Regional extends Component<DefaultProps, Props, void> {
-
   static contextTypes = {
     map: PropTypes.instanceOf(Map)
   }
@@ -74,7 +71,6 @@ export default class Regional extends Component<DefaultProps, Props, void> {
       baseGrid,
       comparisonId,
       differenceGrid,
-      probabilityGrid,
       breaks
     } = this.props
 

--- a/lib/components/map/regional.js
+++ b/lib/components/map/regional.js
@@ -25,7 +25,9 @@ type Props = {
 /**
  * A layer showing a proabilistic regional comparison
  */
-export default class Regional extends Component<DefaultProps, Props, void> {
+export default class Regional extends Component {
+  props: Props
+
   static contextTypes = {
     map: PropTypes.instanceOf(Map)
   }

--- a/lib/containers/regional-analysis-results.js
+++ b/lib/containers/regional-analysis-results.js
@@ -9,7 +9,6 @@ import {
   load,
   loadRegionalAnalysisGrids,
   setActiveRegionalAnalyses,
-  setMinimumImprovementProbability,
   setAggregationArea,
   updateRegionalAnalysis,
   uploadAggregationArea
@@ -28,7 +27,6 @@ function mapStateToProps (state, ownProps) {
     regionalAnalyses: state.region.regionalAnalyses,
     regionId,
     comparisonAnalysis: select.comparisonRegionalAnalysis(state, ownProps),
-    minimumImprovementProbability: get(state, 'analysis.regional.minimumImprovementProbability'),
     origin: get(state, 'analysis.regional.origin'),
     grid: get(state, 'analysis.regional.grid'),
     differenceGrid: get(state, 'analysis.regional.differenceGrid'),
@@ -57,8 +55,6 @@ function mapDispatchToProps (dispatch: Dispatch, ownProps) {
       dispatch(loadRegionalAnalysisGrids(ids)),
     setActiveRegionalAnalysis: ({_id, comparisonId}) =>
       dispatch(setActiveRegionalAnalyses({_id, comparisonId})),
-    setMinimumImprovementProbability: p =>
-      dispatch(setMinimumImprovementProbability(p)),
     setAggregationArea: (opts) => dispatch(setAggregationArea(opts)),
     updateRegionalAnalysis: (a) =>
       dispatch(updateRegionalAnalysis(a)),

--- a/lib/modules/admin/utils.js
+++ b/lib/modules/admin/utils.js
@@ -41,7 +41,7 @@ export function createWorkerUrl (instanceId: string, region: string) {
   return `https://${region}.console.aws.amazon.com/ec2/v2/home?region=${region}#Instances:instanceId=${instanceId};sort=tag:Name`
 }
 
-export function createCloudWatchUrl (instanceId: string, region: string, logGroup: string = 'analysis-staging-workers') {
+export function createCloudWatchUrl (instanceId: string, region: string, logGroup: string = 'analysis-prod-workers') {
   return `https://${region}.console.aws.amazon.com/cloudwatch/home?region=${region}#logEventViewer:group=${logGroup};stream=${instanceId}`
 }
 

--- a/lib/selectors/isochrone.js
+++ b/lib/selectors/isochrone.js
@@ -6,6 +6,7 @@ import {createSelector} from 'reselect'
 
 import {TRAVEL_TIME_PERCENTILES} from '../constants'
 import selectMaxTripDurationMinutes from './max-trip-duration-minutes'
+import selectNearestPercentileIndex from './nearest-percentile-index'
 
 /**
  * SingleValuedSurface, width, height all come from selector defined below and
@@ -43,16 +44,7 @@ export function computeSingleValuedSurface (travelTimeSurface: any, percentile: 
     travelTimeSurface.width * travelTimeSurface.height
   )
 
-  let percentileIndex = 0
-  let closestDiff = Infinity
-  // get the closest percentile
-  TRAVEL_TIME_PERCENTILES.forEach((p, i) => {
-    const currentDiff = Math.abs(p - percentile)
-    if (currentDiff < closestDiff) {
-      percentileIndex = i
-      closestDiff = currentDiff
-    }
-  })
+  const percentileIndex = selectNearestPercentileIndex(percentile)
 
   // y on outside, loop in order, hope the CPU figures this out and prefetches
   for (let y = 0; y < travelTimeSurface.height; y++) {

--- a/lib/selectors/isochrone.js
+++ b/lib/selectors/isochrone.js
@@ -4,7 +4,6 @@ import {Map as LeafletMap} from 'leaflet'
 import get from 'lodash/get'
 import {createSelector} from 'reselect'
 
-import {TRAVEL_TIME_PERCENTILES} from '../constants'
 import selectMaxTripDurationMinutes from './max-trip-duration-minutes'
 import selectNearestPercentileIndex from './nearest-percentile-index'
 

--- a/lib/selectors/nearest-percentile-index.js
+++ b/lib/selectors/nearest-percentile-index.js
@@ -1,9 +1,8 @@
 // @flow
-import {createSelector} from 'reselect'
 
 import {TRAVEL_TIME_PERCENTILES} from '../constants'
 
-export function nearestPercentileIndex (requestedPercentile: number) {
+export default function (requestedPercentile: number) {
   let percentileIndex = 0
   let closestDiff = Infinity
   // get the closest percentile
@@ -17,5 +16,3 @@ export function nearestPercentileIndex (requestedPercentile: number) {
 
   return percentileIndex
 }
-
-export default createSelector(nearestPercentileIndex)

--- a/lib/selectors/nearest-percentile-index.js
+++ b/lib/selectors/nearest-percentile-index.js
@@ -3,8 +3,7 @@ import {createSelector} from 'reselect'
 
 import {TRAVEL_TIME_PERCENTILES} from '../constants'
 
-export default function (requestedPercentile: number) {
-
+export function nearestPercentileIndex (requestedPercentile: number) {
   let percentileIndex = 0
   let closestDiff = Infinity
   // get the closest percentile
@@ -16,6 +15,7 @@ export default function (requestedPercentile: number) {
     }
   })
 
-  return percentileIndex;
-
+  return percentileIndex
 }
+
+export default createSelector(nearestPercentileIndex)

--- a/lib/selectors/nearest-percentile-index.js
+++ b/lib/selectors/nearest-percentile-index.js
@@ -1,0 +1,21 @@
+// @flow
+import {createSelector} from 'reselect'
+
+import {TRAVEL_TIME_PERCENTILES} from '../constants'
+
+export default function (requestedPercentile: number) {
+
+  let percentileIndex = 0
+  let closestDiff = Infinity
+  // get the closest percentile
+  TRAVEL_TIME_PERCENTILES.forEach((p, i) => {
+    const currentDiff = Math.abs(p - requestedPercentile)
+    if (currentDiff < closestDiff) {
+      percentileIndex = i
+      closestDiff = currentDiff
+    }
+  })
+
+  return percentileIndex;
+
+}

--- a/lib/types.js
+++ b/lib/types.js
@@ -92,7 +92,8 @@ export type Bundle = Model & {
 }
 
 export type Project = Model & {
-  name: string
+  name: string,
+  variants: Array<string>
 }
 
 export type MapState = {


### PR DESCRIPTION
By default, R5 no longer bootstraps estimates of accessibility, which obviates the probability masking features for regional analysis results.  This PR removes masking features and makes a few other small changes:
- Eliminates the fetch of the probability surface from analysis-backend, which was triggering an occasional bug.
- Eliminates the "minimum probability of change" slider
- Corrects cloudwatch logGroup used in link from admin panel
- Changes the default suggestion for regional analysis names (see discussion in #538).  While we're at it, we might also want to tackle #737.
- Refactors calculation of percentiles (steps toward #619, #756)