### PR TITLE
Percentile and bundle fixes

### DIFF
--- a/configurations/default/messages.yml
+++ b/configurations/default/messages.yml
@@ -14,6 +14,7 @@ common:
   removeFrom: Remove from
   route: Route
   loading: Loading...
+  processing: Processing...
 error:
   back: Go back
   close: Continue anyways
@@ -28,15 +29,19 @@ authentication:
   username: Logged in as %(username)
 bundle:
   name: Bundle Name
+  explanation: Bundles are a collection of one or more GTFS feeds that make up the transit layer of a baseline network.
+  edit: Edit Bundle
   create: Create GTFS bundle
-  failure: Upload Failed. Is this a valid GTFS bundle?
+  failure: Error processing GTFS. Please upload valid GTFS .zip files.
   feed: Feed
   files: GTFS .zip files
   delete: Delete this bundle
   deleteConfirmation: Are you sure you would like to delete this bundle? Projects using this bundle will no longer work.
   edit: Edit bundle
-  processing: Bundle still being processed...
-  save: Save bundle
+  processing: Wait until processing is complete before leaving this page. This may take a few minutes.
+  save: Save renamed bundle/feed names
+  select: or select an existing one
+  notice: After clicking "Create, you will need to wait a few minutes for GTFS feeds to be processed.
 map:
   northAbbr: N # Local abbreviation for north, used to label north arrow
 mode:

--- a/lib/components/__tests__/__snapshots__/edit-bundle.js.snap
+++ b/lib/components/__tests__/__snapshots__/edit-bundle.js.snap
@@ -3,7 +3,7 @@
 exports[`Component > EditBundle renders correctly 1`] = `
 <div>
   <p>
-    Bundles are a collection of one or more GTFS feeds.
+    Bundles are a collection of one or more GTFS feeds that make up the transit layer of a baseline network.
   </p>
   <div
     className="form-group"
@@ -99,13 +99,13 @@ exports[`Component > EditBundle renders correctly 1`] = `
       href="#"
       onClick={[Function]}
       tabIndex={0}
-      title="Save bundle"
+      title="Save renamed bundle/feed names"
     >
       <i
         className="fa fa-save fa-fw "
       />
        
-      Save bundle
+      Save renamed bundle/feed names
     </a>
     <a
       className="btn btn-danger btn-block"

--- a/lib/components/analysis/stacked-percentile-selector.js
+++ b/lib/components/analysis/stacked-percentile-selector.js
@@ -132,7 +132,7 @@ export default class StackedPercentileSelector extends PureComponent {
               }}
             >
               <div className='project-name'>
-                {`${comparisonProjectName} (Median)`}
+                {`${comparisonProjectName}`}
               </div>
             </div>
             <div className='statistic'>

--- a/lib/components/create-bundle.js
+++ b/lib/components/create-bundle.js
@@ -105,6 +105,11 @@ export default class CreateBundle extends Component {
           method='post'
           onSubmit={this._submit}
         >
+          {uploading &&
+            <div className='alert alert-warning'>
+              {message('bundle.processing')}
+            </div>
+          }
           {uploadFailed &&
             <div className='alert alert-danger'>
               <strong>{message('bundle.failure')}</strong>
@@ -127,6 +132,11 @@ export default class CreateBundle extends Component {
             value={files}
           />
 
+          {name && files && !uploading && !uploadFailed &&
+            <div className='alert alert-warning'>
+              {message('bundle.notice')}
+            </div>
+          }
           <input type='hidden' name='regionId' value={regionId} />
           <button
             className='btn btn-block btn-success'
@@ -134,7 +144,7 @@ export default class CreateBundle extends Component {
             type='submit'
           >{uploading
               ? <span><Icon className='fa-spin' type='spinner' />
-                {message('common.loading')}</span>
+                {message('common.processing')}</span>
               : <span><Icon type='check' /> {message('common.create')}</span>}
           </button>
         </form>

--- a/lib/components/edit-bundle.js
+++ b/lib/components/edit-bundle.js
@@ -96,7 +96,7 @@ export default class EditBundle extends Component {
     const {bundle, goToCreateBundle} = this.props
     return (
       <div>
-        <p>Bundles are a collection of one or more GTFS feeds.</p>
+        <p>{message('bundle.explanation')}</p>
 
         <Group>
           <Button
@@ -108,7 +108,7 @@ export default class EditBundle extends Component {
           </Button>
         </Group>
 
-        <p className='center'>or select an existing one</p>
+        <p className='center'>{message('bundle.select')}</p>
 
         <Group>
           <Select
@@ -121,7 +121,7 @@ export default class EditBundle extends Component {
 
         {bundle &&
           <div>
-            <h5>Edit Bundle</h5>
+            <h5>{message('bundle.edit')}</h5>
 
             {bundle.status === 'PROCESSING_GTFS' &&
               <div className='alert alert-warning'>

--- a/lib/containers/__tests__/__snapshots__/edit-bundle.js.snap
+++ b/lib/containers/__tests__/__snapshots__/edit-bundle.js.snap
@@ -78,7 +78,7 @@ exports[`Container > Edit Bundle renders correctly 1`] = `
     >
       <div>
         <p>
-          Bundles are a collection of one or more GTFS feeds.
+          Bundles are a collection of one or more GTFS feeds that make up the transit layer of a baseline network.
         </p>
         <Group>
           <div
@@ -295,14 +295,14 @@ exports[`Container > Edit Bundle renders correctly 1`] = `
             block={true}
             onClick={[Function]}
             style="success"
-            title="Save bundle"
+            title="Save renamed bundle/feed names"
           >
             <a
               className="btn btn-success btn-block"
               href="#"
               onClick={[Function]}
               tabIndex={0}
-              title="Save bundle"
+              title="Save renamed bundle/feed names"
             >
               <Icon
                 type="save"
@@ -312,7 +312,7 @@ exports[`Container > Edit Bundle renders correctly 1`] = `
                 />
               </Icon>
                
-              Save bundle
+              Save renamed bundle/feed names
             </a>
           </Button>
           <Button

--- a/lib/selectors/comparison-accessibility.js
+++ b/lib/selectors/comparison-accessibility.js
@@ -13,5 +13,6 @@ export default createSelector(
   state => state.analysis.comparisonTravelTimeSurface,
   selectMaxTripDurationMinutes,
   activeOpportunityDataset,
+  state => state.analysis.profileRequest.travelTimePercentile,
   computeAccessibility
 )


### PR DESCRIPTION
We should merge and deploy quickly to address #788.  Until we do, the accessibility values for comparison scenarios will be fixed to 5th percentile travel times, no matter what percentile is selected (and despite the fact that the label says median).

This PR also includes clearer guidance on Bundles.  An additional enhancement would be #791 