### PR TITLE
Run new linter/prettifier on code in preparation of mastarm update

### DIFF
--- a/lib/actions/analysis/__tests__/index.js
+++ b/lib/actions/analysis/__tests__/index.js
@@ -66,7 +66,7 @@ describe('actions > analysis', () => {
       }
     }
 
-    expect(surface.warnings.length).toBe(1)
+    expect(surface.warnings).toHaveLength(1)
     expect(surface.warnings[0]).toEqual(mockScenarioApplicationError)
     expect(surface.errors).toEqual([])
   })

--- a/lib/actions/analysis/__tests__/regional.js
+++ b/lib/actions/analysis/__tests__/regional.js
@@ -1,8 +1,8 @@
 // @flow
 
-import * as regional from '../regional'
 import nock from 'nock'
 
+import * as regional from '../regional'
 import {makeMockStore, mockRegionalAnalyses} from '../../../utils/mock-data'
 
 describe('Actions > Analysis > Regional', () => {

--- a/lib/actions/analysis/index.js
+++ b/lib/actions/analysis/index.js
@@ -19,15 +19,14 @@ import {
   INITIALIZING_CLUSTER,
   COMPUTING_ISOCHRONE
 } from '../../constants/analysis-status'
-import {parseTimesData} from './parse-times-data'
 import * as select from '../../selectors'
 import downloadGeoTIFF from '../../utils/download-geotiff'
 import localStorage from '../../utils/local-storage'
 import timeout from '../../utils/timeout'
-
 import R5Version from '../../modules/r5-version'
-
 import type {GetState, LonLat} from '../../types'
+
+import {parseTimesData} from './parse-times-data'
 
 const RETRY_TIMEOUT_MILLSECONDS = 5000
 

--- a/lib/actions/analysis/parse-times-data.js
+++ b/lib/actions/analysis/parse-times-data.js
@@ -7,14 +7,14 @@ const HEADER_LENGTH = 9 // type + entries
 const TIMES_GRID_TYPE = 'ACCESSGR'
 
 type TimesData = {
-  version: number,
-  zoom: number,
-  west: number,
-  north: number,
-  width: number,
-  height: number,
+  data: Int32Array,
   depth: number,
-  data: Int32Array
+  height: number,
+  north: number,
+  version: number,
+  west: number,
+  width: number,
+  zoom: number
 }
 
 /**

--- a/lib/actions/analysis/regional.js
+++ b/lib/actions/analysis/regional.js
@@ -8,7 +8,6 @@ import sortBy from 'lodash/sortBy'
 import {createAction} from 'redux-actions'
 import {push} from 'react-router-redux'
 
-import {storeProfileRequestSettings} from './'
 import {PROFILE_REQUEST_DEFAULTS} from '../../constants'
 import colors from '../../constants/colors'
 import * as select from '../../selectors'
@@ -16,11 +15,11 @@ import {
   fetchMultipleSignedS3Urls,
   fetchSignedS3Url
 } from '../../utils/fetch-signed-s3-url'
-
 import {activeOpportunityDataset} from '../../modules/opportunity-datasets/selectors'
 import R5Version from '../../modules/r5-version'
-
 import type {LonLat} from '../../types'
+
+import {storeProfileRequestSettings} from './'
 
 const REGIONAL_URL = '/api/regional'
 
@@ -182,8 +181,8 @@ export const deleteRegionalAnalysis = (analysisId: string) => [
 const setAggregationAreaLocally = createAction('set aggregation area')
 const setAggregationAreaId = createAction('set aggregation area id')
 export const setAggregationArea = async (opts: void | {
-  regionId: string,
-  aggregationAreaId: string
+  aggregationAreaId: string,
+  regionId: string
 }) => [
   setAggregationAreaId(opts && opts.aggregationAreaId),
   setAggregationAreaLocally(null), // clear existing so UI doesn't show results that don't match now-selected aggregation area
@@ -205,8 +204,8 @@ export const uploadAggregationArea = ({
   files,
   regionId
 }: {
-  name: string,
   files: FileList,
+  name: string,
   regionId: string
 }) => {
   const formData = new window.FormData()

--- a/lib/actions/get-feeds-routes-and-stops.js
+++ b/lib/actions/get-feeds-routes-and-stops.js
@@ -2,7 +2,6 @@
 import fetch from '@conveyal/woonerf/fetch'
 import uniqBy from 'lodash/uniqBy'
 
-import {lockUiWithError, setFeeds} from './'
 import {
   ADJUST_DWELL_TIME,
   ADJUST_SPEED,
@@ -12,8 +11,9 @@ import {
   REROUTE
 } from '../constants'
 import * as query from '../graphql/query'
-
 import type {Modification} from '../types'
+
+import {lockUiWithError, setFeeds} from './'
 
 let currentBundleId = null // TODO this should be handled more gracefully
 let fetchedFeeds = []
@@ -52,7 +52,7 @@ function getAllRoutesAndStops ({bundleId, routeIds}) {
         fetchedFeeds = []
         if (json.bundle && json.bundle.length > 0) {
           json.bundle[0].feeds.forEach(feed => {
-            const {checksum, feed_id, stops} = feed
+            const {checksum, stops} = feed
             const detailRoutes: any[] = feed.detailRoutes
             const routes: any[] = feed.routes
               .map((r) => detailRoutes.find((d) => d.route_id === r.route_id) || r)
@@ -63,7 +63,7 @@ function getAllRoutesAndStops ({bundleId, routeIds}) {
             stops.forEach(s => { stopsById[s.stop_id] = s })
 
             fetchedFeeds.push({
-              id: feed_id,
+              id: feed.feed_id,
               routes,
               stops,
               stopsById,

--- a/lib/actions/index.js
+++ b/lib/actions/index.js
@@ -1,8 +1,9 @@
 // @flow
+import {stringify} from 'querystring'
+
 import fetch from '@conveyal/woonerf/fetch'
 import {push} from 'react-router-redux'
 import {createAction} from 'redux-actions'
-import {stringify} from 'querystring'
 
 import type {Bundle} from '../types'
 

--- a/lib/actions/modifications.js
+++ b/lib/actions/modifications.js
@@ -3,16 +3,17 @@ import fetch, {fetchMultiple} from '@conveyal/woonerf/fetch'
 import {createAction} from 'redux-actions'
 import {push} from 'react-router-redux'
 
-import {lockUiWithError} from './'
 import * as select from '../selectors'
-import getFeedsRoutesAndStops from './get-feeds-routes-and-stops'
 import {
   create as createModification,
   formatForServer,
   isValid
 } from '../utils/modification'
-
 import type {Modification} from '../types'
+
+import getFeedsRoutesAndStops from './get-feeds-routes-and-stops'
+
+import {lockUiWithError} from './'
 
 type GetState = () => any
 

--- a/lib/actions/project.js
+++ b/lib/actions/project.js
@@ -1,18 +1,19 @@
 // @flow
+import {stringify} from 'querystring'
+
 import fetch from '@conveyal/woonerf/fetch'
 import {createAction} from 'redux-actions'
 import {push} from 'react-router-redux'
-import {stringify} from 'querystring'
 
-import {loadBundle} from './'
+import downloadJson from '../utils/download-json'
+import type {Project} from '../types'
+
 import {
   set as saveModification,
   getForProject as getModificationsForProject
 } from './modifications'
 
-import downloadJson from '../utils/download-json'
-
-import type {Project} from '../types'
+import {loadBundle} from './'
 
 export const setCurrentProject = (_id: string) => ({
   type: 'set current project',

--- a/lib/actions/region.js
+++ b/lib/actions/region.js
@@ -3,13 +3,14 @@ import fetch from '@conveyal/woonerf/fetch'
 import {createAction} from 'redux-actions'
 import {push} from 'react-router-redux'
 
-import {loadBundles} from './'
+import timeout from '../utils/timeout'
+import type {Bookmark, Region} from '../types'
+
 import {setCenter as setMapCenter} from './map'
 import {loadProjects} from './project'
 import {loadProfileRequestSettings} from './analysis'
-import timeout from '../utils/timeout'
 
-import type {Bookmark, Region} from '../types'
+import {loadBundles} from './'
 
 const CHECK_STATUS_TIMEOUT = 10 * 1000
 
@@ -26,8 +27,8 @@ export const create = ({
   region,
   customOpenStreetMapData
 }: {
-  region: Region,
-  customOpenStreetMapData?: File
+  customOpenStreetMapData?: File,
+  region: Region
 }) => fetch({
   url: '/api/region',
   options: {

--- a/lib/components/__tests__/project-title.js
+++ b/lib/components/__tests__/project-title.js
@@ -18,7 +18,7 @@ describe('Component > ProjectTitle', () => {
           children='Children content'
           downloadScenario={downloadScenarioFn}
           project={mockProject}
-          />
+        />
       ),
       deleteProjectFn,
       downloadScenarioFn

--- a/lib/components/analysis/__tests__/bookmark-chooser.js
+++ b/lib/components/analysis/__tests__/bookmark-chooser.js
@@ -4,8 +4,8 @@
 
 import renderer from 'react-test-renderer'
 import React from 'react'
-import BookmarkChooser from '../bookmark-chooser'
 
+import BookmarkChooser from '../bookmark-chooser'
 import {mockProfileRequest, mockBookmark} from '../../../utils/mock-data'
 
 const props = {

--- a/lib/components/analysis/__tests__/legend.js
+++ b/lib/components/analysis/__tests__/legend.js
@@ -1,9 +1,10 @@
 // @flow
 
 import React from 'react'
-import Legend from '../legend'
 import {mount} from 'enzyme'
 import {mountToJson} from 'enzyme-to-json'
+
+import Legend from '../legend'
 
 describe('Components > Analysis > Regional > Legend', () => {
   it('should display', () => {

--- a/lib/components/analysis/__tests__/profile-request-display.js
+++ b/lib/components/analysis/__tests__/profile-request-display.js
@@ -4,7 +4,6 @@ import React from 'react'
 import renderer from 'react-test-renderer'
 
 import {mockProfileRequest} from '../../../utils/mock-data'
-
 import ProfileRequestDisplay from '../profile-request-display'
 
 describe('Components > Analysis > Profile Request Display', () => {

--- a/lib/components/analysis/__tests__/regional-analysis-selector.js
+++ b/lib/components/analysis/__tests__/regional-analysis-selector.js
@@ -14,7 +14,7 @@ describe('Components > Analysis > Regional Analysis Selector', () => {
           allAnalyses={mockRegionalAnalyses}
           deleteAnalysis={jest.fn()}
           goToAnalysis={jest.fn()}
-          />
+        />
       )
       .toJSON()
 

--- a/lib/components/analysis/__tests__/regional.js
+++ b/lib/components/analysis/__tests__/regional.js
@@ -29,7 +29,7 @@ describe('Components > Analysis > Regional', () => {
         setAggregationArea={jest.fn()}
         setAggregationWeights={jest.fn()}
         uploadAggregationArea={jest.fn()}
-        />
+      />
     )
 
     expect(snapshot()).toMatchSnapshot()

--- a/lib/components/analysis/advanced-settings.js
+++ b/lib/components/analysis/advanced-settings.js
@@ -7,22 +7,22 @@ import Select from 'react-select'
 
 import {Button} from '../buttons'
 import {Group, Number as InputNumber} from '../input'
-import EgressModeSelector from './egress-mode-selector'
-
 import type {Bounds, ProfileRequest} from '../../types'
+
+import EgressModeSelector from './egress-mode-selector'
 
 type Props = {
   disabled: boolean,
   hideBoundsEditor: () => void,
   profileRequest: ProfileRequest,
+  regionBounds: Bounds,
   regionalAnalyses: Array<Bounds & {
       _id: string,
-      name: string,
       height: number,
+      name: string,
       width: number,
       zoom: number
     }>,
-  regionBounds: Bounds,
   setProfileRequest: (profileRequestFields: any) => void,
   showBoundsEditor: () => void,
 }
@@ -151,17 +151,17 @@ export default class AdvancedSettings extends Component {
                 block
                 onClick={this._hideBoundsSelector}
                 style='warning'
-                >
+              >
                 <Icon type='stop' /> Stop editing bounds
-                </Button>
+              </Button>
               : <Button
                 disabled={disableInputs}
                 block
                 onClick={this._showBoundsSelector}
                 style='warning'
-                >
+              >
                 <Icon type='pencil' /> Set custom geographic bounds
-                </Button>}
+              </Button>}
           </div>
         </div>
       </Group>
@@ -192,7 +192,7 @@ export default class AdvancedSettings extends Component {
           <Icon
             className='pull-right'
             type={advancedSectionCollapsed ? 'caret-right' : 'caret-down'}
-            />
+          />
         </a>
         {!advancedSectionCollapsed &&
           <div className='panel-body'>
@@ -307,9 +307,9 @@ function webMercatorBoundsToGeographic ({
   height,
   zoom
 }: {
+  height: number,
   north: number,
   west: number,
-  height: number,
   width: number,
   zoom: number
 }): Bounds {

--- a/lib/components/analysis/aggregate-accessibility.js
+++ b/lib/components/analysis/aggregate-accessibility.js
@@ -7,7 +7,6 @@ import {format as d3Format} from 'd3-format'
 
 import colors from '../../constants/colors'
 import {Slider, Group} from '../input'
-
 import type {AggregateAccessibility} from '../../types'
 
 const WIDTH = 300
@@ -25,13 +24,13 @@ const FONT_SIZE = 10
 const PERCENTILE_OF_ACCESSIBILITY = 10
 
 type Props = {
-  aggregateAccessibility: AggregateAccessibility,
-  comparisonAggregateAccessibility: ?AggregateAccessibility,
-  weightByName: string,
   accessToName: string,
+  aggregateAccessibility: AggregateAccessibility,
   comparisonAccessToName: void | string,
+  comparisonAggregateAccessibility: ?AggregateAccessibility,
+  comparisonRegionalAnalysisName: void | string,
   regionalAnalysisName: string,
-  comparisonRegionalAnalysisName: void | string
+  weightByName: string
 }
 
 type State = {
@@ -167,7 +166,7 @@ function Bins ({
   xScale,
   yScale
 }: {
-  bins: {value: number, min: number, max: number}[],
+  bins: {max: number, min: number, value: number}[],
   breakPoint: number,
   color: string,
   xScale: number => number,
@@ -273,16 +272,16 @@ function createXScale (props: Props): number => number {
 
   const minAccessibility = comparisonAggregateAccessibility
     ? Math.min(
-        comparisonAggregateAccessibility.minAccessibility,
-        aggregateAccessibility.minAccessibility
-      )
+      comparisonAggregateAccessibility.minAccessibility,
+      aggregateAccessibility.minAccessibility
+    )
     : aggregateAccessibility.minAccessibility
 
   const maxAccessibility = comparisonAggregateAccessibility
     ? Math.max(
-        comparisonAggregateAccessibility.maxAccessibility,
-        aggregateAccessibility.maxAccessibility
-      )
+      comparisonAggregateAccessibility.maxAccessibility,
+      aggregateAccessibility.maxAccessibility
+    )
     : aggregateAccessibility.maxAccessibility
 
   return scaleLinear()
@@ -295,11 +294,11 @@ function createYScale (props: Props): number => number {
 
   const maxCount = comparisonAggregateAccessibility
     ? Math.max(
-        ...[
-          ...aggregateAccessibility.bins.map(b => b.value),
-          ...comparisonAggregateAccessibility.bins.map(b => b.value)
-        ]
-      )
+      ...[
+        ...aggregateAccessibility.bins.map(b => b.value),
+        ...comparisonAggregateAccessibility.bins.map(b => b.value)
+      ]
+    )
     : Math.max(...aggregateAccessibility.bins.map(b => b.value))
 
   return scaleLinear().domain([0, maxCount]).range([HEIGHT - X_SCALE_HEIGHT, 0]) // invert y, +y is down in SVG

--- a/lib/components/analysis/bookmark-chooser.js
+++ b/lib/components/analysis/bookmark-chooser.js
@@ -8,17 +8,16 @@ import Select from 'react-select'
 
 import {Group} from '../input'
 import {Button} from '../buttons'
-
 import type {Bookmark} from '../../types'
 
 type Props = {
-  bookmarks: Bookmark[],
   bookmarkData: any,
-  disabled: boolean,
-  selectedBookmark: boolean,
-
+  bookmarks: Bookmark[],
   createBookmark: (any) => void,
-  selectBookmark: (Bookmark) => void
+  disabled: boolean,
+
+  selectBookmark: (Bookmark) => void,
+  selectedBookmark: boolean
 }
 
 export default class BookmarkChooser extends Pure {

--- a/lib/components/analysis/boxplot.js
+++ b/lib/components/analysis/boxplot.js
@@ -8,9 +8,9 @@ import type {Quintiles} from '../../types'
  */
 export default class Boxplot extends PureComponent {
   props: Quintiles & {
-    width: number,
+    color: any,
     scale: number => number,
-    color: any
+    width: number
   }
 
   render () {

--- a/lib/components/analysis/index.js
+++ b/lib/components/analysis/index.js
@@ -10,7 +10,6 @@ import {GeoJSON, Marker} from 'react-leaflet'
 import Select from 'react-select'
 import uuid from 'uuid'
 
-import AdvancedSettings from './advanced-settings'
 import BookmarkChooser from '../../containers/bookmark-chooser'
 import {Button, Group as ButtonGroup} from '../buttons'
 import Collapsible from '../collapsible'
@@ -26,12 +25,9 @@ import Map from '../map'
 import ModificationsMap from '../../containers/modifications-map'
 import nearestPercentileIndex from '../../selectors/nearest-percentile-index'
 import OpportunityDatasets from '../../modules/opportunity-datasets'
-import ProfileRequestEditor from './profile-request-editor'
 import Sidebar from '../sidebar'
-import ScenarioApplicationError from './scenario-application-error'
 import StackedPercentileSelector
   from '../../containers/stacked-percentile-selector'
-
 import type {
   Bundle,
   LonLat,
@@ -41,53 +37,57 @@ import type {
   ReactSelectResult
 } from '../../types'
 
+import ScenarioApplicationError from './scenario-application-error'
+import ProfileRequestEditor from './profile-request-editor'
+import AdvancedSettings from './advanced-settings'
+
 type Bounds = {
+  east: number,
   north: number,
   south: number,
-  east: number,
   west: number
 }
 
 type Props = {
   bundles: Bundle[],
+  clearComparisonProject: () => void,
   comparisonDestinationTravelTimeDistribution?: Quintiles,
-  comparisonProject?: Project,
   comparisonIsochrone: any,
+  comparisonProject?: Project,
   comparisonVariant?: number,
+  createRegionalAnalysis: any => void,
   currentBundle?: Bundle,
   currentProject?: Project,
   destination: LonLat,
   destinationTravelTimeDistribution?: Quintiles,
+  downloadComparisonIsochrone: () => void,
+  downloadIsochrone: () => void,
+  fetchTravelTimeSurface: (asGeoTIFF?: boolean) => void,
   isFetchingIsochrone: boolean,
   isochrone: any,
   isochroneFetchStatusMessage?: string,
+  loadAllRegionalAnalyses: (regionId: string) => void,
   profileRequest: ProfileRequest,
   profileRequestHasChanged: boolean,
-  regionBounds?: Bounds,
-  regionId: string,
-  regionalAnalyses: Array<Bounds & {
-      _id: string,
-      name: string,
-      height: number,
-      width: number,
-      zoom: number
-    }>,
-  scenarioApplicationErrors?: any[],
-  scenarioApplicationWarnings?: any[],
+
   projects: Array<{
     _id: string,
     name: string,
     variants: string[]
   }>,
-
-  clearComparisonProject: () => void,
-  createRegionalAnalysis: any => void,
-  downloadComparisonIsochrone: () => void,
-  downloadIsochrone: () => void,
-  fetchTravelTimeSurface: (asGeoTIFF?: boolean) => void,
-  loadAllRegionalAnalyses: (regionId: string) => void,
   push: (string) => void,
+  regionBounds?: Bounds,
+  regionId: string,
+  regionalAnalyses: Array<Bounds & {
+      _id: string,
+      height: number,
+      name: string,
+      width: number,
+      zoom: number
+    }>,
   removeDestination: () => void,
+  scenarioApplicationErrors?: any[],
+  scenarioApplicationWarnings?: any[],
   setComparisonProject: (project: any) => void,
   setCurrentProject: (projectId: string) => void,
   setDestination: (any) => void,
@@ -186,8 +186,8 @@ export default class SinglePointAnalysis extends Pure {
     const {createRegionalAnalysis, currentProject, regionalAnalyses, profileRequest} = this.props
     if (currentProject) {
       const name = window.prompt(
-      'Enter a name and click ok to begin a regional analysis job for this project and settings:',
-      `Analysis ${regionalAnalyses.length + 1}: ${currentProject.name} ` +
+        'Enter a name and click ok to begin a regional analysis job for this project and settings:',
+        `Analysis ${regionalAnalyses.length + 1}: ${currentProject.name} ` +
       `${currentProject.variants[profileRequest.variantIndex]}`)
       if (name && name.length > 0) {
         createRegionalAnalysis({
@@ -437,13 +437,13 @@ export default class SinglePointAnalysis extends Pure {
                   disabled={!isochrone}
                   onClick={downloadIsochrone}
                   style='info'
-                  ><Icon type='download' /> Isochrone as GeoJSON
+                ><Icon type='download' /> Isochrone as GeoJSON
                 </Button>
                 <Button
                   disabled={!comparisonIsochrone}
                   onClick={downloadComparisonIsochrone}
                   style='info'
-                  ><Icon type='download' /> Comparison Isochrone as GeoJSON
+                ><Icon type='download' /> Comparison Isochrone as GeoJSON
                 </Button>
               </ButtonGroup>
 
@@ -451,7 +451,7 @@ export default class SinglePointAnalysis extends Pure {
                 <Button
                   onClick={this._downloadGeoTIFFs}
                   style='info'
-                  ><Icon type='globe' /> Generate & Download GeoTIFFs
+                ><Icon type='globe' /> Generate & Download GeoTIFFs
                 </Button>
               </ButtonGroup>
 

--- a/lib/components/analysis/minute-ticks.js
+++ b/lib/components/analysis/minute-ticks.js
@@ -27,8 +27,8 @@ export default function MinuteTicks ({scale, textHeight}: Props) {
             textAnchor: i === arr.length - 1
               ? 'end' // don't run off end, fudge position of last value a bit
               : i === 0
-                  ? 'start' // don't center the whole '15 minutes' text
-                  : 'middle'
+                ? 'start' // don't center the whole '15 minutes' text
+                : 'middle'
           }}
         >
           {/* label first minute */}

--- a/lib/components/analysis/profile-request-editor.js
+++ b/lib/components/analysis/profile-request-editor.js
@@ -3,11 +3,11 @@ import message from '@conveyal/woonerf/message'
 import React, {Component} from 'react'
 
 import DatePicker from '../date-picker'
-import ModeSelector from './mode-selector'
 import R5Version from '../../modules/r5-version'
 import TimePicker from '../time-picker'
-
 import type {ProfileRequest} from '../../types'
+
+import ModeSelector from './mode-selector'
 
 type Props = {
   disabled: boolean,

--- a/lib/components/analysis/regional-analysis-selector.js
+++ b/lib/components/analysis/regional-analysis-selector.js
@@ -4,6 +4,7 @@ import React from 'react'
 import Select from 'react-select'
 
 import {Group} from '../input'
+
 import RunningAnalysis from './running-analysis'
 
 type Props = {

--- a/lib/components/analysis/regional-results-list.js
+++ b/lib/components/analysis/regional-results-list.js
@@ -5,27 +5,27 @@ import React, {Component} from 'react'
 import ErrorModal from '../error-modal'
 import InnerDock from '../inner-dock'
 import Map from '../map'
-import Selector from './regional-analysis-selector'
 import Sidebar from '../sidebar'
-
 import type {Bounds} from '../../types'
+
+import Selector from './regional-analysis-selector'
 
 type RegionalAnalysis = Bounds & {
   _id: string,
-  name: string,
   height: number,
+  name: string,
   width: number,
   zoom: number
 }
 
 type Props = {
   allAnalyses: RegionalAnalysis[],
-  regionId: string,
-
   deleteAnalysis: (analysisId: string) => void,
+
   goToAnalysis: ({analysisId: string, regionId: string}) => void,
   goToSinglePointAnalysisPage: () => void,
-  loadAllAnalyses: () => void
+  loadAllAnalyses: () => void,
+  regionId: string
 }
 
 const REFETCH_INTERVAL = 30 * 1000 // 30 seconds
@@ -70,12 +70,12 @@ export default class RegionalAnalysisResultsList extends Component {
                   deleteAnalysis={p.deleteAnalysis}
                   goToAnalysis={(analysisId) =>
                     p.goToAnalysis({analysisId, regionId: p.regionId})}
-                  />
+                />
                 : <a
                   onClick={() => p.goToSinglePointAnalysisPage(p.regionId)}
                   tabIndex={0}
                 >You have no running or completed regional analysis jobs! To create one, go to the single point analysis page.
-                  </a>}
+                </a>}
             </div>
           </InnerDock>
         </div>

--- a/lib/components/analysis/regional-results.js
+++ b/lib/components/analysis/regional-results.js
@@ -4,15 +4,10 @@ import message from '@conveyal/woonerf/message'
 import React, {Component} from 'react'
 import Select from 'react-select'
 
-import AggregateAccessibility from './aggregate-accessibility'
 import {Button} from '../buttons'
-import Legend from './legend'
 import colors from '../../constants/colors'
-import ProfileRequestDisplay from './profile-request-display'
 import {Group, Text, File} from '../input'
-
 import OpportunityDatasets from '../../modules/opportunity-datasets'
-
 import type {
   RegionalAnalysis,
   Grid,
@@ -22,43 +17,47 @@ import type {
   ReactSelectResult
 } from '../../types'
 
+import ProfileRequestDisplay from './profile-request-display'
+import Legend from './legend'
+import AggregateAccessibility from './aggregate-accessibility'
+
 type Props = {
+  accessToName: string,
+  aggregateAccessibility?: AggregateAccessibilityType,
+  aggregationAreaId?: string,
+  aggregationAreaUploading?: boolean,
+  aggregationAreas: AggregationArea[],
+  aggregationWeightsId?: string,
+  aggregationWeightsName?: string,
   analysis: RegionalAnalysis,
   analysisId: string,
   breaks: number[],
+  comparisonAccessToName?: string,
+  comparisonAggregateAccessibility?: AggregateAccessibilityType,
   comparisonAnalysis?: RegionalAnalysis,
   differenceGrid?: Grid,
+  fetch: any => any,
   grid?: Grid,
-  aggregationAreas: AggregationArea[],
+  loadRegionalAnalysisGrids: (any) => void,
   opportunityDatasets: OpportunityDataset[],
-  regionId: string,
   projectId: string,
-  regionalAnalyses?: RegionalAnalysis[],
-  aggregationAreaId?: string,
-  aggregationWeightsId?: string,
-  aggregationAreaUploading?: boolean,
-  aggregateAccessibility?: AggregateAccessibilityType,
-  comparisonAggregateAccessibility?: AggregateAccessibilityType,
-  accessToName: string,
-  comparisonAccessToName?: string,
-  aggregationWeightsName?: string,
 
   // actions
-  fetch: any => any,
-  loadRegionalAnalysisGrids: (any) => void,
+  regionId: string,
+  regionalAnalyses?: RegionalAnalysis[],
   setActiveRegionalAnalysis: any => void,
   setAggregationArea: (opts: void | {aggregationAreaId: string, regionId: string}) => void,
   uploadAggregationArea: (arg: {
-    name: string,
     files: FileList,
+    name: string,
     regionId: string
   }) => void
 }
 
 type State = {
-  showAggregationAreaUpload: boolean,
   aggregationAreaFiles: null | FileList,
-  aggregationAreaName: null | string
+  aggregationAreaName: null | string,
+  showAggregationAreaUpload: boolean
 }
 
 /** render a regional analysis */
@@ -321,7 +320,7 @@ export default class RegionalResults extends Component<void, Props, State> {
             <ProfileRequestDisplay
               {...comparisonAnalysis}
               {...comparisonAnalysis.request}
-              />
+            />
           </div>}
 
         <p>

--- a/lib/components/analysis/regional.js
+++ b/lib/components/analysis/regional.js
@@ -6,12 +6,10 @@ import {Rectangle} from 'react-leaflet'
 
 import {Application, Dock, Title} from '../base'
 import {IconLink} from '../link'
-
 import AggregationArea from '../../containers/aggregation-area'
 import RegionalLayer from '../../containers/regional-layer'
 import SamplingDistribution from '../../containers/regional-analysis-sampling-distribution'
 import OpportunityDatasets from '../../modules/opportunity-datasets'
-
 import LabelLayer from '../map/label-layer'
 
 import ProfileRequestDisplay from './profile-request-display'

--- a/lib/components/analysis/running-analysis.js
+++ b/lib/components/analysis/running-analysis.js
@@ -24,7 +24,7 @@ export default function RunningAnalysis ({analysis, onDelete}: Props) {
           onClick={onDelete}
           tabIndex={0}
           title='Cancel regional analysis'
-          >
+        >
           <Icon type='times' />
         </a>
       </span>

--- a/lib/components/analysis/stacked-percentile-selector.js
+++ b/lib/components/analysis/stacked-percentile-selector.js
@@ -5,9 +5,10 @@ import {format} from 'd3-format'
 import React, {PureComponent} from 'react'
 import memoize from 'lodash/memoize'
 
-import StackedPercentile from './stacked-percentile'
 import {Button, Group as ButtonGroup} from '../buttons'
 import colors from '../../constants/colors'
+
+import StackedPercentile from './stacked-percentile'
 
 export const PROJECT = 'project'
 export const BASE = 'base'
@@ -24,13 +25,13 @@ export default class StackedPercentileSelector extends PureComponent {
   props: {
     accessibility?: number,
     comparisonAccessibility?: number,
-    comparisonPercentileCurves?: number[][],
     comparisonInProgress: boolean,
+    comparisonPercentileCurves?: number[][],
     comparisonProjectName?: string,
-    opportunityDatasetName?: string,
-    isochroneCutoff: number,
     isFetchingIsochrone: boolean,
+    isochroneCutoff: number,
     maxAccessibility: number,
+    opportunityDatasetName?: string,
     percentileCurves: number[][],
     projectName: string,
     setIsochroneCutoff: (cutoff: number) => void

--- a/lib/components/analysis/stacked-percentile.js
+++ b/lib/components/analysis/stacked-percentile.js
@@ -5,8 +5,9 @@ import {format} from 'd3-format'
 import {scalePow, scaleLinear} from 'd3-scale'
 import {line, area} from 'd3-shape'
 
-import Boxplot from './boxplot'
 import {TRAVEL_TIME_PERCENTILES} from '../../constants'
+
+import Boxplot from './boxplot'
 import {PROJECT, BASE, COMPARISON} from './stacked-percentile-selector'
 import MinuteTicks from './minute-ticks'
 
@@ -41,18 +42,18 @@ const MAX_TRIP_DURATION = 120
 const Y_AXIS_EXPONENT = 0.5
 
 type Props = {
-  opportunityDatasetName: string,
-  percentileCurves: number[][],
-  comparisonPercentileCurves: number[][],
-  isochroneCutoff: number,
-  width: number,
-  height: number,
-  maxAccessibility: number,
   color: any,
   comparisonColor: any,
-  selected: string,
+  comparisonLabel: string,
+  comparisonPercentileCurves: number[][],
+  height: number,
+  isochroneCutoff: number,
   label: string,
-  comparisonLabel: string
+  maxAccessibility: number,
+  opportunityDatasetName: string,
+  percentileCurves: number[][],
+  selected: string,
+  width: number
 }
 
 type State = {
@@ -195,8 +196,8 @@ export default class StackedPercentile extends PureComponent {
     color,
     width
   }: {
-    percentileCurves: number[][],
     color: any,
+    percentileCurves: number[][],
     width: number
   }) {
     const {yScale} = this.state
@@ -273,9 +274,9 @@ export default class StackedPercentile extends PureComponent {
     color,
     breaks
   }: {
-    percentileCurves: number[][],
+    breaks: number[],
     color: any,
-    breaks: number[]
+    percentileCurves: number[][]
   }) {
     const {xScale, yScale} = this.state
     // add one to x value below to convert from 0-based array indices (index 0 has accessibility from 0-1 minute)
@@ -313,7 +314,7 @@ export default class StackedPercentile extends PureComponent {
     )
   }
 
-  renderCumulativeLine ({curve, color}: {curve: number[], color: any}) {
+  renderCumulativeLine ({curve, color}: {color: any, curve: number[]}) {
     const {xScale, yScale} = this.state
     const percentileLine = line()
       // add one for the reason described above

--- a/lib/components/bundles.js
+++ b/lib/components/bundles.js
@@ -1,10 +1,9 @@
 // @flow
 import Icon from '@conveyal/woonerf/components/icon'
 import React from 'react'
+import type {Children} from 'react'
 
 import {Application, Dock, Title} from './base'
-
-import type {Children} from 'react'
 
 export default function Bundles ({children}: {children?: Children}) {
   return (

--- a/lib/components/create-bundle.js
+++ b/lib/components/create-bundle.js
@@ -3,9 +3,9 @@ import Icon from '@conveyal/woonerf/components/icon'
 import message from '@conveyal/woonerf/message'
 import React, {Component} from 'react'
 
-import {File, Text} from './input'
-
 import type {Bundle} from '../types'
+
+import {File, Text} from './input'
 
 // how often to poll when waiting for a bundle to be read on the server.
 const POLL_TIMEOUT_MS = 10000
@@ -13,11 +13,11 @@ const STATUS_DONE = 'DONE'
 const STATUS_ERROR = 'ERROR'
 
 type Props = {
-  regionId: string,
-
   addBundle: Bundle => void,
+
   deleteBundle: () => void,
   fetch: any => void,
+  regionId: string,
   saveBundle: Bundle => void
 }
 
@@ -133,9 +133,9 @@ export default class CreateBundle extends Component {
             disabled={uploading || !name || !files}
             type='submit'
           >{uploading
-             ? <span><Icon className='fa-spin' type='spinner' />
-               {message('common.loading')}</span>
-             : <span><Icon type='check' /> {message('common.create')}</span>}
+              ? <span><Icon className='fa-spin' type='spinner' />
+                {message('common.loading')}</span>
+              : <span><Icon type='check' /> {message('common.create')}</span>}
           </button>
         </form>
       </div>

--- a/lib/components/create-project.js
+++ b/lib/components/create-project.js
@@ -4,17 +4,18 @@ import message from '@conveyal/woonerf/message'
 import React from 'react'
 import Select from 'react-select'
 
+import type {Bundle} from '../types'
+
 import {Application, Title, Dock} from './base'
 import {Button} from './buttons'
 import {Group as FormGroup, Text} from './input'
-import type {Bundle} from '../types'
 
 type Props = {
   bundles: Bundle[],
-  regionId: string,
-
   create: (any) => void,
-  goToCreateBundle: () => void
+
+  goToCreateBundle: () => void,
+  regionId: string
 }
 
 export default class CreateProject extends React.PureComponent {
@@ -70,12 +71,12 @@ export default class CreateProject extends React.PureComponent {
                 value={bundleId}
               />
             </FormGroup>
-          : <FormGroup>
-            <p>{message('project.noBundles')}</p>
-            <Button block onClick={this._goToCreateBundle} style='success'>
-              <Icon type='plus' /> {message('bundle.create')}
-            </Button>
-          </FormGroup>}
+            : <FormGroup>
+              <p>{message('project.noBundles')}</p>
+              <Button block onClick={this._goToCreateBundle} style='success'>
+                <Icon type='plus' /> {message('bundle.create')}
+              </Button>
+            </FormGroup>}
           {!readyToCreate && <p className='alert alert-danger'>
             <Icon type='exclamation-circle' /> {message('project.createActionTooltip')}
           </p>}

--- a/lib/components/create-region.js
+++ b/lib/components/create-region.js
@@ -4,9 +4,10 @@ import message from '@conveyal/woonerf/message'
 import memoize from 'lodash/memoize'
 import React, {Component} from 'react'
 
+import {DEFAULT_BOUNDS} from '../constants/region'
+
 import {Application, Dock, Title} from './base'
 import {Button} from './buttons'
-import {DEFAULT_BOUNDS} from '../constants/region'
 import {Text, File} from './input'
 import EditBounds from './map/edit-bounds'
 import LabelLayer from './map/label-layer'
@@ -30,7 +31,7 @@ function parseLat (val) {
 }
 
 type Props = {
-  create: ({region: any, customOpenStreetMapData: ?Object}) => void
+  create: ({customOpenStreetMapData: ?Object, region: any}) => void
 }
 
 export default class CreateRegion extends Component {

--- a/lib/components/directional-markers.js
+++ b/lib/components/directional-markers.js
@@ -4,7 +4,6 @@ import {GridLayer, point} from 'leaflet'
 import {MapLayer} from 'react-leaflet'
 
 import {getBearingAndCoordinatesAlongLine} from '../utils/markers'
-
 import type {Pattern} from '../types'
 
 type Props = {

--- a/lib/components/edit-bundle.js
+++ b/lib/components/edit-bundle.js
@@ -3,21 +3,21 @@ import Icon from '@conveyal/woonerf/components/icon'
 import memoize from 'lodash/memoize'
 import React, {Component} from 'react'
 import Select from 'react-select'
-
-import {Button} from './buttons'
-import {Group, Text} from './input'
 import message from '@conveyal/woonerf/message'
 
 import type {Bundle, ReactSelectResult} from '../types'
 
+import {Button} from './buttons'
+import {Group, Text} from './input'
+
 type Props = {
   bundle?: Bundle,
   bundles: Bundle[],
-  isLoaded: boolean,
+  deleteBundle: () => void,
 
   goToCreateBundle: () => void,
   goToEditBundle: (_id: string) => void,
-  deleteBundle: () => void,
+  isLoaded: boolean,
   saveBundle: (bundle: Bundle) => void
 }
 

--- a/lib/components/edit-project.js
+++ b/lib/components/edit-project.js
@@ -1,21 +1,21 @@
 // @flow
 import React, {PureComponent} from 'react'
-
 import Icon from '@conveyal/woonerf/components/icon'
-import {Application, Dock, Title} from './base'
-import {Button} from './buttons'
-import {Group as FormGroup, Text} from './input'
 import message from '@conveyal/woonerf/message'
 
 import type {Project} from '../types'
 
+import {Application, Dock, Title} from './base'
+import {Button} from './buttons'
+import {Group as FormGroup, Text} from './input'
+
 type Props = {
   bundleName: string,
-  project: Project,
-
   close: (any) => void,
-  save: (any) => void,
-  deleteProject: (project: any) => void
+
+  deleteProject: (project: any) => void,
+  project: Project,
+  save: (any) => void
 }
 
 export default class EditProject extends PureComponent {

--- a/lib/components/edit-region.js
+++ b/lib/components/edit-region.js
@@ -4,12 +4,12 @@ import message from '@conveyal/woonerf/message'
 import memoize from 'lodash/memoize'
 import React from 'react'
 
+import type {Region, LonLat} from '../types.js'
+
 import {Application, Dock, Title} from './base'
 import {Button} from './buttons'
 import {Text} from './input'
 import EditBounds from './map/edit-bounds'
-
-import type {Region, LonLat} from '../types.js'
 
 const cardinalDirections = ['North', 'South', 'East', 'West']
 
@@ -30,11 +30,11 @@ function parseLat (val) {
 }
 
 type Props = {
-  region: Region,
+  deleteRegion: () => void,
 
   // actions
-  deleteRegion: () => void,
   load: (string) => void,
+  region: Region,
   save: (region: Region) => void,
   setCenter: (LonLat) => void,
   setLocally: (Object) => void

--- a/lib/components/error-modal.js
+++ b/lib/components/error-modal.js
@@ -5,16 +5,17 @@ import React from 'react'
 import {connect} from 'react-redux'
 
 import {clearError} from '../actions'
+
 import {Button} from './buttons'
 import Modal, {ModalBody, ModalTitle} from './modal'
 import Collapsible from './collapsible'
 
 type Props = {
+  clearError: () => void,
   error: string,
   errorMessage: string,
-  url: string,
   stack: string,
-  clearError: () => void
+  url: string
 }
 
 function mapStateToProps (state, ownProps) {
@@ -57,8 +58,8 @@ class ErrorModal extends React.PureComponent {
               <p>{stack}</p>
             </Collapsible>
             <br />
-            </div>
-          }
+          </div>
+        }
         <p>
           {message('error.report') + ' '}
           <a href={'mailto:' + `${message('error.supportEmail')}` +

--- a/lib/components/import-modifications.js
+++ b/lib/components/import-modifications.js
@@ -4,21 +4,21 @@ import Icon from '@conveyal/woonerf/components/icon'
 import React, {PureComponent} from 'react'
 import Select from 'react-select'
 
-import {Application, Dock} from './base'
-import {Button} from './buttons'
 import ProjectTitle from '../containers/project-title'
-
 import type {Project} from '../types'
 
+import {Application, Dock} from './base'
+import {Button} from './buttons'
+
 type Props = {
-  projects: Project[],
   copyFromProject: ({
     fromProjectId: string,
     toProjectId: string
   }) => void,
-  toProjectId: string,
+  projects: Project[],
+  push: string => void,
   regionId: string,
-  push: string => void
+  toProjectId: string
 }
 
 type State = {

--- a/lib/components/import-shapefile.js
+++ b/lib/components/import-shapefile.js
@@ -6,34 +6,34 @@ import distance from '@turf/distance'
 import {lineString, point} from '@turf/helpers'
 import dbg from 'debug'
 
-import {Application, Dock} from './base'
 import {ADD_TRIP_PATTERN} from '../constants'
 import ProjectTitle from '../containers/project-title'
-import {Button} from './buttons'
-import {File, Number as InputNumber, Select, Checkbox} from './input'
 import {create as createModification} from '../utils/modification'
 import {create as createTimetable} from '../utils/timetable'
-
 import type {Modification} from '../types'
+
+import {File, Number as InputNumber, Select, Checkbox} from './input'
+import {Button} from './buttons'
+import {Application, Dock} from './base'
 
 const debug = dbg('analysis-ui:import-shapefile')
 
 type Props = {
   createModifications: (Modification[]) => void,
-  variants: boolean[],
-  projectId: string
+  projectId: string,
+  variants: boolean[]
 }
 
 type State = {
-  shapefile: any,
-  stopSpacingMeters: number, // meters
-  bidirectional: boolean,
   autoCreateStops: boolean,
-  nameProp: string,
-  freqProp: string,
-  speedProp: string,
+  bidirectional: boolean, // meters
   error?: Error,
+  freqProp: string,
+  nameProp: string,
   properties?: string[],
+  shapefile: any,
+  speedProp: string,
+  stopSpacingMeters: number,
   uploading: boolean
 }
 

--- a/lib/components/input.js
+++ b/lib/components/input.js
@@ -170,7 +170,7 @@ export class Number extends PureComponent {
           onWheel={preventDefaultIfFocused}
           {...propsLessOnChange}
           id={id}
-          />
+        />
         {error &&
           <span className='help-block'>
             {isNaN(parseFloat(max))

--- a/lib/components/link.js
+++ b/lib/components/link.js
@@ -7,10 +7,10 @@ import Tip from './tip'
 
 export default class Link extends Component {
   props: {
-    className?: string,
     children?: Children,
-    title?: string,
+    className?: string,
     tip?: string,
+    title?: string,
     to?: string
   }
 
@@ -26,5 +26,5 @@ export default class Link extends Component {
   }
 }
 
-export const IconLink = ({type, ...props}: {type: string, props?: any}) =>
+export const IconLink = ({type, ...props}: {props?: any, type: string}) =>
   <Link {...props} type='button'><Icon type={type} /></Link>

--- a/lib/components/map/destination-travel-time-distribution.js
+++ b/lib/components/map/destination-travel-time-distribution.js
@@ -5,12 +5,12 @@ import {scaleLinear} from 'd3-scale'
 import {Marker as LeafletMarker} from 'leaflet'
 import React, {PureComponent} from 'react'
 
-import DraggablePopup from './draggable-popup'
 import Boxplot from '../analysis/boxplot'
 import MinuteTicks from '../analysis/minute-ticks'
 import colors from '../../constants/colors'
-
 import type {LonLat, Quintiles} from '../../types'
+
+import DraggablePopup from './draggable-popup'
 
 const WIDTH = 450
 const HEIGHT = 100
@@ -20,9 +20,9 @@ const SCALE = scaleLinear().domain([0, MAX_TRIP_DURATION]).range([0, WIDTH])
 const FONT_SIZE = 10
 
 type Props = {
+  comparisonDistribution?: Quintiles,
   destination: LonLat,
   distribution: Quintiles,
-  comparisonDistribution?: Quintiles,
   isFetchingIsochrone: boolean,
   remove: () => void,
   setDestination: (LonLat) => void

--- a/lib/components/map/edit-region-bounds.js
+++ b/lib/components/map/edit-region-bounds.js
@@ -1,9 +1,9 @@
 // @flow
 import React, {Component} from 'react'
 
-import EditBounds from './edit-bounds'
-
 import type {Bounds, Region} from '../../types'
+
+import EditBounds from './edit-bounds'
 
 export default class EditRegionBounds extends Component {
   props: {

--- a/lib/components/map/gridualizer.js
+++ b/lib/components/map/gridualizer.js
@@ -9,17 +9,17 @@ type Interpolator = (Grid, number, number) => (number) => number
 
 type Props = {
   breaks?: number[],
-  colors?: string[],
   colorizer?: number => number[],
-  interpolator: Interpolator,
-  grid: Grid
+  colors?: string[],
+  grid: Grid,
+  interpolator: Interpolator
 }
 
 type State = {
   colorizer: number => number[],
+  drawTile: null | () => void,
   grid: Grid,
-  interpolator: Interpolator,
-  drawTile: null | () => void
+  interpolator: Interpolator
 }
 
 function createCreateDrawTile (props: Props) {

--- a/lib/components/map/index.js
+++ b/lib/components/map/index.js
@@ -7,18 +7,17 @@ import {connect} from 'react-redux'
 import {Map as LeafletMap, TileLayer} from 'react-leaflet'
 
 import * as select from '../../selectors'
-
 import type {LonLat} from '../../types'
 
 type Props = {
   bounds: Leaflet.LatLngBounds,
   center: LonLat,
   children: React.Children,
+  maxBounds: Leaflet.LatLngBounds,
+  minZoom: number,
   tileUrl: string,
   zIndex: number,
-  zoom: number,
-  minZoom: number,
-  maxBounds: Leaflet.LatLngBounds
+  zoom: number
 }
 
 // prefer to use canvas for rendering, improves speed significantly

--- a/lib/components/map/isochrone.js
+++ b/lib/components/map/isochrone.js
@@ -5,25 +5,25 @@ import PropTypes from 'prop-types'
 import React, {Component} from 'react'
 import {Marker} from 'react-leaflet'
 
-import GeoJSON from './geojson'
 import colors from '../../constants/colors'
-
 import type {LonLat} from '../../types'
 
+import GeoJSON from './geojson'
+
 type Props = {
+  addDestinationTravelTimeDistributionComponentToMap: () => void,
   comparisonInProgress: boolean,
   comparisonIsochrone: any,
   isDestinationTravelTimeDistributionComponentOnMap: boolean,
-  isochroneCutoff: number,
-  isochroneLonLat: any,
   isochrone: any,
+  isochroneCutoff: number,
   isochroneIsStale: boolean,
 
   // actions
+  isochroneLonLat: any,
   remove: () => void,
-  setDestination: () => void,
-  addDestinationTravelTimeDistributionComponentToMap: () => void,
   removeDestinationTravelTimeDistributionComponentFromMap: () => void,
+  setDestination: () => void,
   setIsochroneLonLat: (lonlat: LonLat) => void
 }
 

--- a/lib/components/map/regional-analysis-sampling-distribution.js
+++ b/lib/components/map/regional-analysis-sampling-distribution.js
@@ -8,10 +8,10 @@ import {format} from 'd3-format'
 import range from 'lodash/range'
 import lonlat from '@conveyal/lonlat'
 
-import DraggablePopup from './draggable-popup'
 import colors from '../../constants/colors'
-
 import type {LonLat} from '../../types'
+
+import DraggablePopup from './draggable-popup'
 
 const WIDTH = 400
 const HEIGHT = 200
@@ -19,18 +19,18 @@ const SCALE_HEIGHT = 15
 
 type Props = {
   _id: string,
-  samplingDistribution: number[],
-  comparisonSamplingDistribution: ?(number[]),
   comparisonId: ?string,
+  comparisonSamplingDistribution: ?(number[]),
   origin: LonLat,
+  samplingDistribution: number[],
   setRegionalAnalysisOrigin: () => void
 }
 
 type State = {
-  xScale: scaleLinear,
-  yScale: scaleLinear,
+  comparisonEstimate: number[][] | null,
   estimate: number[][],
-  comparisonEstimate: number[][] | null
+  xScale: scaleLinear,
+  yScale: scaleLinear
 }
 
 /**
@@ -139,8 +139,8 @@ function precomputeScales ({
 
   const comparisonEstimate = comparisonSamplingDistribution
     ? stats.kde().sample(comparisonSamplingDistribution)(
-        range(WIDTH).map(xScale.invert)
-      )
+      range(WIDTH).map(xScale.invert)
+    )
     : null
 
   const estimateMax = Math.max(

--- a/lib/components/map/regional.js
+++ b/lib/components/map/regional.js
@@ -5,9 +5,9 @@ import PropTypes from 'prop-types'
 import React, {Component} from 'react'
 
 import colors from '../../constants/colors'
-import Gridualizer from './gridualizer'
-
 import type {Grid} from '../../types'
+
+import Gridualizer from './gridualizer'
 
 const NO_DATA = -Math.pow(2, 30)
 

--- a/lib/components/minutes-seconds.js
+++ b/lib/components/minutes-seconds.js
@@ -1,8 +1,9 @@
 // @flow
 import React, {PureComponent} from 'react'
 
-import {Text} from './input'
 import {secondsToMmSsString, mmSsStringToSeconds} from '../utils/time'
+
+import {Text} from './input'
 
 type Props = {
   onBlur?: any => void,

--- a/lib/components/modal.js
+++ b/lib/components/modal.js
@@ -1,7 +1,6 @@
 // @flow
 import React from 'react'
 import Modal from 'react-modal'
-
 import type {Children} from 'react'
 
 type Props = {

--- a/lib/components/modification/__tests__/add-trip-pattern.js
+++ b/lib/components/modification/__tests__/add-trip-pattern.js
@@ -4,7 +4,6 @@ import renderer from 'react-test-renderer'
 import React from 'react'
 
 import {mockMapState, mockModification} from '../../../utils/mock-data'
-
 import {AddTripPattern} from '../add-trip-pattern'
 
 describe('Component > Modification > AddTripPattern', () => {

--- a/lib/components/modification/__tests__/adjust-dwell-time.js
+++ b/lib/components/modification/__tests__/adjust-dwell-time.js
@@ -4,7 +4,6 @@ import renderer from 'react-test-renderer'
 import React from 'react'
 
 import {mockFeed, mockModification, mockPattern} from '../../../utils/mock-data'
-
 import AdjustDwellTime from '../adjust-dwell-time'
 
 describe('Component > Modification > AdjustDwellTime', () => {

--- a/lib/components/modification/__tests__/adjust-speed.js
+++ b/lib/components/modification/__tests__/adjust-speed.js
@@ -4,7 +4,6 @@ import renderer from 'react-test-renderer'
 import React from 'react'
 
 import {mockFeed, mockModification} from '../../../utils/mock-data'
-
 import AdjustSpeed from '../adjust-speed'
 
 describe('Component > Modification > AdjustSpeed', () => {

--- a/lib/components/modification/__tests__/convert-to-frequency.js
+++ b/lib/components/modification/__tests__/convert-to-frequency.js
@@ -3,7 +3,6 @@ import renderer from 'react-test-renderer'
 import React from 'react'
 
 import {mockFeed, mockModification, mockPattern, mockStop1} from '../../../utils/mock-data'
-
 import ConvertToFrequency from '../convert-to-frequency'
 
 describe('Component > Modification > ConvertToFrequency', () => {

--- a/lib/components/modification/__tests__/copy-timetable.js
+++ b/lib/components/modification/__tests__/copy-timetable.js
@@ -8,7 +8,6 @@ import {
   mockSegment,
   mockWithProvider
 } from '../../../utils/mock-data'
-
 import CopyTimetable from '../copy-timetable'
 
 const mockRegionId = 'r1'
@@ -86,7 +85,7 @@ describe('Component > Modification > CopyTimetable', () => {
         getTimetables={() => new Promise((resolve, reject) => {
           setTimeout(resolve(getTimetables()), 200)
         })}
-        />
+      />
     )
 
     // snapshot loading state
@@ -110,7 +109,7 @@ describe('Component > Modification > CopyTimetable', () => {
         currentProject={mockProject}
         currentRegionId={mockRegionId}
         getTimetables={getTimetables}
-        />
+      />
     )
 
     // wait for load to finish
@@ -136,7 +135,7 @@ describe('Component > Modification > CopyTimetable', () => {
         currentProject={mockProject}
         currentRegionId={mockRegionIdWithNoTimetables}
         getTimetables={getTimetables}
-        />
+      />
     )
 
     // wait for load to finish
@@ -157,7 +156,7 @@ describe('Component > Modification > CopyTimetable', () => {
         currentProject={mockProject}
         currentRegionId={mockRegionIdWithNoTimetables}
         getTimetables={getTimetables}
-        />
+      />
     )
 
     // wait for load to finish
@@ -181,7 +180,7 @@ describe('Component > Modification > CopyTimetable', () => {
           currentProject={mockProject}
           currentRegionId={mockRegionId}
           getTimetables={getTimetables}
-          />
+        />
       )
 
       // wait for load to finish
@@ -203,7 +202,7 @@ describe('Component > Modification > CopyTimetable', () => {
           currentProject={mockProject}
           currentRegionId={mockRegionId}
           getTimetables={getTimetables}
-          />
+        />
       )
 
       // wait for load to finish
@@ -225,7 +224,7 @@ describe('Component > Modification > CopyTimetable', () => {
           currentProject={mockProject}
           currentRegionId={mockRegionId}
           getTimetables={getTimetables}
-          />
+        />
       )
 
       // wait for load to finish
@@ -250,7 +249,7 @@ describe('Component > Modification > CopyTimetable', () => {
           currentProject={mockProject}
           currentRegionId={mockRegionId}
           getTimetables={getTimetables}
-          />
+        />
       )
 
       // wait for load to finish

--- a/lib/components/modification/__tests__/edit-alignment.js
+++ b/lib/components/modification/__tests__/edit-alignment.js
@@ -4,7 +4,6 @@ import renderer from 'react-test-renderer'
 import React from 'react'
 
 import {mockModification} from '../../../utils/mock-data'
-
 import EditAlignment from '../edit-alignment'
 
 describe('Component > Modification > Edit Alignment', function () {

--- a/lib/components/modification/__tests__/select-feed-and-routes.js
+++ b/lib/components/modification/__tests__/select-feed-and-routes.js
@@ -16,7 +16,7 @@ describe('Component > SelectFeedAndRoutes', () => {
           onChange={onChangeFn}
           selectedFeed={null}
           selectedRouteIds={[]}
-          />
+        />
       )
       .toJSON()
     expect(tree).toMatchSnapshot()

--- a/lib/components/modification/__tests__/select-patterns.js
+++ b/lib/components/modification/__tests__/select-patterns.js
@@ -15,7 +15,7 @@ describe('Component > SelectPatterns', () => {
           onChange={onChangeFn}
           routePatterns={[mockPattern]}
           trips={null}
-          />
+        />
       )
       .toJSON()
     expect(tree).toMatchSnapshot()

--- a/lib/components/modification/add-trip-pattern.js
+++ b/lib/components/modification/add-trip-pattern.js
@@ -1,9 +1,6 @@
 // @flow
 import React from 'react'
 
-import EditAlignment from './edit-alignment'
-import Timetables from './timetables'
-
 import type {
   Modification,
   GTFSStop,
@@ -12,6 +9,9 @@ import type {
   Timetable
 } from '../../types'
 
+import EditAlignment from './edit-alignment'
+import Timetables from './timetables'
+
 type Props = {
   allPhaseFromTimetableStops: any,
   extendFromEnd: boolean,
@@ -19,8 +19,8 @@ type Props = {
   mapState: MapState,
   modification: Modification,
   numberOfStops: number,
-  qualifiedStops: Stop[],
   projectTimetables: Timetable[],
+  qualifiedStops: Stop[],
   segmentDistances: number[],
   setMapState: (MapState) => void,
   update: (any) => void

--- a/lib/components/modification/adjust-dwell-time.js
+++ b/lib/components/modification/adjust-dwell-time.js
@@ -2,9 +2,6 @@
 import React, {Component} from 'react'
 
 import {Number as InputNumber} from '../input'
-import SelectFeedRouteAndPatterns from './select-feed-route-and-patterns'
-import SelectStops from './select-stops'
-
 import type {
   Modification,
   Feed,
@@ -12,6 +9,9 @@ import type {
   RoutePatterns,
   Stop
 } from '../../types'
+
+import SelectFeedRouteAndPatterns from './select-feed-route-and-patterns'
+import SelectStops from './select-stops'
 
 type Props = {
   feeds: Feed[],

--- a/lib/components/modification/adjust-speed.js
+++ b/lib/components/modification/adjust-speed.js
@@ -5,9 +5,9 @@ import React, {Component} from 'react'
 import {Button, Group} from '../buttons'
 import {MAP_STATE_HOP_SELECTION} from '../../constants'
 import {Group as FormGroup, Number} from '../input'
-import SelectFeedRouteAndPatterns from './select-feed-route-and-patterns'
-
 import type {Modification, Feed, MapState, RoutePatterns} from '../../types'
+
+import SelectFeedRouteAndPatterns from './select-feed-route-and-patterns'
 
 type Props = {
   feeds: Feed[],

--- a/lib/components/modification/convert-to-frequency.js
+++ b/lib/components/modification/convert-to-frequency.js
@@ -3,11 +3,8 @@ import Icon from '@conveyal/woonerf/components/icon'
 import React, {Component} from 'react'
 
 import {Button} from '../buttons'
-import FrequencyEntry from './frequency-entry'
 import {Checkbox} from '../input'
-import SelectFeedAndRoutes from './select-feed-and-routes'
 import {create as createFrequencyEntry} from '../../utils/frequency-entry'
-
 import type {
   Modification,
   Feed,
@@ -16,18 +13,21 @@ import type {
   Timetable
 } from '../../types'
 
+import SelectFeedAndRoutes from './select-feed-and-routes'
+import FrequencyEntry from './frequency-entry'
+
 type Props = {
   allPhaseFromTimetableStops: any,
-  feeds: Feed[],
   feedScopedModificationStops: Stop[],
+  feeds: Feed[],
   modification: Modification,
-  routePatterns: RoutePatterns,
   projectTimetables: Timetable[],
+  routePatterns: RoutePatterns,
   selectedFeed: Feed,
 
   // actions
-  setActiveTrips(any): void,
-  update(any): void,
+  setActiveTrips: (any) => void,
+  update: (any) => void,
   updateAndRetrieveFeedData: (any) => void
 }
 

--- a/lib/components/modification/copy-timetable.js
+++ b/lib/components/modification/copy-timetable.js
@@ -37,8 +37,8 @@ type Region = ModelWithName & {
 type Props = {
   create: () => void,
   currentModification: Modification,
-  currentRegionId: string,
   currentProject: Project,
+  currentRegionId: string,
   getTimetables: () => Promise<{
     status: number,
     value: ?Array<Region>
@@ -129,8 +129,8 @@ export default class CopyTimetable extends Component {
         const currentTimetable = currentModification &&
             currentModification.timetables &&
             currentModification.timetables.length > 0
-              ? currentModification.timetables[0]
-              : undefined
+          ? currentModification.timetables[0]
+          : undefined
 
         this.setState({
           data: regions,
@@ -171,9 +171,9 @@ export default class CopyTimetable extends Component {
   }
 
   _getStateForNewProject (project: ?Project): {
-    project: ?Project,
     modification: ?Modification,
     modificationOptions: Array<Modification>,
+    project: ?Project,
     timetable: ?Timetable,
     timetableOptions: Array<Timetable>
   } {

--- a/lib/components/modification/edit-alignment.js
+++ b/lib/components/modification/edit-alignment.js
@@ -11,21 +11,19 @@ import {
   REROUTE
 } from '../../constants'
 import colors from '../../constants/colors'
-
 import {Button} from '../buttons'
 import {Checkbox, Number} from '../input'
-
 import type {MapState} from '../../types'
 
 type Props = {
+  disabled: boolean,
   extendFromEnd: boolean,
   mapState: MapState,
   modification: any,
-  disabled: boolean,
   numberOfStops?: number,
   segmentDistances?: number[],
 
-  setMapState(any): void,
+  setMapState: (any) => void,
   update: (any) => void
 }
 

--- a/lib/components/modification/editor.js
+++ b/lib/components/modification/editor.js
@@ -16,7 +16,6 @@ import RemoveStops from '../../containers/remove-stops'
 import RemoveTrips from '../../containers/remove-trips'
 import Reroute from '../../containers/reroute'
 import {Checkbox, Group, Text, TextArea} from '../input'
-
 import type {MapState, Modification} from '../../types'
 
 // Also autosaves on exit
@@ -24,14 +23,14 @@ const AUTOSAVE_EVERY_MS = 10 * 1000
 
 type Props = {
   allVariants: string[],
+  clearActive: () => void,
+  copyModification: () => void,
   feedIsLoaded: boolean,
   modification?: Modification,
   modificationId: string,
+
   projectId: string,
   regionId: string,
-
-  clearActive: () => void,
-  copyModification: () => void,
   removeModification: () => void,
   setActive: () => void,
   setMapState: (MapState) => void,
@@ -219,7 +218,7 @@ export default class ModificationEditor extends React.Component {
                   value={modification.description}
                   onChange={this._onDescriptionChange}
                   label={message('modification.description')}
-                    />}
+                />}
 
                 {!showDescription &&
                 <Group>
@@ -236,14 +235,14 @@ export default class ModificationEditor extends React.Component {
                   type={modification.type}
                   update={this._updateLocally}
                   updateAndRetrieveFeedData={this._updateAndRetrieveFeedData}
-                  />
+                />
 
                 <Variants
                   activeVariants={modification.variants}
                   allVariants={allVariants}
                   modificationId={modification._id}
                   setVariant={this._setVariant}
-                  />
+                />
               </div>
               : <p>Loading modification...</p>
             : <div>

--- a/lib/components/modification/frequency-entry.js
+++ b/lib/components/modification/frequency-entry.js
@@ -3,11 +3,12 @@ import Icon from '@conveyal/woonerf/components/icon'
 import PropTypes from 'prop-types'
 import React, {Component} from 'react'
 
+import {Text} from '../input'
+import {Button} from '../buttons'
+
 import TimetableEntry from './timetable-entry'
 import SelectTrip from './select-trip'
 import SelectPatterns from './select-patterns'
-import {Text} from '../input'
-import {Button} from '../buttons'
 
 /** Represents a single frequency entry */
 export default class FrequencyEntry extends Component {
@@ -81,10 +82,10 @@ export default class FrequencyEntry extends Component {
         )
     )
     const stopsInPatterns = modificationStops.filter(
-      ({stop_id}) =>
+      (ms) =>
         !!patternsWithTrips.find(
           pattern =>
-            !!pattern.stops.find(stop => stop.stop_id === stop_id.split(':')[1])
+            !!pattern.stops.find(stop => stop.stop_id === ms.stop_id.split(':')[1])
         )
     )
     return (

--- a/lib/components/modification/group.js
+++ b/lib/components/modification/group.js
@@ -3,15 +3,15 @@ import Icon from '@conveyal/woonerf/components/icon'
 import message from '@conveyal/woonerf/message'
 import React, {PureComponent} from 'react'
 
-import ModificationTitle from './title'
-
 import type {Modification} from '../../types'
 
-type Props = {
-  modifications: Modification[],
-  type: string,
+import ModificationTitle from './title'
 
+type Props = {
   goToEditModification: (_id: string) => void,
+  modifications: Modification[],
+
+  type: string,
   updateModification: (modification: Modification) => void
 }
 

--- a/lib/components/modification/list.js
+++ b/lib/components/modification/list.js
@@ -2,6 +2,7 @@
 import Icon from '@conveyal/woonerf/components/icon'
 import toStartCase from 'lodash/startCase'
 import React, {Component} from 'react'
+import message from '@conveyal/woonerf/message'
 
 import {Application, Dock, Title} from '../base'
 import {Button} from '../buttons'
@@ -9,23 +10,22 @@ import {MODIFICATION_TYPES} from '../../constants'
 import LabelLayer from '../map/label-layer'
 import {IconLink} from '../link'
 import Modal, {ModalBody, ModalTitle} from '../modal'
-import ModificationGroup from './group'
 import ModificationsMap from '../../containers/modifications-map'
 import ProjectTitle from '../../containers/project-title'
 import VariantEditor from '../../containers/variant-editor'
 import {Group, Input, Text, Select} from '../input'
-import message from '@conveyal/woonerf/message'
-
 import type {Modification, Project} from '../../types'
 
+import ModificationGroup from './group'
+
 type Props = {
+  createModification: ({name: string, type: string}) => void,
   modifications: Modification[],
   project: Project,
   projectId: string,
-  regionId: string,
 
-  createModification: ({name: string, type: string}) => void,
   push: string => void,
+  regionId: string,
   updateModification: (modification: Modification) => void
 }
 
@@ -202,17 +202,17 @@ export default class ModificationsList extends Component {
           </Group>
 
           {MODIFICATION_TYPES.filter(
-              type => filteredModificationsByType[type]
-            ).map(type => (
-              <ModificationGroup
-                goToEditModification={this._goToEditModification}
-                key={`modification-group-${type}`}
-                modifications={filteredModificationsByType[type]}
-                projectId={projectId}
-                type={type}
-                updateModification={this._updateModification}
-              />
-            ))}
+            type => filteredModificationsByType[type]
+          ).map(type => (
+            <ModificationGroup
+              goToEditModification={this._goToEditModification}
+              key={`modification-group-${type}`}
+              modifications={filteredModificationsByType[type]}
+              projectId={projectId}
+              type={type}
+              updateModification={this._updateModification}
+            />
+          ))}
         </Dock>
 
         {showCreateModification &&

--- a/lib/components/modification/phase.js
+++ b/lib/components/modification/phase.js
@@ -6,7 +6,6 @@ import Select from 'react-select'
 import {Group as FormGroup} from '../input'
 import MinutesSeconds from '../minutes-seconds'
 import {toString as timetableToString} from '../../utils/timetable'
-
 import type {ClearableReactSelectResult, GTFSStop, Timetable} from '../../types'
 
 type Props = {
@@ -14,14 +13,14 @@ type Props = {
   disabled: boolean,
   modificationStops: GTFSStop[],
   phaseAtStop: null | string,
-  phaseFromTimetable: null | string,
   phaseFromStop: null | string,
+  phaseFromTimetable: null | string,
   phaseSeconds: number,
   selectedPhaseFromTimetableStops: GTFSStop[],
   timetableHeadway: number,
 
   // actions
-  update(any): void
+  update: (any) => void
 }
 
 type State = {
@@ -134,7 +133,7 @@ export default class Phase extends PureComponent<void, Props, State> {
                       }))}
                       placeholder={message('phasing.fromStop')}
                       value={phaseFromStop}
-                      />
+                    />
                   </FormGroup>
                   : <div className='alert alert-danger' role='alert'>
                     {message('phasing.noAvailableStopsWarning')}
@@ -152,8 +151,8 @@ export default class Phase extends PureComponent<void, Props, State> {
   }
 }
 
-const getSelectedTimetable = ({availableTimetables, phaseFromTimetable}): | void
-  | Timetable =>
-  availableTimetables.find(
-    tt => phaseFromTimetable && tt._id === phaseFromTimetable.split(':')[1]
+function getSelectedTimetable (opts): void | Timetable {
+  return opts.availableTimetables.find(tt =>
+    opts.phaseFromTimetable && tt._id === opts.phaseFromTimetable.split(':')[1]
   )
+}

--- a/lib/components/modification/remove-stops.js
+++ b/lib/components/modification/remove-stops.js
@@ -3,10 +3,10 @@ import message from '@conveyal/woonerf/message'
 import React, {Component} from 'react'
 
 import {Number as InputNumber} from '../input'
+import type {Feed, Modification, RoutePatterns, Stop} from '../../types'
+
 import SelectFeedRouteAndPatterns from './select-feed-route-and-patterns'
 import SelectStops from './select-stops'
-
-import type {Feed, Modification, RoutePatterns, Stop} from '../../types'
 
 type Props = {
   feeds: Feed[],

--- a/lib/components/modification/remove-trips.js
+++ b/lib/components/modification/remove-trips.js
@@ -3,9 +3,9 @@ import React from 'react'
 import memoize from 'lodash/memoize'
 import omit from 'lodash/omit'
 
-import SelectFeedRouteAndPatterns from './select-feed-route-and-patterns'
-
 import type {Feed, Modification, RoutePatterns} from '../../types'
+
+import SelectFeedRouteAndPatterns from './select-feed-route-and-patterns'
 
 type Props = {
   feeds: Feed[],

--- a/lib/components/modification/reroute.js
+++ b/lib/components/modification/reroute.js
@@ -12,23 +12,22 @@ import {
   MAP_STATE_TRANSIT_EDITOR
 } from '../../constants'
 import {Group as FormGroup} from '../input'
+import type {Feed, MapState, RoutePatterns, Stop} from '../../types'
 
 import EditAlignment from './edit-alignment'
 import SelectFeedRouteAndPatterns from './select-feed-route-and-patterns'
 import SegmentSpeeds from './segment-speeds'
 
-import type {Feed, MapState, RoutePatterns, Stop} from '../../types'
-
 type Props = {
   feeds: Feed[],
-  modification: any,
   mapState: MapState,
+  modification: any,
   qualifiedStops: Stop[],
   routePatterns: RoutePatterns,
   segmentDistances: number[],
   selectedFeed?: Feed,
+  setMapState: (MapState) => void,
   stops: Stop[],
-  setMapState(MapState): void,
   update: (any) => void,
   updateAndRetrieveFeedData: (any) => void
 }

--- a/lib/components/modification/segment-speeds.js
+++ b/lib/components/modification/segment-speeds.js
@@ -13,20 +13,19 @@ import {
   getAverageSpeedOfSegments,
   getTravelTimeMinutes
 } from '../../utils/segments'
-
 import type {Stop} from '../../types'
 
 type Props = {
   dwellTime: number,
   dwellTimes: number[],
+  highlightSegment: (number) => void,
+  highlightStop: (number) => void,
   numberOfStops: number,
   qualifiedStops: Stop[],
+
   segmentDistances: number[],
   segmentSpeeds: number[],
-
-  highlightSegment(number): void,
-  highlightStop(number): void,
-  update(any): void
+  update: (any) => void
 }
 
 type State = {

--- a/lib/components/modification/select-feed-and-routes.js
+++ b/lib/components/modification/select-feed-and-routes.js
@@ -5,7 +5,6 @@ import Select from 'react-select'
 
 import {Button} from '../buttons'
 import {Group as FormGroup} from '../input'
-
 import type {Feed, ReactSelectMultiResult, ReactSelectResult} from '../../types'
 
 type Props = {
@@ -35,8 +34,8 @@ export default class SelectFeedAndRoutes
       routes: !routes
         ? []
         : Array.isArray(routes)
-            ? routes.map(r => (r ? r.value : ''))
-            : [routes.value]
+          ? routes.map(r => (r ? r.value : ''))
+          : [routes.value]
     })
   }
 

--- a/lib/components/modification/select-feed-route-and-patterns.js
+++ b/lib/components/modification/select-feed-route-and-patterns.js
@@ -1,10 +1,10 @@
 // @flow
 import React, {PureComponent} from 'react'
 
+import type {Feed, RoutePatterns} from '../../types'
+
 import SelectPatterns from './select-patterns'
 import SelectFeedAndRoutes from './select-feed-and-routes'
-
-import type {Feed, RoutePatterns} from '../../types'
 
 type Props = {
   allowMultipleRoutes?: boolean,
@@ -14,8 +14,8 @@ type Props = {
     routes: null | string[],
     trips: null | string[]
   }) => void,
-  routes: null | string[],
   routePatterns: RoutePatterns,
+  routes: null | string[],
   selectedFeed: null | Feed,
   trips: null | string[] // trips can be null indicating a wildcard
 }

--- a/lib/components/modification/select-patterns.js
+++ b/lib/components/modification/select-patterns.js
@@ -3,7 +3,6 @@ import React, {PureComponent} from 'react'
 import Select from 'react-select'
 
 import {Group as FormGroup} from '../input'
-
 import type {ClearableReactSelectMultiResult, RoutePattern} from '../../types'
 
 type Props = {

--- a/lib/components/modification/select-trip.js
+++ b/lib/components/modification/select-trip.js
@@ -4,16 +4,15 @@ import Select from 'react-select'
 
 import {Group as FormGroup} from '../input'
 import {secondsToHhMmString} from '../../utils/time'
-
 import type {Feed, ReactSelectResult, RoutePattern} from '../../types'
 
 type Props = {
   feed: Feed,
+  onChange: (trip: string) => void,
   patternTrips: string[],
   routes: string[],
-  trip: string,
 
-  onChange: (trip: string) => void
+  trip: string
 }
 
 /** Select trips */

--- a/lib/components/modification/timetable-entry.js
+++ b/lib/components/modification/timetable-entry.js
@@ -1,14 +1,15 @@
 // @flow
-import message from '@conveyal/woonerf/message'
 import assert from 'assert'
+
+import message from '@conveyal/woonerf/message'
 import React, {PureComponent} from 'react'
 
 import {Checkbox} from '../input'
 import MinutesSeconds from '../minutes-seconds'
-import Phase from './phase'
 import TimePicker from '../time-picker'
-
 import type {GTFSStop, Timetable} from '../../types'
+
+import Phase from './phase'
 
 const DAYS = [
   'Monday',

--- a/lib/components/modification/timetable.js
+++ b/lib/components/modification/timetable.js
@@ -8,23 +8,23 @@ import {
 } from '../../constants'
 import {Text} from '../input'
 import {Button} from '../buttons'
+import type {GTFSStop, Stop, Timetable} from '../../types'
+
 import SegmentSpeeds from './segment-speeds'
 import TimetableEntry from './timetable-entry'
-
-import type {GTFSStop, Stop, Timetable} from '../../types'
 
 type Props = {
   allPhaseFromTimetableStops: any,
   bidirectional: boolean,
   modificationStops: GTFSStop[],
   numberOfStops: number,
-  qualifiedStops: Stop[],
   projectTimetables: Timetable[],
-  segmentDistances: number[],
-  timetable: Timetable,
-
+  qualifiedStops: Stop[],
   remove: () => void,
+  segmentDistances: number[],
+
   setMapState: (any) => void,
+  timetable: Timetable,
   update: (any) => void
 }
 

--- a/lib/components/modification/timetables.js
+++ b/lib/components/modification/timetables.js
@@ -7,23 +7,23 @@ import {DEFAULT_SEGMENT_SPEED} from '../../constants/timetables'
 import CopyTimetable from '../../containers/copy-timetable'
 import {Button} from '../buttons'
 import Modal, {ModalTitle} from '../modal'
-import TimetableComponent from './timetable'
 import {create as createTimetable} from '../../utils/timetable'
-
 import type {GTFSStop, Stop, Timetable} from '../../types'
+
+import TimetableComponent from './timetable'
 
 type Props = {
   allPhaseFromTimetableStops: any,
   bidirectional: boolean,
   modificationStops: GTFSStop[],
-  qualifiedStops: Stop[],
   numberOfStops: number,
   projectTimetables: Timetable[],
+  qualifiedStops: Stop[],
   segmentDistances: number[],
-  timetables: Timetable[],
+  setMapState: (any) => void,
 
-  setMapState(any): void,
-  update(any): void
+  timetables: Timetable[],
+  update: (any) => void
 }
 
 type State = {
@@ -131,7 +131,7 @@ export default class Timetables extends PureComponent<void, Props, State> {
             <ModalTitle>Copy Timetable</ModalTitle>
             <CopyTimetable
               create={this._createFromOther}
-              />
+            />
           </Modal>
         }
       </div>

--- a/lib/components/modifications-map/__tests__/draw-polygon.js
+++ b/lib/components/modifications-map/__tests__/draw-polygon.js
@@ -13,7 +13,7 @@ describe('Project-Map > DrawPolygon', () => {
         <Map>
           <DrawPolygon
             onPolygon={jest.fn()}
-            />
+          />
         </Map>
       )
       .toJSON()

--- a/lib/components/modifications-map/__tests__/hop-select-polygon.js
+++ b/lib/components/modifications-map/__tests__/hop-select-polygon.js
@@ -15,7 +15,7 @@ describe('Project-Map > HopSelectPolygon', () => {
           <HopSelectPolygon
             hopStops={[]}
             selectHops={jest.fn()}
-            />
+          />
         </Map>
       )
       .toJSON()

--- a/lib/components/modifications-map/__tests__/reroute-layer.js
+++ b/lib/components/modifications-map/__tests__/reroute-layer.js
@@ -21,7 +21,7 @@ describe('Project-Map > RerouteLayer', () => {
           highlightStop={mockStop1}
           modification={mockModification}
           showAddedSegment
-          />
+        />
       </Map>
     )
     expect(tree).toMatchSnapshot()

--- a/lib/components/modifications-map/add-trip-pattern-layer.js
+++ b/lib/components/modifications-map/add-trip-pattern-layer.js
@@ -12,7 +12,6 @@ import {
 } from '../map/circle-icons'
 import DirectionalMarkers from '../directional-markers'
 import getStops from '../../utils/get-stops'
-
 import type {FeatureCollection, Segment, Stop} from '../../types'
 
 type Props = {
@@ -31,8 +30,8 @@ type State = {
     }
   ],
   geojson: FeatureCollection,
-  stops: Stop[],
-  stopRadius: number
+  stopRadius: number,
+  stops: Stop[]
 }
 
 /**

--- a/lib/components/modifications-map/adjust-speed-layer.js
+++ b/lib/components/modifications-map/adjust-speed-layer.js
@@ -3,9 +3,10 @@
 import React, {Component} from 'react'
 import {FeatureGroup} from 'react-leaflet'
 
+import colors from '../../constants/colors'
+
 import PatternLayer from './pattern-layer'
 import HopLayer from './hop-layer'
-import colors from '../../constants/colors'
 
 export default class AdjustSpeedLayer extends Component {
   render () {

--- a/lib/components/modifications-map/hop-select-polygon.js
+++ b/lib/components/modifications-map/hop-select-polygon.js
@@ -4,9 +4,9 @@ import {FeatureGroup} from 'react-leaflet'
 import inside from '@turf/inside'
 import {point} from '@turf/helpers'
 
-import DrawPolygon from './draw-polygon'
-
 import type {Feature, GTFSStop} from '../../types'
+
+import DrawPolygon from './draw-polygon'
 
 type Props = {
   hopStops: GTFSStop[][],

--- a/lib/components/modifications-map/index.js
+++ b/lib/components/modifications-map/index.js
@@ -20,6 +20,8 @@ import {
 } from '../../constants'
 import colors from '../../constants/colors'
 import updateAddStopsTerminus from '../../utils/update-add-stops-terminus'
+import type {Feed, LonLat, Modification, Stop} from '../../types'
+
 import AddTripPatternLayer from './add-trip-pattern-layer'
 import AdjustSpeedLayer from './adjust-speed-layer'
 import HopSelectPolygon from './hop-select-polygon'
@@ -29,8 +31,6 @@ import RerouteLayer from './reroute-layer'
 import StopLayer from './stop-layer'
 import StopSelectPolygon from './stop-select-polygon'
 import TransitEditor from './transit-editor'
-
-import type {Feed, LonLat, Modification, Stop} from '../../types'
 
 type Props = {
   activeModification?: Object,

--- a/lib/components/modifications-map/pattern-stops-layer.js
+++ b/lib/components/modifications-map/pattern-stops-layer.js
@@ -3,6 +3,7 @@
 import React, {Component} from 'react'
 
 import colors from '../../constants/colors'
+
 import PatternLayer from './pattern-layer'
 import StopLayer from './stop-layer'
 

--- a/lib/components/modifications-map/reroute-layer.js
+++ b/lib/components/modifications-map/reroute-layer.js
@@ -10,7 +10,6 @@ import colors from '../../constants/colors'
 import DirectionalMarkers from '../directional-markers'
 import PatternGeometry from '../map/geojson-patterns'
 import {getPatternsForModification} from '../../utils/patterns'
-
 import type {FeatureCollection, Pattern} from '../../types'
 
 type DefaultProps = {
@@ -142,8 +141,8 @@ function getStateFromProps ({dim, feed, modification}: Props) {
       // make sure to find a toStopIndex _after_ the fromStopIndex (helps with loop routes also)
       const toStopIndex = modification.toStop != null
         ? pattern.stops.findIndex(
-            (s, i) => i > fromStopIndex && s.stop_id === modification.toStop
-          )
+          (s, i) => i > fromStopIndex && s.stop_id === modification.toStop
+        )
         : pattern.stops.length - 1
 
       const modificationAppliesToThisPattern =

--- a/lib/components/modifications-map/stop-select-polygon.js
+++ b/lib/components/modifications-map/stop-select-polygon.js
@@ -4,9 +4,9 @@ import {FeatureGroup} from 'react-leaflet'
 import inside from '@turf/inside'
 import {point} from '@turf/helpers'
 
-import DrawPolygon from './draw-polygon'
-
 import type {Feature, GTFSStop} from '../../types'
+
+import DrawPolygon from './draw-polygon'
 
 type Props = {
   routeStops: GTFSStop[],

--- a/lib/components/modifications-map/transit-editor/gtfs-stop-gridlayer.js
+++ b/lib/components/modifications-map/transit-editor/gtfs-stop-gridlayer.js
@@ -4,7 +4,6 @@ import {MapLayer} from 'react-leaflet'
 
 import {MINIMUM_SNAP_STOP_ZOOM_LEVEL} from '../../../constants'
 import colors from '../../../constants/colors'
-
 import type {GTFSStop} from '../../../types'
 
 type Props = {

--- a/lib/components/modifications-map/transit-editor/index.js
+++ b/lib/components/modifications-map/transit-editor/index.js
@@ -12,7 +12,6 @@ import {
 
 import {MINIMUM_SNAP_STOP_ZOOM_LEVEL} from '../../../constants'
 import colors from '../../../constants/colors'
-
 import {Button} from '../../buttons'
 import {
   getControlPointIconForZoom,
@@ -23,9 +22,9 @@ import getStopsFromSegments from '../../../utils/get-stops'
 import getNearestStopToPoint from '../../../utils/get-stop-near-point'
 import getLineString from '../../../utils/get-line-string'
 import createLogDomEvent from '../../../utils/log-dom-event'
-import GTFSStopGridLayer from './gtfs-stop-gridlayer'
-
 import type {Feed, LonLatC, Modification} from '../../../types'
+
+import GTFSStopGridLayer from './gtfs-stop-gridlayer'
 
 const logDomEvent = createLogDomEvent('transit-editor')
 

--- a/lib/components/panel.js
+++ b/lib/components/panel.js
@@ -1,6 +1,5 @@
 // @flow
 import React, {PureComponent} from 'react'
-
 import type {Children} from 'react'
 
 export class Panel extends PureComponent {

--- a/lib/components/project-title.js
+++ b/lib/components/project-title.js
@@ -11,8 +11,8 @@ type Props = {
   _id: string,
   downloadScenario: (index: number) => void,
   project?: {
-    bundleId: string,
     _id: string,
+    bundleId: string,
     name: string,
     regionId: string,
     variants: string[]
@@ -20,8 +20,8 @@ type Props = {
 }
 
 type State = {
-  showPrintSelect: boolean,
-  showExportSelect: boolean
+  showExportSelect: boolean,
+  showPrintSelect: boolean
 }
 
 export default class ProjectTitle extends Component {
@@ -52,7 +52,7 @@ export default class ProjectTitle extends Component {
               className='pull-right'
               onClick={this._showPrintSelect}
               title={message('project.print')}
-              >
+            >
               <Icon type='print' />
               {this.state.showPrintSelect &&
                 <SelectScenario
@@ -67,7 +67,7 @@ export default class ProjectTitle extends Component {
               className='pull-right'
               onClick={this._showExportSelect}
               title={message('project.export')}
-              >
+            >
               <Icon type='download' />
               {this.state.showExportSelect &&
                 <SelectScenario

--- a/lib/components/report/add-trips.js
+++ b/lib/components/report/add-trips.js
@@ -4,21 +4,21 @@ import {latLngBounds} from 'leaflet'
 import React, {Component} from 'react'
 import lineDistance from '@turf/line-distance'
 
-import DaysOfService from './days-of-service'
-import Distance from './distance'
 import tryCatchRender from '../try-catch-render'
-import MiniMap from './mini-map'
-import Phase from './phase'
 import AddTripPatternLayer from '../modifications-map/add-trip-pattern-layer'
-import Speed from './speed'
 import {getAverageSpeedOfSegments} from '../../utils/segments'
 import {secondsToHhMmString} from '../../utils/time'
-
 import type {Modification, GTFSStop, Timetable} from '../../types'
 
+import DaysOfService from './days-of-service'
+import Distance from './distance'
+import MiniMap from './mini-map'
+import Phase from './phase'
+import Speed from './speed'
+
 type Props = {
-  modification: Modification,
   feedScopedStops: GTFSStop[],
+  modification: Modification,
   projectTimetables: Timetable[]
 }
 

--- a/lib/components/report/adjust-dwell-time.js
+++ b/lib/components/report/adjust-dwell-time.js
@@ -4,10 +4,11 @@ import PropTypes from 'prop-types'
 import React, {Component} from 'react'
 import {latLngBounds} from 'leaflet'
 
-import MiniMap from './mini-map'
 import PatternStopsLayer from '../modifications-map/pattern-stops-layer'
 import colors from '../../constants/colors'
 import {getPatternsForModification} from '../../utils/patterns'
+
+import MiniMap from './mini-map'
 
 export default class AdjustDwellTime extends Component {
   static propTypes = {

--- a/lib/components/report/adjust-frequency.js
+++ b/lib/components/report/adjust-frequency.js
@@ -6,12 +6,13 @@ import PropTypes from 'prop-types'
 import React, {Component} from 'react'
 
 import {secondsToHhMmString} from '../../utils/time'
+import PatternLayer from '../modifications-map/pattern-layer'
+import colors from '../../constants/colors'
+
 import Distance from './distance'
 import DaysOfService from './days-of-service'
 import MiniMap from './mini-map'
 import Phase from './phase'
-import PatternLayer from '../modifications-map/pattern-layer'
-import colors from '../../constants/colors'
 
 export default class AdjustFrequency extends Component {
   static propTypes = {

--- a/lib/components/report/adjust-speed.js
+++ b/lib/components/report/adjust-speed.js
@@ -3,9 +3,11 @@ import message from '@conveyal/woonerf/message'
 import PropTypes from 'prop-types'
 import React, {Component} from 'react'
 import {latLngBounds} from 'leaflet'
-import MiniMap from './mini-map'
+
 import AdjustSpeedLayer from '../modifications-map/adjust-speed-layer'
 import {getPatternsForModification} from '../../utils/patterns'
+
+import MiniMap from './mini-map'
 
 export default class AdjustSpeed extends Component {
   static propTypes = {

--- a/lib/components/report/index.js
+++ b/lib/components/report/index.js
@@ -2,8 +2,6 @@
 import message from '@conveyal/woonerf/message'
 import React, {Component} from 'react'
 
-import ModificationComponent from './modification'
-
 import type {
   Bundle,
   Feed,
@@ -13,21 +11,23 @@ import type {
   Timetable
 } from '../../types'
 
+import ModificationComponent from './modification'
+
 type Props = {
   allFeedIds: string[],
-  projectId: string,
-  regionId: string,
-  modifications?: Modification[],
-  project?: Project,
   bundle?: Bundle,
+  feedScopedStops: Stop[],
   feedsById: {
     [id: string]: Feed
   },
-  variant: string,
-  loadProject(string): void,
-  loadRegion(string): void,
-  feedScopedStops: Stop[],
-  projectTimetables: Timetable[]
+  loadProject: (string) => void,
+  loadRegion: (string) => void,
+  modifications?: Modification[],
+  project?: Project,
+  projectId: string,
+  projectTimetables: Timetable[],
+  regionId: string,
+  variant: string
 }
 
 function alertOnError (error: {message?: string, reason?: string}) {

--- a/lib/components/report/phase.js
+++ b/lib/components/report/phase.js
@@ -3,14 +3,13 @@ import message from '@conveyal/woonerf/message'
 import React, {PureComponent} from 'react'
 
 import {secondsToHhMmString} from '../../utils/time'
-
 import type {GTFSStop, Timetable} from '../../types'
 import {toString as timetableToString} from '../../utils/timetable'
 
 type Props = {
-  timetable: Timetable,
+  feedScopedStops: GTFSStop[],
   projectTimetables: Timetable[],
-  feedScopedStops: GTFSStop[]
+  timetable: Timetable
 }
 
 /**

--- a/lib/components/report/remove-stops.js
+++ b/lib/components/report/remove-stops.js
@@ -4,10 +4,11 @@ import PropTypes from 'prop-types'
 import React, {Component} from 'react'
 import {latLngBounds} from 'leaflet'
 
-import MiniMap from './mini-map'
 import PatternStopsLayer from '../modifications-map/pattern-stops-layer'
 import colors from '../../constants/colors'
 import {getPatternsForModification} from '../../utils/patterns'
+
+import MiniMap from './mini-map'
 
 export default class RemoveStops extends Component {
   static propTypes = {

--- a/lib/components/report/remove-trips.js
+++ b/lib/components/report/remove-trips.js
@@ -3,9 +3,10 @@ import message from '@conveyal/woonerf/message'
 import React, {PureComponent} from 'react'
 import {latLngBounds} from 'leaflet'
 
-import MiniMap from './mini-map'
 import PatternLayer from '../modifications-map/pattern-layer'
 import colors from '../../constants/colors'
+
+import MiniMap from './mini-map'
 
 /**
  * Removed trips
@@ -54,7 +55,7 @@ export default class RemoveTrips extends PureComponent {
                 .filter(
                   p =>
                     p.trips.findIndex(
-                      ({trip_id}) => modification.trips.indexOf(trip_id) > -1
+                      (t) => modification.trips.indexOf(t.trip_id) > -1
                     ) > -1
                 )
                 .map(p => (

--- a/lib/components/report/reroute.js
+++ b/lib/components/report/reroute.js
@@ -7,13 +7,14 @@ import lineDistance from '@turf/line-distance'
 import lineSlice from '@turf/line-slice'
 import {point} from '@turf/helpers'
 
-import Distance from './distance'
-import MiniMap from './mini-map'
 import RerouteLayer from '../modifications-map/reroute-layer'
-import Speed from './speed'
 import {getPatternsForModification} from '../../utils/patterns'
 import getStops from '../../utils/get-stops'
 import {getAverageSpeedOfSegments} from '../../utils/segments'
+
+import Speed from './speed'
+import MiniMap from './mini-map'
+import Distance from './distance'
 
 export default class Reroute extends Component {
   static propTypes = {
@@ -80,8 +81,8 @@ export default class Reroute extends Component {
     // make sure to find a toStopIndex _after_ the fromStopIndex (helps with loop routes also)
     const toStopIndex = modification.toStop != null
       ? pattern.stops.findIndex(
-          (s, i) => i >= fromStopIndex && s.stop_id === modification.toStop
-        )
+        (s, i) => i >= fromStopIndex && s.stop_id === modification.toStop
+      )
       : pattern.stops.length - 1
 
     const modificationAppliesToThisPattern =

--- a/lib/components/select-project.js
+++ b/lib/components/select-project.js
@@ -4,16 +4,16 @@ import Icon from '@conveyal/woonerf/components/icon'
 import React, {Component} from 'react'
 import {Link} from 'react-router'
 
+import type {Bundle, Project, Region} from '../types'
+
 import {Application, Dock, Title} from './base'
 import {ButtonLink} from './buttons'
 import {Group} from './input'
 
-import type {Bundle, Project, Region} from '../types'
-
 type Props = {
   bundles: Bundle[],
-  region: Region,
-  projects: Project[]
+  projects: Project[],
+  region: Region
 }
 
 function Status ({code}: {code: string}) {
@@ -48,14 +48,14 @@ export default class SelectProject extends Component {
               >
                 <Icon type='plus' /> {message('project.createAction')}
               </ButtonLink>
-            : <ButtonLink
-              block
-              style='success'
-              to={`/regions/${region._id}/bundles/create`}
-              title={message('project.uploadBundle')}
-                >
-              <Icon type='database' /> {message('project.uploadBundle')}
-            </ButtonLink>
+              : <ButtonLink
+                block
+                style='success'
+                to={`/regions/${region._id}/bundles/create`}
+                title={message('project.uploadBundle')}
+              >
+                <Icon type='database' /> {message('project.uploadBundle')}
+              </ButtonLink>
             }
           </Group>
           {projects.length > 0 &&

--- a/lib/components/sidebar.js
+++ b/lib/components/sidebar.js
@@ -11,13 +11,14 @@ import {connect} from 'react-redux'
 
 import {CREATING_ID} from '../constants/region'
 import * as select from '../selectors'
+
 import Tip from './tip'
 
 type Props = {
   currentPath: string,
   outstandingRequests: number,
-  regionId?: string,
   projectId?: string,
+  regionId?: string,
   username?: string
 }
 
@@ -139,7 +140,7 @@ class Sidebar extends Pure {
           </div>
           : <div
             className='Sidebar-logo'
-            />}
+          />}
 
         <SidebarNavItem
           icon='globe'

--- a/lib/components/time-picker.js
+++ b/lib/components/time-picker.js
@@ -2,8 +2,9 @@
 import PropTypes from 'prop-types'
 import React, {Component} from 'react'
 
-import {Text} from './input'
 import {secondsToHhMmString} from '../utils/time'
+
+import {Text} from './input'
 
 const preventDefaultIfFocused = e => {
   // http://stackoverflow.com/questions/17614844

--- a/lib/components/tip.js
+++ b/lib/components/tip.js
@@ -4,8 +4,8 @@ import React, {Children, Component} from 'react'
 export default class Tip extends Component {
   el: HTMLElement
   props: {
-    className?: string,
     children?: Children,
+    className?: string,
     tip: string
   }
 

--- a/lib/containers/add-trip-pattern.js
+++ b/lib/containers/add-trip-pattern.js
@@ -3,7 +3,6 @@ import {connect} from 'react-redux'
 
 import {AddTripPattern} from '../components/modification/add-trip-pattern'
 import * as select from '../selectors'
-
 import type {Modification} from '../types'
 
 function mapStateToProps (

--- a/lib/containers/destination-travel-time-distribution.js
+++ b/lib/containers/destination-travel-time-distribution.js
@@ -1,5 +1,6 @@
 // @flow
 import {connect} from 'react-redux'
+
 import DestinationTravelTimeDistribution
   from '../components/map/destination-travel-time-distribution'
 import {setDestination} from '../actions/analysis'

--- a/lib/containers/edit-region-bounds.js
+++ b/lib/containers/edit-region-bounds.js
@@ -3,7 +3,6 @@ import {connect} from 'react-redux'
 
 import {setLocally} from '../actions/region'
 import EditRegionBounds from '../components/map/edit-region-bounds'
-
 import selectCurrentRegion from '../selectors/current-region'
 
 function mapStateToProps (state, ownProps) {

--- a/lib/containers/edit-region.js
+++ b/lib/containers/edit-region.js
@@ -13,7 +13,6 @@ import {
 } from '../actions/region'
 import EditRegion from '../components/edit-region'
 import {CREATING_ID, DEFAULT_BOUNDS} from '../constants/region'
-
 import * as select from '../selectors'
 
 function mapStateToProps (state, ownProps) {

--- a/lib/containers/project-title.js
+++ b/lib/containers/project-title.js
@@ -3,7 +3,6 @@ import {connect} from 'react-redux'
 
 import {downloadScenario} from '../actions/project'
 import ProjectTitle from '../components/project-title'
-
 import * as select from '../selectors'
 
 function mapStateToProps (state, props) {

--- a/lib/containers/region.js
+++ b/lib/containers/region.js
@@ -3,7 +3,6 @@ import {connect} from 'react-redux'
 
 import {load as loadRegion} from '../actions/region'
 import Region from '../components/region'
-
 import * as select from '../selectors'
 
 function mapStateToProps (state, ownProps) {

--- a/lib/containers/regional-layer.js
+++ b/lib/containers/regional-layer.js
@@ -1,6 +1,7 @@
 // @flow
 import get from 'lodash/get'
 import {connect} from 'react-redux'
+
 import {setRegionalAnalysisOrigin} from '../actions/analysis/regional'
 import RegionalLayer from '../components/map/regional'
 

--- a/lib/containers/regional-results-list.js
+++ b/lib/containers/regional-results-list.js
@@ -4,7 +4,6 @@ import {push} from 'react-router-redux'
 
 import RegionalResultsList from '../components/analysis/regional-results-list'
 import * as select from '../selectors'
-
 import {
   load,
   deleteRegionalAnalysis,

--- a/lib/containers/remove-stops.js
+++ b/lib/containers/remove-stops.js
@@ -3,7 +3,6 @@ import {connect} from 'react-redux'
 
 import RemoveStops from '../components/modification/remove-stops'
 import * as select from '../selectors'
-
 import type {Modification} from '../types'
 
 function mapStateToProps (

--- a/lib/containers/remove-trips.js
+++ b/lib/containers/remove-trips.js
@@ -3,7 +3,6 @@ import {connect} from 'react-redux'
 
 import RemoveTrips from '../components/modification/remove-trips'
 import * as select from '../selectors'
-
 import type {Modification} from '../types'
 
 function mapStateToProps (

--- a/lib/containers/stacked-percentile-selector.js
+++ b/lib/containers/stacked-percentile-selector.js
@@ -7,7 +7,6 @@ import {setProfileRequest} from '../actions/analysis'
 import StackedPercentileSelector
   from '../components/analysis/stacked-percentile-selector'
 import * as select from '../selectors'
-
 import {activeOpportunityDataset} from '../modules/opportunity-datasets/selectors'
 
 function mapStateToProps (state, ownProps) {

--- a/lib/modules/admin/components/job-dashboard.js
+++ b/lib/modules/admin/components/job-dashboard.js
@@ -13,11 +13,11 @@ const formatStartTime = (ms: number) =>
 class JobDashboard extends React.PureComponent {
   props: {
     allBundlesById: Object,
-    jobsWithWorkers: Job[],
-
     clearJob: () => void,
+
     fetchJobs: () => void,
     highlightJob: () => void,
+    jobsWithWorkers: Job[],
     selectJob: () => void
   }
 
@@ -26,7 +26,7 @@ class JobDashboard extends React.PureComponent {
     this.props.fetchJobs()
     this._fetchJobsIntervalId = setInterval(() =>
       this.props.fetchJobs(),
-      REFRESH_INTERVAL_MS)
+    REFRESH_INTERVAL_MS)
   }
 
   componentWillUnmount () {
@@ -115,7 +115,7 @@ class JobRow extends React.PureComponent {
           : <a
             href={utils.createR5Url(p.workerCommit)}
             target='_blank'
-            >{p.workerCommit}</a>}
+          >{p.workerCommit}</a>}
       </td>
       <td className='JobProject'>
         <a href={`/regions/${regionId}/projects/${projectId}`} target='_blank'>project</a>

--- a/lib/modules/admin/components/sparkline.js
+++ b/lib/modules/admin/components/sparkline.js
@@ -66,8 +66,8 @@ function ReferenceLine (p) {
 
 type SparklineProps = {
   data: number[],
-  reference?: number,
   max: number,
+  reference?: number,
   width: number
 }
 

--- a/lib/modules/admin/components/worker-dashboard.js
+++ b/lib/modules/admin/components/worker-dashboard.js
@@ -8,18 +8,19 @@ import React from 'react'
 
 import {REFRESH_INTERVAL_MS} from '../constants'
 import * as utils from '../utils'
+
 import WorkerSparkline from './sparkline'
 
 const bytesToGB = (bytes: number) => (bytes * 1e-9).toFixed(2)
 
 class WorkerDashboard extends React.PureComponent {
   props: {
+    fetchWorkers: () => void,
     maxLoad: number,
     maxTasksPerMinute: number,
-    workersSortBy: any,
     workers: any,
 
-    fetchWorkers: () => void
+    workersSortBy: any
   }
 
   state = {
@@ -31,7 +32,7 @@ class WorkerDashboard extends React.PureComponent {
     this.props.fetchWorkers()
     this._fetchWorkerIntervalId = setInterval(() =>
       this.props.fetchWorkers(),
-      REFRESH_INTERVAL_MS)
+    REFRESH_INTERVAL_MS)
   }
 
   componentWillUnmount () {

--- a/lib/modules/admin/types.js
+++ b/lib/modules/admin/types.js
@@ -8,6 +8,6 @@ export type Worker = any
 
 export type State = {
   jobs: Job[],
-  workersSortBy: string[],
-  workers: Worker[]
+  workers: Worker[],
+  workersSortBy: string[]
 }

--- a/lib/modules/opportunity-datasets/actions.js
+++ b/lib/modules/opportunity-datasets/actions.js
@@ -8,7 +8,6 @@ import selectCurrentRegionId from '../../selectors/current-region-id'
 import {fetchSignedS3Url} from '../../utils/fetch-signed-s3-url'
 
 import * as select from './selectors'
-
 import type {
   Action,
   Dispatch,

--- a/lib/modules/opportunity-datasets/components/choropleth.js
+++ b/lib/modules/opportunity-datasets/components/choropleth.js
@@ -4,7 +4,6 @@ import {connect} from 'react-redux'
 import {interpolatePuBuGn as getColor} from 'd3-scale-chromatic'
 
 import Gridualizer from '../../../components/map/gridualizer'
-
 import * as select from '../selectors'
 
 const NUM_COLORS = 5

--- a/lib/modules/opportunity-datasets/components/dotmap.js
+++ b/lib/modules/opportunity-datasets/components/dotmap.js
@@ -3,7 +3,6 @@ import {colorizers} from '@conveyal/gridualizer'
 import {connect} from 'react-redux'
 
 import Gridualizer from '../../../components/map/gridualizer'
-
 import * as select from '../selectors'
 
 function mapStateToProps (state, ownProps) {

--- a/lib/modules/opportunity-datasets/components/edit.js
+++ b/lib/modules/opportunity-datasets/components/edit.js
@@ -5,7 +5,6 @@ import React, {PureComponent} from 'react'
 
 import {Button} from '../../../components/buttons'
 import {Group} from '../../../components/input'
-
 import type {OpportunityDataset} from '../types'
 
 type Props = {
@@ -71,14 +70,14 @@ export default class EditOpportunityDatatset extends PureComponent {
           onClick={this._deleteDataset}
           style='danger'
           title={message('opportunityDatasets.delete')}
-          ><Icon type='trash' /> {message('opportunityDatasets.delete')}
+        ><Icon type='trash' /> {message('opportunityDatasets.delete')}
         </Button>
         <Button
           block
           onClick={this._deleteSourceSet}
           style='danger'
           title={message('opportunityDatasets.deleteSource')}
-          ><Icon type='trash' /> {message('opportunityDatasets.deleteSource')}
+        ><Icon type='trash' /> {message('opportunityDatasets.deleteSource')}
         </Button>
       </Group>
       <Group label={message('analysis.gisExport')}>
@@ -87,14 +86,14 @@ export default class EditOpportunityDatatset extends PureComponent {
           onClick={this._downloadTiff}
           style='success'
           title={message('opportunityDatasets.downloadTiff')}
-          ><Icon type='download' /> {message('opportunityDatasets.downloadTiff')}
+        ><Icon type='download' /> {message('opportunityDatasets.downloadTiff')}
         </Button>
         <Button
           block
           onClick={this._downloadGrid}
           style='success'
           title={message('opportunityDatasets.downloadGrid')}
-          ><Icon type='download' /> {message('opportunityDatasets.downloadGrid')}
+        ><Icon type='download' /> {message('opportunityDatasets.downloadGrid')}
         </Button>
       </Group>
     </div>

--- a/lib/modules/opportunity-datasets/components/heading.js
+++ b/lib/modules/opportunity-datasets/components/heading.js
@@ -1,12 +1,11 @@
 // @flow
 import Icon from '@conveyal/woonerf/components/icon'
 import React, {PureComponent} from 'react'
+import type {Children} from 'react'
 
 import {Application, Dock, Title} from '../../../components/base'
 
 import Dotmap from './dotmap'
-
-import type {Children} from 'react'
 
 export default class Heading extends PureComponent {
   props: {

--- a/lib/modules/opportunity-datasets/components/list.js
+++ b/lib/modules/opportunity-datasets/components/list.js
@@ -9,13 +9,13 @@ import {connect} from 'react-redux'
 import {createStructuredSelector} from 'reselect'
 
 import {Button} from '../../../components/buttons'
-import EditOpportunityDataset from './edit'
 import {Group} from '../../../components/input'
 import * as actions from '../actions'
 import * as select from '../selectors'
-import Selector from './selector'
-
 import type {OpportunityDataset, UploadStatus} from '../types'
+
+import Selector from './selector'
+import EditOpportunityDataset from './edit'
 
 const UPLOAD_STATUS_CHECK_INTERVAL = 5000 // five seconds
 
@@ -32,16 +32,16 @@ function statusToStyle (status): string {
 
 type Props = {
   activeOpportunityDataset?: OpportunityDataset,
-  uploadStatuses: UploadStatus[],
-
   checkUploadStatus: () => void,
+
   clearStatus: (statusId: string) => void,
-  downloadLODES: () => void,
   deleteOpportunityDataset: (dataset: OpportunityDataset) => void,
   deleteSourceSet: (sourceId: string) => void,
+  downloadLODES: () => void,
   downloadOpportunityDataset: (dataset: OpportunityDataset, format: string) => void,
   editOpportunityDataset: (dataset: OpportunityDataset) => void,
-  goToUpload: () => void
+  goToUpload: () => void,
+  uploadStatuses: UploadStatus[]
 }
 
 export class ListOpportunityDatasets extends PureComponent {
@@ -84,27 +84,27 @@ export class ListOpportunityDatasets extends PureComponent {
     return <div>
       {uploadStatuses.length > 0 && <h5>Upload Status</h5>}
       {uploadStatuses
-          .filter((status) => differenceInHours(status.completedAt || status.createdAt, new Date()) < 24)
-          .map((status, i) =>
-            <Status
-              clear={this._clearStatus(status.id)}
-              key={`us-${i}`}
-              {...status}
-              />)}
+        .filter((status) => differenceInHours(status.completedAt || status.createdAt, new Date()) < 24)
+        .map((status, i) =>
+          <Status
+            clear={this._clearStatus(status.id)}
+            key={`us-${i}`}
+            {...status}
+          />)}
       <Group>
         <Button
           block
           onClick={goToUpload}
           style='success'
           title={message('opportunityDatasets.upload')}
-          ><Icon type='plus' /> {message('opportunityDatasets.upload')}
+        ><Icon type='plus' /> {message('opportunityDatasets.upload')}
         </Button>
         <Button
           block
           onClick={this._downloadLODES}
           style='primary'
           title={message('opportunityDatasets.downloadLODES')}
-          ><Icon type='users' /> {message('opportunityDatasets.downloadLODES')}
+        ><Icon type='users' /> {message('opportunityDatasets.downloadLODES')}
         </Button>
       </Group>
       <p className='center'>{message('opportunityDatasets.select')}</p>

--- a/lib/modules/opportunity-datasets/components/selector.js
+++ b/lib/modules/opportunity-datasets/components/selector.js
@@ -6,17 +6,16 @@ import {createStructuredSelector} from 'reselect'
 
 import * as actions from '../actions'
 import * as select from '../selectors'
-
 import type {ReactSelectResult} from '../../../types'
 import type {OpportunityDataset} from '../types'
 
 export class OpportunityDatasetSelector extends PureComponent {
   props: {
     activeOpportunityDataset?: OpportunityDataset,
-    opportunityDatasets: OpportunityDataset[],
-
     loadOpportunityDataset: (dataset: OpportunityDataset) => void,
+
     loadOpportunityDatasets: () => void,
+    opportunityDatasets: OpportunityDataset[],
     setActiveOpportunityDataset: (_id?: string) => void
   }
 

--- a/lib/modules/opportunity-datasets/components/upload.js
+++ b/lib/modules/opportunity-datasets/components/upload.js
@@ -7,7 +7,6 @@ import {connect} from 'react-redux'
 
 import {Button} from '../../../components/buttons'
 import {File, Text} from '../../../components/input'
-
 import {uploadOpportunityDataset} from '../actions'
 
 /** Create an opportunity dataset by uploading files */
@@ -63,7 +62,7 @@ export class UploadOpportunityDataset extends PureComponent {
         <form
           encType='multipart/form-data'
           ref={(form) => { this.form = form }}
-          >
+        >
           <Text
             name='Name'
             label={`${message('analysis.gridName')}*`}
@@ -100,7 +99,7 @@ export class UploadOpportunityDataset extends PureComponent {
             disabled={uploading || !name || !files}
             onClick={this._submit}
             type='success'
-            >{uploading
+          >{uploading
               ? <span>
                 <Icon type='spinner' className='fa-spin' /> {message('analysis.uploading')}
               </span>

--- a/lib/modules/opportunity-datasets/types.js
+++ b/lib/modules/opportunity-datasets/types.js
@@ -4,22 +4,22 @@
 import type {Grid} from '../../types'
 
 export type OpportunityDataset = {
-  sourceName: string,
-  sourceId: string,
+  _id: string,
   grid?: Grid,
   key: string,
   name: string,
-  _id: string,
-  regionId: string
+  regionId: string,
+  sourceId: string,
+  sourceName: string
 }
 
 export type PartialOpportunityDataset = {
-  sourceName?: string,
-  sourceId?: string,
+  _id: string,
   grid?: Grid,
   key?: string,
   name?: string,
-  _id: string
+  sourceId?: string,
+  sourceName?: string
 }
 
 export type UploadStatus = {
@@ -42,12 +42,12 @@ export type State = {
 }
 
 export type Action =
-  {type: 'opportunityDatasets/ADD', payload: OpportunityDataset}
-| {type: 'opportunityDatasets/REMOVE', payload: OpportunityDataset}
-| {type: 'opportunityDatasets/SET_ALL', payload: OpportunityDataset[]}
-| {type: 'opportunityDatasets/SET_ACTIVE', payload: void | string}
-| {type: 'opportunityDatasets/UPDATE', payload: PartialOpportunityDataset}
-| {type: 'opportunityDatasets/UPDATE_UPLOAD_STATUSES', payload: UploadStatus[]}
+  {payload: OpportunityDataset, type: 'opportunityDatasets/ADD'}
+| {payload: OpportunityDataset, type: 'opportunityDatasets/REMOVE'}
+| {payload: OpportunityDataset[], type: 'opportunityDatasets/SET_ALL'}
+| {payload: void | string, type: 'opportunityDatasets/SET_ACTIVE'}
+| {payload: PartialOpportunityDataset, type: 'opportunityDatasets/UPDATE'}
+| {payload: UploadStatus[], type: 'opportunityDatasets/UPDATE_UPLOAD_STATUSES'}
 
 export type Actions =
   Action

--- a/lib/modules/r5-version/actions.js
+++ b/lib/modules/r5-version/actions.js
@@ -4,7 +4,6 @@ import fetch from '@conveyal/woonerf/fetch'
 import {
   R5_BUCKET
 } from './constants'
-
 import type {Action} from './types'
 
 export const setCurrentR5Version =

--- a/lib/modules/r5-version/components/__tests__/selector.js
+++ b/lib/modules/r5-version/components/__tests__/selector.js
@@ -2,7 +2,6 @@
 import React from 'react'
 
 import {mockWithProvider} from '../../../../utils/mock-data'
-
 import Selector from '../selector'
 
 describe('R5 Version > Components > Selector', () => {

--- a/lib/modules/r5-version/components/selector.js
+++ b/lib/modules/r5-version/components/selector.js
@@ -7,24 +7,22 @@ import Select from 'react-select'
 import {createStructuredSelector} from 'reselect'
 
 import {Group} from '../../../components/input'
-
 import {
   loadR5Versions,
   setCurrentR5Version
 } from '../actions'
 import {RELEASE_VERSION_REGEX} from '../constants'
 import * as select from '../selectors'
-
 import type {ReactSelectResult} from '../../../types'
 
 type Props = {
   allValidVersions: string[],
   analysisVersion?: string,
   currentR5Version: string,
-  newerVersionIsAvailable: boolean,
-  releaseVersions: string[],
-
   loadR5Versions: () => void,
+  newerVersionIsAvailable: boolean,
+
+  releaseVersions: string[],
   setCurrentR5Version: (version: string) => void
 }
 
@@ -111,7 +109,7 @@ export class SelectR5Version extends Component<void, Props, State> {
             onChange={this._selectVersion}
             options={options}
             value={currentR5Version}
-            />
+          />
         </Group>
 
         {newerVersionIsAvailable &&

--- a/lib/modules/r5-version/reducer.js
+++ b/lib/modules/r5-version/reducer.js
@@ -1,6 +1,5 @@
 // @flow
 import type {Action, State} from './types'
-
 import {RECOMMENDED_R5_VERSION} from './constants'
 
 export function initialState (): State {

--- a/lib/modules/r5-version/selectors.js
+++ b/lib/modules/r5-version/selectors.js
@@ -10,7 +10,6 @@ import {
 } from './constants'
 import {initialState} from './reducer'
 import {versionToNumber} from './utils'
-
 import type {State} from './types'
 
 type FullState = {

--- a/lib/modules/r5-version/types.js
+++ b/lib/modules/r5-version/types.js
@@ -1,9 +1,9 @@
 // @flow
 
 export type Action =
-  {type: 'r5Version/SET_ALL', payload: string[]}
-| {type: 'r5Version/SET_CURRENT', payload: string}
-| {type: 'r5Version/SET_LAST_ANALYSIS_VERSION', payload: void | string}
+  {payload: string[], type: 'r5Version/SET_ALL'}
+| {payload: string, type: 'r5Version/SET_CURRENT'}
+| {payload: void | string, type: 'r5Version/SET_LAST_ANALYSIS_VERSION'}
 
 export type State = {
   +analysisVersion: void | string,

--- a/lib/reducers/__tests__/region.js
+++ b/lib/reducers/__tests__/region.js
@@ -3,7 +3,6 @@
 import {handleActions} from 'redux-actions'
 
 import * as region from '../region'
-
 import {mockRegionalAnalyses, mockRegion} from '../../utils/mock-data'
 
 describe('reducers > region', () => {

--- a/lib/reducers/network.js
+++ b/lib/reducers/network.js
@@ -6,19 +6,19 @@ import {
 } from '@conveyal/woonerf/fetch'
 
 type NetworkError = {
-  error: string,
   detailMessage: string,
-  url: string,
-  stack: string
+  error: string,
+  stack: string,
+  url: string
 }
 
 type Action =
-  {type: 'lock ui with error', payload: any}
-| {type: 'clear error', payload: void}
+  {payload: any, type: 'lock ui with error'}
+| {payload: void, type: 'clear error'}
 
 type FetchPayload = {
-  url: string,
-  options: any
+  options: any,
+  url: string
 }
 
 type NetworkState = {

--- a/lib/selectors/__tests__/aggregate-accessibility.js
+++ b/lib/selectors/__tests__/aggregate-accessibility.js
@@ -6,6 +6,7 @@
 /** Test that the aggregate accessibility selector works correctly */
 
 import range from 'lodash/range'
+
 import {getAggregateAccessibility} from '../aggregate-accessibility'
 
 const contains = (width, height) => (x, y) =>
@@ -91,7 +92,7 @@ describe('Selectors > aggregation accessibility', () => {
       throw new Error('expected aggregate accessibility to be defined')
     }
 
-    expect(aggregateAccessibility.bins.length).toEqual(15)
+    expect(aggregateAccessibility.bins).toHaveLength(15)
 
     expect(aggregateAccessibility.bins[0].min).toEqual(1000)
     expect(aggregateAccessibility.bins[0].max).toEqual(1300)

--- a/lib/selectors/__tests__/all-modification-feed-ids.js
+++ b/lib/selectors/__tests__/all-modification-feed-ids.js
@@ -1,6 +1,5 @@
 // @flow
 import selectAllModificationFeedIds from '../all-modification-feed-ids'
-
 import {ADD_TRIP_PATTERN, ADJUST_DWELL_TIME, CONVERT_TO_FREQUENCY} from '../../constants'
 
 const {describe, expect, it} = global
@@ -28,6 +27,6 @@ describe('selectors > all-modification-feed-ids', () => {
       }
     })
 
-    expect(allFeedIds.length).toBe(3)
+    expect(allFeedIds).toHaveLength(3)
   })
 })

--- a/lib/selectors/accessibility.js
+++ b/lib/selectors/accessibility.js
@@ -3,10 +3,10 @@ import {createSelector} from 'reselect'
 
 import {TRAVEL_TIME_PERCENTILES} from '../constants'
 import {activeOpportunityDataset} from '../modules/opportunity-datasets/selectors'
-import selectMaxTripDurationMinutes from './max-trip-duration-minutes'
-
 import type {TravelTimeSurface} from '../types'
 import type {OpportunityDataset} from '../modules/opportunity-datasets/types'
+
+import selectMaxTripDurationMinutes from './max-trip-duration-minutes'
 
 const DEPTH = TRAVEL_TIME_PERCENTILES.indexOf(50)
 

--- a/lib/selectors/add-trips-gtfs-stops.js
+++ b/lib/selectors/add-trips-gtfs-stops.js
@@ -1,8 +1,9 @@
 // @flow
 import {createSelector} from 'reselect'
 
-import selectActiveModification from './active-modification'
 import {ADD_TRIP_PATTERN} from '../constants'
+
+import selectActiveModification from './active-modification'
 
 export default createSelector(
   [selectActiveModification, state => state],

--- a/lib/selectors/aggregate-accessibility.js
+++ b/lib/selectors/aggregate-accessibility.js
@@ -5,7 +5,6 @@ import range from 'lodash/range'
 import {createSelector} from 'reselect'
 
 import {activeOpportunityDatasetGrid} from '../modules/opportunity-datasets/selectors'
-
 import type {Grid, AggregateAccessibility} from '../types'
 
 const N_HISTOGRAM_BINS = 15

--- a/lib/selectors/all-modification-feed-ids.js
+++ b/lib/selectors/all-modification-feed-ids.js
@@ -2,6 +2,7 @@
 import {createSelector} from 'reselect'
 
 import {ADD_TRIP_PATTERN, CONVERT_TO_FREQUENCY} from '../constants'
+
 import selectModifications from './modifications'
 
 export default createSelector(

--- a/lib/selectors/all-phase-from-timetable-stops.js
+++ b/lib/selectors/all-phase-from-timetable-stops.js
@@ -13,8 +13,8 @@ const selectTimetables = createSelector(
     ((modification.entries && modification.entries.length > 0) ||
       (modification.timetables && modification.timetables.length > 0)
       ? (modification.entries || modification.timetables)
-          .filter(tt => !!tt.phaseFromTimetable)
-          .map(tt => tt.phaseFromTimetable)
+        .filter(tt => !!tt.phaseFromTimetable)
+        .map(tt => tt.phaseFromTimetable)
       : [])
 )
 

--- a/lib/selectors/bookmark-data.js
+++ b/lib/selectors/bookmark-data.js
@@ -1,8 +1,9 @@
 // @flow
 import {createSelector} from 'reselect'
 
-import selectCurrentRegionId from './current-region-id'
 import {activeOpportunityDataset} from '../modules/opportunity-datasets/selectors'
+
+import selectCurrentRegionId from './current-region-id'
 
 export default createSelector(
   activeOpportunityDataset,

--- a/lib/selectors/comparison-accessibility.js
+++ b/lib/selectors/comparison-accessibility.js
@@ -1,8 +1,9 @@
 // @flow
 import {createSelector} from 'reselect'
-import {computeAccessibility} from './accessibility'
 
 import {activeOpportunityDataset} from '../modules/opportunity-datasets/selectors'
+
+import {computeAccessibility} from './accessibility'
 import selectMaxTripDurationMinutes from './max-trip-duration-minutes'
 
 /**

--- a/lib/selectors/comparison-aggregate-accessibility.js
+++ b/lib/selectors/comparison-aggregate-accessibility.js
@@ -1,5 +1,6 @@
 // @flow
 import {createSelector} from 'reselect'
+
 import {getAggregateAccessibility} from './aggregate-accessibility'
 
 /** Aggregate accessibility for the comparison regional analysis */

--- a/lib/selectors/comparison-destination-travel-time-distribution.js
+++ b/lib/selectors/comparison-destination-travel-time-distribution.js
@@ -1,5 +1,6 @@
 // @flow
 import {createSelector} from 'reselect'
+
 import {
   createDestinationTravelTimeDistribution
 } from './destination-travel-time-distribution'

--- a/lib/selectors/comparison-percentile-curves.js
+++ b/lib/selectors/comparison-percentile-curves.js
@@ -1,8 +1,9 @@
 // @flow
 import {createSelector} from 'reselect'
-import {computePercentileCurves} from './percentile-curves'
 
 import {activeOpportunityDatasetGrid} from '../modules/opportunity-datasets/selectors'
+
+import {computePercentileCurves} from './percentile-curves'
 
 /**
  * Select the percentile curves for the comparison project

--- a/lib/selectors/max-accessibility.js
+++ b/lib/selectors/max-accessibility.js
@@ -10,9 +10,9 @@ export default createSelector(
   (percentileCurves, comparisonPercentileCurves) =>
     (comparisonPercentileCurves
       ? Math.max(
-          computeMaxAccessibility(percentileCurves),
-          computeMaxAccessibility(comparisonPercentileCurves)
-        )
+        computeMaxAccessibility(percentileCurves),
+        computeMaxAccessibility(comparisonPercentileCurves)
+      )
       : computeMaxAccessibility(percentileCurves))
 )
 

--- a/lib/selectors/modifications-on-map.js
+++ b/lib/selectors/modifications-on-map.js
@@ -2,6 +2,7 @@
 import {createSelector} from 'reselect'
 
 import {ADD_TRIP_PATTERN} from '../constants'
+
 import selectActiveModificationId from './active-modification-id'
 import selectModifications from './modifications'
 

--- a/lib/selectors/percentile-curves.js
+++ b/lib/selectors/percentile-curves.js
@@ -4,7 +4,6 @@ import times from 'lodash/times'
 import {createSelector} from 'reselect'
 
 import {activeOpportunityDatasetGrid} from '../modules/opportunity-datasets/selectors'
-
 import type {Grid, TravelTimeSurface} from '../types'
 
 const MAX_TRIP_DURATION = 120
@@ -58,8 +57,8 @@ export function computePercentileCurves ({
   travelTimeSurface,
   grid
 }: {
-  travelTimeSurface: TravelTimeSurface,
-  grid: Grid
+  grid: Grid,
+  travelTimeSurface: TravelTimeSurface
 }): number[][] {
   return times(travelTimeSurface.depth, percentileIndex =>
     computePercentile({

--- a/lib/selectors/stops-from-modification.js
+++ b/lib/selectors/stops-from-modification.js
@@ -1,6 +1,7 @@
 import {createSelector} from 'reselect'
 
-import selectSegments from './segments'
 import getStops from '../utils/get-stops'
+
+import selectSegments from './segments'
 
 export default createSelector(selectSegments, segments => getStops(segments))

--- a/lib/types.js
+++ b/lib/types.js
@@ -14,8 +14,8 @@ export type Model = {
 }
 
 export type LonLat = {
-  lon: number,
-  lat: number
+  lat: number,
+  lon: number
 }
 
 export type Coordinates = [number, number] // [lon, lat]
@@ -52,13 +52,13 @@ export type Feature = {
 }
 
 export type FeatureCollection = {
-  type: 'FeatureCollection',
-  features: Feature[]
+  features: Feature[],
+  type: 'FeatureCollection'
 }
 
 export type LineString = {
-  type: 'LineString',
-  coordinates: number[][]
+  coordinates: number[][],
+  type: 'LineString'
 }
 
 /**
@@ -87,8 +87,8 @@ export type Bundle = Model & {
     name: string
   }>,
   regionId: string,
-  serviceStart: string,
   serviceEnd: string,
+  serviceStart: string,
   status: string,
   totalFeeds: number
 }
@@ -100,8 +100,8 @@ export type Project = Model & {
 }
 
 export type MapState = {
-  activeTrips?: number[],
   action?: string,
+  activeTrips?: number[],
   followRoad?: boolean,
   state: null | string
 }
@@ -110,18 +110,18 @@ export type Timetable = {
   _id: string,
   dwellTime: number,
   dwellTimes?: number[],
-  name: string,
-  headwaySecs: number,
-  phaseFromTimetable: string,
-  phaseFromStop: string,
-  phaseAtStop: null | string,
-  phaseSeconds: number,
-  segmentSpeeds: number[],
-  startTime: number,
   endTime: number,
   exactTimes: boolean,
+  headwaySecs: number,
   modificationId: string,
-  modificationName: string
+  modificationName: string,
+  name: string,
+  phaseAtStop: null | string,
+  phaseFromStop: string,
+  phaseFromTimetable: string,
+  phaseSeconds: number,
+  segmentSpeeds: number[],
+  startTime: number
 }
 
 export type Pattern = {
@@ -130,24 +130,24 @@ export type Pattern = {
 
 export type Route = {
   label: string,
-  route_id: string,
-  patterns: any[]
+  patterns: any[],
+  route_id: string
 }
 
 export type Trip = {
   duration: number,
-  trip_id: string,
-  start_time: number,
   end_time: number,
-  trip_short_name: string,
-  trip_headsign: string
+  start_time: number,
+  trip_headsign: string,
+  trip_id: string,
+  trip_short_name: string
 }
 
 export type RoutePattern = {
+  geometry?: any,
   name: string,
   pattern_id: string,
-  trips: Trip[],
-  geometry?: any
+  trips: Trip[]
 }
 
 export type RoutePatterns = RoutePattern[]
@@ -182,30 +182,30 @@ export type ModificationType =
 
 export type Modification = Model & {
   // All modifications have these
-  description: string,
-  projectId: string,
-  showOnMap: boolean,
-  type: ModificationType,
-  variants: boolean[],
-
-  // Only some have these
   bidirectional?: boolean,
+  description: string,
   dwellTime?: number,
   entries?: Timetable[],
   feed?: string,
+
+  // Only some have these
   fromStop?: string,
   hopes?: number,
+  projectId: string,
   retainTripsOutsideFrequencyEntries?: boolean,
   routes?: string[],
   scale?: boolean,
   secondsSavedAtEachStop?: number,
-  segments?: Segment[],
   segmentSpeeds?: number[],
+  segments?: Segment[],
+  showOnMap: boolean,
   stops?: string[],
   timetables?: Timetable[],
   toStop?: string,
   trips?: string[],
-  value?: number
+  type: ModificationType,
+  value?: number,
+  variants: boolean[]
 }
 
 export type ProfileRequest = {
@@ -230,35 +230,35 @@ export type ProfileRequest = {
 }
 
 export type Bookmark = Model & {
-  opportunityDataset: string,
   isochroneCutoff: number,
+  opportunityDataset: string,
   profileRequest: ProfileRequest,
   regionId: string
 }
 
 export type Stop = {
-  stopId: void | string,
+  autoCreated: boolean,
+  distanceFromStart: number,
   index: number,
   lat: number,
   lon: number,
-  autoCreated: boolean,
-  distanceFromStart: number
+  stopId: void | string
 }
 
 export type Bounds = {
-  north: number,
   east: number,
+  north: number,
   south: number,
   west: number
 }
 
 export type Region = Model & {
-  description: string,
-  bounds: Bounds,
-  statusCode: string,
-  bundles?: any[],
   bookmarks?: any[],
-  opportunityDatasets: any[]
+  bounds: Bounds,
+  bundles?: any[],
+  description: string,
+  opportunityDatasets: any[],
+  statusCode: string
 }
 
 // Analysis types
@@ -268,38 +268,38 @@ export type AggregationArea = {
 }
 
 export type AggregateAccessibility = {
-  weightedAverage: number,
-  minAccessibility: number,
-  maxAccessibility: number,
-  percentiles: number[],
   bins: {
-    min: number,
     max: number,
+    min: number,
     value: number
-  }[]
+  }[],
+  maxAccessibility: number,
+  minAccessibility: number,
+  percentiles: number[],
+  weightedAverage: number
 }
 
 export type Grid = {
-  zoom: number,
-  width: number,
-  height: number,
-  west: number,
-  north: number,
+  contains: (x: number, y: number) => boolean,
   data: number[],
+  height: number,
   min: number,
-  contains(x: number, y: number): boolean
+  north: number,
+  west: number,
+  width: number,
+  zoom: number
 }
 
 export type Surface = {
-  zoom: number,
-  west: number,
-  north: number,
-  width: number,
-  height: number,
   depth: number,
   errors: string[],
+  get: (x: number, y: number) => number[],
+  height: number,
+  north: number,
   warnings: string[],
-  get: (x: number, y: number) => number[]
+  west: number,
+  width: number,
+  zoom: number
 }
 
 export type OpportunityDataset = {
@@ -308,41 +308,41 @@ export type OpportunityDataset = {
 }
 
 export type RegionalAnalysis = Model & {
-  zoom: number,
-  width: number,
+  bounds: any,
+  bundleId: string,
+  complete: ?boolean,
+  cutoffMinutes: number,
+  deleted: ?boolean,
+  grid: string, // TODO
   height: number,
   north: number,
-  west: number,
-  request: any, // TODO
-  workerVersion: string,
-  bundleId: string,
-  bounds: any, // TODO geojson geometry
+  projectId: ?string, // TODO geojson geometry
 
   // assigned by server
-  complete: ?boolean,
-  projectId: ?string,
-  deleted: ?boolean,
+  request: any,
   status: string,
-  grid: string,
-  cutoffMinutes: number,
-  travelTimePercentile: number
+  travelTimePercentile: number,
+  west: number,
+  width: number,
+  workerVersion: string,
+  zoom: number
 }
 
 export type Quintiles = {
-  low: number,
-  iqrLow: number,
-  med: number,
+  high: number,
   iqrHigh: number,
-  high: number
+  iqrLow: number,
+  low: number,
+  med: number
 }
 
 export type TravelTimeSurface = {
   depth: number,
+  get: (number, number, number) => number,
+  height: number,
   north: number,
   west: number,
-  height: number,
-  width: number,
-  get: (number, number, number) => number
+  width: number
 }
 
 /**

--- a/lib/utils/fetch-signed-s3-url.js
+++ b/lib/utils/fetch-signed-s3-url.js
@@ -9,7 +9,7 @@ import fetch, {fetchMultiple} from '@conveyal/woonerf/fetch'
  * chained individually, otherwise the signed URLs can expire while we are
  * waiting for other responses.
  */
-export function fetchSignedS3Url ({url, next}: {url: string, next: (any) => any}) {
+export function fetchSignedS3Url ({url, next}: {next: (any) => any, url: string}) {
   return fetch({
     url: `${url}?redirect=false`,
     next: (res) =>
@@ -25,7 +25,7 @@ export function fetchSignedS3Url ({url, next}: {url: string, next: (any) => any}
   })
 }
 
-export function fetchMultipleSignedS3Urls ({urls, next}: {urls: string[], next: (any) => any}) {
+export function fetchMultipleSignedS3Urls ({urls, next}: {next: (any) => any, urls: string[]}) {
   return fetchMultiple({
     fetches: urls.map(url => ({url: `${url}?redirect=false`})),
     next: (responses) =>

--- a/lib/utils/get-line-string.js
+++ b/lib/utils/get-line-string.js
@@ -2,9 +2,9 @@
 import lonlat, {isEqual as coordinatesAreEqual} from '@conveyal/lonlat'
 import {lineString} from '@turf/helpers'
 
-import getRoutePolyline from './get-route-polyline'
-
 import type {LonLatC} from '../types'
+
+import getRoutePolyline from './get-route-polyline'
 
 const MINIMUM_COORDINATE_DISTANCE = 1e-6
 

--- a/lib/utils/rgb-color-contrast.js
+++ b/lib/utils/rgb-color-contrast.js
@@ -1,6 +1,6 @@
 // @flow
 
-export function isLight (c: {r: number, g: number, b: number}) {
+export function isLight (c: {b: number, g: number, r: number}) {
   const yiq = ((c.r * 299) + (c.g * 587) + (c.b * 114)) / 1000
   return yiq >= 128
 }

--- a/lib/utils/segments.js
+++ b/lib/utils/segments.js
@@ -1,6 +1,7 @@
 /** Functions to manipulate the segments object present in reroute and add trips */
 
 import sum from 'lodash/sum'
+
 import {DEFAULT_SEGMENT_SPEED} from '../constants/timetables'
 
 /**


### PR DESCRIPTION
Mastarm has been updated significantly and the main reason why I haven't updated it in Analysis UI is due to lint/flow/jest tests.

This is a first step that is mainly `mastarm lint --fix` using the new mastarm but will still pass our current linter on the old mastarm.