### PR TITLE
Show only one route per modification on map

### DIFF
--- a/configurations/default/messages.yml
+++ b/configurations/default/messages.yml
@@ -195,6 +195,7 @@ modification:
   importFromProjectInfo: When importing from a project associated with a different bundle, only "Add Trips" modifications will be copied. If a modification uses an existing stop from the baseline GTFS, it will be replaced in the imported modification by a new stop at the same location.
   name: Modification name
   type: Modification type
+  onlyOneRoute: While all routes selected below will be included in analysis, only one will be shown on the map.
   copyTimetable:
     noSegments: The modification being copied to and/or from does not have any segments. The default segment speed of %(segmentSpeed) km/h will be used.
     curHasMoreSegments: The modification of the timetable you are copying from has less segments than the modification you are copying to. The segment speeds will be copied %(numSegments) segment(s) and after that, the default segment speed of %(segmentSpeed) km/h will be used.

--- a/lib/actions/get-feeds-routes-and-stops.js
+++ b/lib/actions/get-feeds-routes-and-stops.js
@@ -160,15 +160,15 @@ function getUniqueRouteIdsFromModifications (modifications) {
       // ID, which means we're pulling down a bit more data than we need to but
       // it's pretty benign
       if (modification.routes && modification.routes.length > 0) {
-        // TODO This needs to be optimized on the server side. Previously, only
-        // adjust-speed modifications could be applied to multiple routes, and
-        // only one route per modification would be displayed in the browser.
-        // Removing these restrictions may lead to unwieldy geojsons for display.
-        modification.routes.forEach(routeId => {
-          if (routeIds.indexOf(routeId) === -1) {
-            routeIds.push(routeId)
-          }
-        })
+        // TODO To safely show multiple route, we need to add features to the
+        // backend. The current implementation, displaying all patterns
+        // individually, will crash browsers if used for a large number of
+        // routes. So for the moment, we only display patterns for one route per
+        // modification.
+        const routeId = modification.routes[0]
+        if (routeIds.indexOf(routeId) === -1) {
+          routeIds.push(routeId)
+        }
       }
     }
   }

--- a/lib/components/modification/editor.js
+++ b/lib/components/modification/editor.js
@@ -229,6 +229,12 @@ export default class ModificationEditor extends React.Component {
                   </Button>
                 </Group>}
 
+                {modification.routes && modification.routes.length > 1 &&
+                  <div className='alert alert-warning' role='alert'>
+                    {message('modification.onlyOneRoute')}
+                  </div>
+                }
+
                 <ModificationType
                   modification={modification}
                   setMapState={setMapState}


### PR DESCRIPTION
Undoes fix for #696
Adds note in UI that only one route will be shown on map, which we'll want to keep until some backend/gtfs-api changes.