### PR TITLE
Abort fetching isochrones

### DIFF
--- a/lib/actions/analysis/index.js
+++ b/lib/actions/analysis/index.js
@@ -5,11 +5,12 @@
  */
 
 import lonlat from '@conveyal/lonlat'
-import {fetchError, fetchMultiple} from '@conveyal/woonerf/fetch'
+import {fetchMultiple} from '@conveyal/woonerf/fetch'
 import {createAction} from 'redux-actions'
 
 import {
   ANALYSIS_URL,
+  FETCH_TRAVEL_TIME_SURFACE,
   PROFILE_REQUEST_DEFAULTS,
   TRAVEL_TIME_PERCENTILES
 } from '../../constants'
@@ -27,7 +28,8 @@ import type {GetState, LonLat} from '../../types'
 
 import {parseTimesData} from './parse-times-data'
 
-const RETRY_TIMEOUT_MILLSECONDS = 5000
+const RETRY_TIMEOUT_MILLISECONDS = 1000 * 30 // 30 seconds
+const MAX_RETRIES = 10
 
 export const clearComparisonProject = createAction('clear comparison project')
 export const setActiveVariant = createAction('set active variant')
@@ -128,10 +130,12 @@ export const fetchTravelTimeSurface = (asGeoTIFF: boolean) =>
     // Store the profile request settings for the user/region
     dispatch(storeProfileRequestSettings(profileRequest))
 
+    let retryCount = 0
     async function retry (response) {
-      if (response.status === 202) {
+      console.log(retryCount)
+      if (response.status === 202 && ++retryCount < MAX_RETRIES) {
         dispatch(setIsochroneFetchStatusMessage(INITIALIZING_CLUSTER))
-        await timeout(RETRY_TIMEOUT_MILLSECONDS)
+        await timeout(RETRY_TIMEOUT_MILLISECONDS)
         return true
       } else {
         return false
@@ -170,6 +174,7 @@ export const fetchTravelTimeSurface = (asGeoTIFF: boolean) =>
     }
 
     dispatch(fetchMultiple({
+      type: FETCH_TRAVEL_TIME_SURFACE,
       fetches,
       next (error, responses) {
         if (error) {
@@ -181,11 +186,10 @@ export const fetchTravelTimeSurface = (asGeoTIFF: boolean) =>
           ])
 
           // responses is just the single response when there was an error
-          if (Array.isArray(responses.value)) {
-            dispatch(setScenarioApplicationErrors(responses.value))
-          } else {
-            dispatch(fetchError(responses.value))
-          }
+          dispatch(setScenarioApplicationErrors(Array.isArray(responses.value)
+            ? responses.value
+            : [responses.value]
+          ))
         } else if (asGeoTIFF === true) {
           downloadGeoTIFF({
             data: responses[0].value,

--- a/lib/components/__tests__/date-picker.js
+++ b/lib/components/__tests__/date-picker.js
@@ -1,7 +1,6 @@
 // @flow
 import React from 'react'
 import {mount} from 'enzyme'
-import {mountToJson} from 'enzyme-to-json'
 
 import DatePicker from '../date-picker'
 

--- a/lib/components/analysis/index.js
+++ b/lib/components/analysis/index.js
@@ -45,6 +45,7 @@ import ProfileRequestEditor from './profile-request-editor'
 import AdvancedSettings from './advanced-settings'
 
 type Props = {
+  abortFetchTravelTimeSurface: () => void,
   analysisBounds: Leaflet.LatLngBounds,
   bundles: Bundle[],
   clearComparisonProject: () => void,
@@ -118,6 +119,7 @@ export default class SinglePointAnalysis extends Pure {
   }
 
   componentWillUnmount () {
+    this.props.abortFetchTravelTimeSurface()
     this.props.clearTravelTimeSurfaces()
   }
 
@@ -352,12 +354,21 @@ export default class SinglePointAnalysis extends Pure {
           <div className='ApplicationDockTitle'>
             <Icon type='area-chart' /> Analysis
 
+            {isFetchingIsochrone &&
+              <Button
+                className='pull-right'
+                onClick={p.abortFetchTravelTimeSurface}
+                style='danger'
+              >
+                <Icon type='close' /> Abort
+              </Button>}
+
             <Button
               className='pull-right'
               disabled={disableInputs}
               onClick={fetchTravelTimeSurface}
               style='primary'
-              title={disableInputs && message('analysis.disableFetch')}
+              title={disableInputs ? message('analysis.disableFetch') : ''}
             >
               <Icon
                 type='refresh'
@@ -374,7 +385,9 @@ export default class SinglePointAnalysis extends Pure {
               disabled={disableCreateRegionalAnalysis}
               style='success'
               onClick={this._createRegionalAnalysis}
-              title={disableCreateRegionalAnalysis && message('analysis.disableRegionalAnalysis')}
+              title={disableCreateRegionalAnalysis
+                ? message('analysis.disableRegionalAnalysis')
+                : ''}
             >
               {creatingRegionalAnalysis
                 ? <Icon spin type='refresh' />

--- a/lib/constants/index.js
+++ b/lib/constants/index.js
@@ -38,6 +38,11 @@ export const MODIFICATION_TYPES = [
 ]
 
 /**
+ * Fetch types
+ */
+export const FETCH_TRAVEL_TIME_SURFACE = 'FETCH_TRAVEL_TIME_SURFACE'
+
+/**
  * Default values
  */
 export const DEFAULT_ADD_STOPS_DWELL = 0

--- a/lib/containers/single-point-analysis.js
+++ b/lib/containers/single-point-analysis.js
@@ -1,7 +1,9 @@
 // @flow
+import {abortFetch} from '@conveyal/woonerf/fetch'
 import {connect} from 'react-redux'
 import {push} from 'react-router-redux'
 
+import {FETCH_TRAVEL_TIME_SURFACE} from '../constants'
 import SinglePointAnalysis from '../components/analysis'
 import {loadBundle} from '../actions'
 import {
@@ -9,6 +11,7 @@ import {
   clearComparisonProject,
   setComparisonProject,
   setDestination,
+  setIsochroneFetchStatus,
   setProfileRequest,
   setTravelTimeSurface,
   setComparisonTravelTimeSurface
@@ -103,6 +106,10 @@ const clearTravelTimeSurfaces = () => [
 ]
 
 const mapDispatchToProps = {
+  abortFetchTravelTimeSurface: () => [
+    abortFetch({type: FETCH_TRAVEL_TIME_SURFACE}),
+    setIsochroneFetchStatus(false)
+  ],
   clearComparisonProject,
   clearTravelTimeSurfaces,
   createRegionalAnalysis,

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@conveyal/gridualizer": "^2.1.0",
     "@conveyal/lonlat": "^1.4.0",
-    "@conveyal/woonerf": "^3.0.0",
+    "@conveyal/woonerf": "^4.1.0",
     "@mapbox/polyline": "^0.2.0",
     "@turf/bearing": "3.7.5",
     "@turf/destination": "3.7.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,12 @@
 # yarn lockfile v1
 
 
+"@babel/runtime@^7.1.2":
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.1.2.tgz#81c89935f4647706fc54541145e6b4ecfef4b8e3"
+  dependencies:
+    regenerator-runtime "^0.12.0"
+
 "@conveyal/gridualizer@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@conveyal/gridualizer/-/gridualizer-2.1.0.tgz#a9e2dfde5d764eebca60c84dd5e0930aee5ca38a"
@@ -20,22 +26,22 @@
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@conveyal/lonlat/-/lonlat-1.4.0.tgz#18a5c1349078a779e710d24af11bc02b24127ba0"
 
-"@conveyal/woonerf@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@conveyal/woonerf/-/woonerf-3.0.0.tgz#8575eab098c696e43423633f30bb9640eb5186a1"
+"@conveyal/woonerf@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@conveyal/woonerf/-/woonerf-4.1.0.tgz#e511b9f816752b26c557b2daf544429c7996a7a8"
   dependencies:
-    auth0-lock "^10.19.0"
-    debug "^2.6.8"
+    debug "^4.0.1"
     isomorphic-fetch "^2.2.1"
-    lodash "^4.17.4"
-    react-addons-perf "^15.4.2"
-    react-redux "^5.0.5"
+    lodash "^4.17.11"
+    logrocket "^0.6.17"
+    react-redux "^5.0.7"
     react-router "^3.0.2"
     react-router-redux "^4.0.8"
-    redux "^3.7.2"
-    redux-actions "^2.2.1"
+    redux "^4.0.0"
+    redux-actions "^2.6.1"
     redux-logger "^3.0.6"
-    redux-thunk "^2.2.0"
+    redux-mock-store "^1.5.3"
+    redux-thunk "^2.3.0"
 
 "@mapbox/polyline@^0.2.0":
   version "0.2.0"
@@ -599,36 +605,6 @@ auth0-js@^9.3.0:
     superagent "^3.8.2"
     url-join "^1.1.0"
     winchan "^0.2.0"
-
-auth0-js@~8.11.2:
-  version "8.11.3"
-  resolved "https://registry.yarnpkg.com/auth0-js/-/auth0-js-8.11.3.tgz#97385a17c8aad1cd612bf82fded328a4396eebdf"
-  dependencies:
-    base64-js "^1.2.0"
-    idtoken-verifier "^1.1.0"
-    qs "^6.4.0"
-    superagent "^3.3.1"
-    url-join "^1.1.0"
-    winchan "^0.2.0"
-
-auth0-lock@^10.19.0:
-  version "10.24.1"
-  resolved "https://registry.yarnpkg.com/auth0-lock/-/auth0-lock-10.24.1.tgz#f85a87c3a9309b9a7a7df369040fc663bde6ec9c"
-  dependencies:
-    auth0-js "~8.11.2"
-    blueimp-md5 "2.3.1"
-    fbjs "^0.3.1"
-    idtoken-verifier "^1.0.1"
-    immutable "^3.7.3"
-    jsonp "^0.2.0"
-    password-sheriff "^1.1.0"
-    prop-types "^15.6.0"
-    react "^15.6.2"
-    react-dom "^15.6.2"
-    react-transition-group "^2.2.1"
-    superagent "^3.3.1"
-    trim "0.0.1"
-    url-join "^1.1.0"
 
 auth0-lock@^11.3.1:
   version "11.3.1"
@@ -2445,7 +2421,7 @@ debug@^3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@^4.1.0:
+debug@^4.0.1, debug@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.0.tgz#373687bffa678b38b1cd91f861b63850035ddc87"
   dependencies:
@@ -3781,9 +3757,11 @@ hoist-non-react-statics@^1.0.3, hoist-non-react-statics@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
 
-hoist-non-react-statics@^2.2.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz#343db84c6018c650778898240135a1420ee22ce0"
+hoist-non-react-statics@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.1.0.tgz#42414ccdfff019cd2168168be998c7b3bd5245c0"
+  dependencies:
+    react-is "^16.3.2"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -3878,7 +3856,7 @@ iconv-lite@^0.4.15, iconv-lite@~0.4.13:
   version "0.4.18"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.18.tgz#23d8656b16aae6742ac29732ea8f0336a4789cf2"
 
-idtoken-verifier@^1.0.1, idtoken-verifier@^1.1.0:
+idtoken-verifier@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/idtoken-verifier/-/idtoken-verifier-1.1.0.tgz#1add30125aa3e5e5859d152b356a908a8e2eb5a0"
   dependencies:
@@ -4030,6 +4008,12 @@ interpret@^1.0.0:
 invariant@^2.0.0, invariant@^2.2.0, invariant@^2.2.1, invariant@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
+  dependencies:
+    loose-envify "^1.0.0"
+
+invariant@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   dependencies:
     loose-envify "^1.0.0"
 
@@ -4510,6 +4494,10 @@ js-tokens@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
+"js-tokens@^3.0.0 || ^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+
 js-yaml@^3.5.1, js-yaml@^3.7.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.9.1.tgz#08775cebdfdd359209f0d2acd383c8f86a6904a0"
@@ -4635,6 +4623,10 @@ jszip@^2.4.0:
   dependencies:
     pako "~1.0.2"
 
+just-curry-it@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/just-curry-it/-/just-curry-it-3.1.0.tgz#ab59daed308a58b847ada166edd0a2d40766fbc5"
+
 kind-of@^3.0.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
@@ -4738,7 +4730,7 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
-lodash-es@^4.17.4, lodash-es@^4.2.0, lodash-es@^4.2.1:
+lodash-es@^4.2.0, lodash-es@^4.2.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.4.tgz#dcc1d7552e150a0640073ba9cb31d70f032950e7"
 
@@ -4930,6 +4922,10 @@ lodash@^4.0.0, lodash@^4.1.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lo
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
+lodash@^4.17.11:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+
 lodash@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-1.3.1.tgz#a4663b53686b895ff074e2ba504dfb76a8e2b770"
@@ -4944,6 +4940,10 @@ logrocket@^0.6.16:
   version "0.6.16"
   resolved "https://registry.yarnpkg.com/logrocket/-/logrocket-0.6.16.tgz#09ac05426b096016e19395a0c0b0acf97a647418"
 
+logrocket@^0.6.17:
+  version "0.6.17"
+  resolved "https://registry.yarnpkg.com/logrocket/-/logrocket-0.6.17.tgz#4a9b6deed53a9c798204dd30203ed0dadd89c41c"
+
 longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
@@ -4953,6 +4953,12 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
     js-tokens "^3.0.0"
+
+loose-envify@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+  dependencies:
+    js-tokens "^3.0.0 || ^4.0.0"
 
 loud-rejection@^1.0.0:
   version "1.6.0"
@@ -6214,6 +6220,13 @@ prop-types@^15.6.0:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+prop-types@^15.6.1:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
+  dependencies:
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 propagate@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/propagate/-/propagate-0.4.0.tgz#f3fcca0a6fe06736a7ba572966069617c130b481"
@@ -6331,7 +6344,7 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-addons-perf@^15.4.1, react-addons-perf@^15.4.2:
+react-addons-perf@^15.4.1:
   version "15.4.2"
   resolved "https://registry.yarnpkg.com/react-addons-perf/-/react-addons-perf-15.4.2.tgz#110bdcf5c459c4f77cb85ed634bcd3397536383b"
   dependencies:
@@ -6398,6 +6411,10 @@ react-input-autosize@^2.1.2:
   dependencies:
     prop-types "^15.5.8"
 
+react-is@^16.3.2, react-is@^16.6.0:
+  version "16.6.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.6.0.tgz#456645144581a6e99f6816ae2bd24ee94bdd0c01"
+
 react-leaflet-control@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/react-leaflet-control/-/react-leaflet-control-1.4.0.tgz#b2a34581943e1d3b02062ed7a0ec79e7acc7b923"
@@ -6415,6 +6432,10 @@ react-leaflet@1.5.0:
     babel-runtime "^6.25.0"
     lodash "^4.0.0"
     warning "^3.0.0"
+
+react-lifecycles-compat@^3.0.0:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
 react-modal@^1.4.0:
   version "1.9.7"
@@ -6445,16 +6466,17 @@ react-redux@^5.0.2:
     loose-envify "^1.1.0"
     prop-types "^15.5.10"
 
-react-redux@^5.0.5:
-  version "5.0.6"
-  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-5.0.6.tgz#23ed3a4f986359d68b5212eaaa681e60d6574946"
+react-redux@^5.0.7:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-5.1.0.tgz#948b1e2686473d1999092bcfb32d0dc43d33f667"
   dependencies:
-    hoist-non-react-statics "^2.2.1"
-    invariant "^2.0.0"
-    lodash "^4.2.0"
-    lodash-es "^4.2.0"
+    "@babel/runtime" "^7.1.2"
+    hoist-non-react-statics "^3.0.0"
+    invariant "^2.2.4"
     loose-envify "^1.1.0"
-    prop-types "^15.5.10"
+    prop-types "^15.6.1"
+    react-is "^16.6.0"
+    react-lifecycles-compat "^3.0.0"
 
 react-router-redux@^4.0.5, react-router-redux@^4.0.8:
   version "4.0.8"
@@ -6655,6 +6677,10 @@ reduce-reducers@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/reduce-reducers/-/reduce-reducers-0.1.2.tgz#fa1b4718bc5292a71ddd1e5d839c9bea9770f14b"
 
+reduce-reducers@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/reduce-reducers/-/reduce-reducers-0.4.3.tgz#8e052618801cd8fc2714b4915adaa8937eb6d66c"
+
 redux-actions@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/redux-actions/-/redux-actions-1.2.2.tgz#31f15ba494fe130f05c4a9f486c99cc8725f80cd"
@@ -6663,14 +6689,15 @@ redux-actions@^1.2.1:
     lodash "^4.13.1"
     reduce-reducers "^0.1.0"
 
-redux-actions@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/redux-actions/-/redux-actions-2.2.1.tgz#d64186b25649a13c05478547d7cd7537b892410d"
+redux-actions@^2.6.1:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/redux-actions/-/redux-actions-2.6.3.tgz#5f3123ef967b8e022af922bee14c3d528c8f0748"
   dependencies:
-    invariant "^2.2.1"
-    lodash "^4.13.1"
-    lodash-es "^4.17.4"
-    reduce-reducers "^0.1.0"
+    invariant "^2.2.4"
+    just-curry-it "^3.1.0"
+    loose-envify "^1.4.0"
+    reduce-reducers "^0.4.3"
+    to-camel-case "^1.0.0"
 
 redux-logger@^3.0.6:
   version "3.0.6"
@@ -6682,11 +6709,17 @@ redux-mock-store@^1.2.1:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/redux-mock-store/-/redux-mock-store-1.2.3.tgz#1b3ad299da91cb41ba30d68e3b6f024475fb9e1b"
 
-redux-thunk@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.2.0.tgz#e615a16e16b47a19a515766133d1e3e99b7852e5"
+redux-mock-store@^1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/redux-mock-store/-/redux-mock-store-1.5.3.tgz#1f10528949b7ce8056c2532624f7cafa98576c6d"
+  dependencies:
+    lodash.isplainobject "^4.0.6"
 
-redux@^3.6.0, redux@^3.7.2:
+redux-thunk@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
+
+redux@^3.6.0:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/redux/-/redux-3.7.2.tgz#06b73123215901d25d065be342eb026bc1c8537b"
   dependencies:
@@ -6694,6 +6727,13 @@ redux@^3.6.0, redux@^3.7.2:
     lodash-es "^4.2.1"
     loose-envify "^1.1.0"
     symbol-observable "^1.0.3"
+
+redux@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.1.tgz#436cae6cc40fbe4727689d7c8fae44808f1bfef5"
+  dependencies:
+    loose-envify "^1.4.0"
+    symbol-observable "^1.2.0"
 
 regenerate@^1.2.1:
   version "1.3.2"
@@ -6706,6 +6746,10 @@ regenerator-runtime@^0.10.0:
 regenerator-runtime@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz#7e54fe5b5ccd5d6624ea6255c3473be090b802e1"
+
+regenerator-runtime@^0.12.0:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
 
 regenerator-transform@0.9.11:
   version "0.9.11"
@@ -7469,6 +7513,10 @@ symbol-observable@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
 
+symbol-observable@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
+
 symbol-tree@^3.2.1:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
@@ -7615,9 +7663,25 @@ to-arraybuffer@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
 
+to-camel-case@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/to-camel-case/-/to-camel-case-1.0.0.tgz#1a56054b2f9d696298ce66a60897322b6f423e46"
+  dependencies:
+    to-space-case "^1.0.0"
+
 to-fast-properties@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
+
+to-no-case@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/to-no-case/-/to-no-case-1.0.2.tgz#c722907164ef6b178132c8e69930212d1b4aa16a"
+
+to-space-case@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/to-space-case/-/to-space-case-1.0.0.tgz#b052daafb1b2b29dc770cea0163e5ec0ebc9fc17"
+  dependencies:
+    to-no-case "^1.0.0"
 
 tough-cookie@>=2.3.0, tough-cookie@^2.3.2, tough-cookie@~2.3.0:
   version "2.3.2"


### PR DESCRIPTION
- Add an abort button when fetching an isochrone. 
- Auto abort when you leave the page. 
- Increase the timeout retry delay to 30 seconds and limit it to ten retries.

NOTE: This includes the latest `woonerf` which removes duplicate data from the `decrement fetch` action so a lot of snapshots have been updated.