### PR TITLE
Set region data correctly

### DIFF
--- a/lib/actions/analysis/__tests__/__snapshots__/index.js.snap
+++ b/lib/actions/analysis/__tests__/__snapshots__/index.js.snap
@@ -50,7 +50,7 @@ Object {
   "payload": Object {
     "maxRides": 20,
   },
-  "type": "set profile request",
+  "type": "update profile request",
 }
 `;
 

--- a/lib/actions/analysis/index.js
+++ b/lib/actions/analysis/index.js
@@ -63,7 +63,8 @@ const setComparisonTravelTimeSurface = createAction(
 /**
  * Save the profile request parameters to local storage
  */
-export const setProfileRequest = createAction('set profile request')
+export const setEntireProfileRequest = createAction('set profile request')
+export const setProfileRequest = createAction('update profile request')
 export const setDisplayedProfileRequest = createAction('set displayed profile request')
 
 const requestSettingsKey = 'profileRequestSettings'
@@ -77,7 +78,7 @@ export const storeProfileRequestSettings = (profileRequest: any) =>
     storedSettings[regionId] = profileRequest
     localStorage.setItem(requestSettingsKey, JSON.stringify(storedSettings))
 
-    dispatch(setProfileRequest(profileRequest))
+    dispatch(setEntireProfileRequest(profileRequest))
   }
 
 export const loadProfileRequestSettings = (regionId: string) => {
@@ -85,7 +86,7 @@ export const loadProfileRequestSettings = (regionId: string) => {
   const profileRequestSettings = storedProfileRequestSettings[regionId]
   if (profileRequestSettings) {
     return [
-      setProfileRequest({
+      setEntireProfileRequest({
         ...PROFILE_REQUEST_DEFAULTS, // keep this in case we want to add new fields / change the defaults
         ...profileRequestSettings
       }),
@@ -93,7 +94,7 @@ export const loadProfileRequestSettings = (regionId: string) => {
     ]
   } else {
     return [
-      setProfileRequest(PROFILE_REQUEST_DEFAULTS),
+      setEntireProfileRequest(PROFILE_REQUEST_DEFAULTS),
       R5Version.actions.setCurrentR5Version(R5Version.RECOMMENDED_R5_VERSION)
     ]
   }

--- a/lib/actions/analysis/index.js
+++ b/lib/actions/analysis/index.js
@@ -91,6 +91,11 @@ export const loadProfileRequestSettings = (regionId: string) => {
       }),
       R5Version.actions.setCurrentR5Version(profileRequestSettings.workerVersion)
     ]
+  } else {
+    return [
+      setProfileRequest(PROFILE_REQUEST_DEFAULTS),
+      R5Version.actions.setCurrentR5Version(R5Version.RECOMMENDED_R5_VERSION)
+    ]
   }
 }
 

--- a/lib/actions/region.js
+++ b/lib/actions/region.js
@@ -8,16 +8,9 @@ import {setAll as setProjects} from './project'
 import {loadProfileRequestSettings} from './analysis'
 import timeout from '../utils/timeout'
 
-import OpportunityDatasets from '../modules/opportunity-datasets'
-
 import type {Bookmark, Region} from '../types'
 
 const CHECK_STATUS_TIMEOUT = 10 * 1000
-
-const setOpportunityDatasetsIfRequired = (region: Region) =>
-  region.opportunityDatasets && region.opportunityDatasets.length > 0
-    ? OpportunityDatasets.actions.setOpportunityDatasets(region.opportunityDatasets)
-    : () => {}
 
 function createFormData (region, customOpenStreetMapData) {
   const formData = new window.FormData()
@@ -75,7 +68,6 @@ export const load = (id: string, done?: Function) => (dispatch: Function) =>
       const region = response.value
       dispatch([
         setLocally({...region, projects: []}),
-        setOpportunityDatasetsIfRequired(region),
         setMapCenter([
           (region.bounds.west + region.bounds.east) / 2,
           (region.bounds.north + region.bounds.south) / 2

--- a/lib/components/analysis/index.js
+++ b/lib/components/analysis/index.js
@@ -113,8 +113,7 @@ export default class SinglePointAnalysis extends Pure {
   }
 
   componentDidMount () {
-    const p = this.props
-    if (p.regionalAnalyses.length === 0) p.loadAllRegionalAnalyses(p.regionId)
+    this.props.loadAllRegionalAnalyses(this.props.regionId)
     this._setProfileRequestLonLat()
   }
 

--- a/lib/modules/opportunity-datasets/components/selector.js
+++ b/lib/modules/opportunity-datasets/components/selector.js
@@ -21,10 +21,7 @@ export class OpportunityDatasetSelector extends PureComponent {
   }
 
   componentDidMount () {
-    const p = this.props
-    if (!p.opportunityDatasets || p.opportunityDatasets.length === 0) {
-      p.loadOpportunityDatasets()
-    }
+    this.props.loadOpportunityDatasets()
   }
 
   _selectOpportunityDataset = (option: ReactSelectResult) => {

--- a/lib/modules/r5-version/index.js
+++ b/lib/modules/r5-version/index.js
@@ -1,10 +1,11 @@
 // @flow
 import * as actions from './actions'
 import * as components from './components'
+import * as constants from './constants'
 import reducer from './reducer'
 import * as select from './selectors'
 
-const R5Version = {actions, components, reducer, select}
+const R5Version = {actions, components, reducer, select, ...constants}
 
 // Expose for command line usage
 if (window) window.R5Version = R5Version

--- a/lib/reducers/__tests__/__snapshots__/analysis.js.snap
+++ b/lib/reducers/__tests__/__snapshots__/analysis.js.snap
@@ -431,48 +431,6 @@ Object {
 }
 `;
 
-exports[`reducers > analysis should handle set profile request 1`] = `
-Object {
-  "active": false,
-  "isFetchingIsochrone": false,
-  "profileRequest": Object {
-    "accessModes": "WALK",
-    "bikeSpeed": 4.166666666666667,
-    "date": "2016-12-20",
-    "directModes": "WALK",
-    "egressModes": "WALK",
-    "fromTime": 24321,
-    "maxRides": 4,
-    "maxTripDurationMinutes": 60,
-    "monteCarloDraws": 200,
-    "percentiles": Array [
-      5,
-      25,
-      50,
-      75,
-      95,
-    ],
-    "toTime": 25220,
-    "transitModes": "BUS,TRAM,RAIL,SUBWAY",
-    "travelTimePercentile": 50,
-    "variantIndex": 0,
-    "walkSpeed": 1.3888888888888888,
-  },
-  "regional": Object {
-    "_id": null,
-    "breaks": Array [],
-    "comparisonGrid": null,
-    "comparisonId": null,
-    "grid": null,
-    "minimumImprovementProbability": 0,
-    "percentile": 50,
-    "probabilityGrid": null,
-  },
-  "scenarioApplicationErrors": null,
-  "selectedBookmark": null,
-}
-`;
-
 exports[`reducers > analysis should handle set regional analysis grids 1`] = `
 Object {
   "active": false,
@@ -570,6 +528,48 @@ Object {
       "title": "Error while applying the modification entitled 'Add Trip Pattern'.",
     },
   ],
+  "selectedBookmark": null,
+}
+`;
+
+exports[`reducers > analysis should handle update profile request 1`] = `
+Object {
+  "active": false,
+  "isFetchingIsochrone": false,
+  "profileRequest": Object {
+    "accessModes": "WALK",
+    "bikeSpeed": 4.166666666666667,
+    "date": "2016-12-20",
+    "directModes": "WALK",
+    "egressModes": "WALK",
+    "fromTime": 24321,
+    "maxRides": 4,
+    "maxTripDurationMinutes": 60,
+    "monteCarloDraws": 200,
+    "percentiles": Array [
+      5,
+      25,
+      50,
+      75,
+      95,
+    ],
+    "toTime": 25220,
+    "transitModes": "BUS,TRAM,RAIL,SUBWAY",
+    "travelTimePercentile": 50,
+    "variantIndex": 0,
+    "walkSpeed": 1.3888888888888888,
+  },
+  "regional": Object {
+    "_id": null,
+    "breaks": Array [],
+    "comparisonGrid": null,
+    "comparisonId": null,
+    "grid": null,
+    "minimumImprovementProbability": 0,
+    "percentile": 50,
+    "probabilityGrid": null,
+  },
+  "scenarioApplicationErrors": null,
   "selectedBookmark": null,
 }
 `;

--- a/lib/reducers/__tests__/analysis.js
+++ b/lib/reducers/__tests__/analysis.js
@@ -22,9 +22,9 @@ describe('reducers > analysis', () => {
   })
 
   // Specific Handler Tests
-  it('should handle set profile request', () => {
+  it('should handle update profile request', () => {
     const action = {
-      type: 'set profile request',
+      type: 'update profile request',
       payload: {
         fromTime: 24321,
         toTime: 25220

--- a/lib/reducers/analysis.js
+++ b/lib/reducers/analysis.js
@@ -6,6 +6,12 @@ export const reducers = {
   'set profile request' (state, action) {
     return {
       ...state,
+      profileRequest: action.payload
+    }
+  },
+  'update profile request' (state, action) {
+    return {
+      ...state,
       profileRequest: {
         ...state.profileRequest,
         ...action.payload


### PR DESCRIPTION
This PR fixes #744 and #710 by:

1. Loading Opportunity Datasets each time the selector is shown (on page navigation)
2. Loading Regional Analyses when navigating to the analysis page
3. Setting the entire profile request--instead of just updating it--on region change