### PR TITLE
Scenario management

### DIFF
--- a/configurations/default/messages.yml
+++ b/configurations/default/messages.yml
@@ -143,6 +143,7 @@ project:
   select: Select a project…
 variant:
   name: Scenario
+  baseline: Baseline
   plural: Scenarios
   enterName: Enter a name for your scenario:
   editName: Rename this scenario

--- a/configurations/default/messages.yml
+++ b/configurations/default/messages.yml
@@ -134,7 +134,7 @@ project:
   selectBundle: Select a GTFS bundle...
   noBundles: To get started with projects in this region, first create a GTFS bundle.
   print: Print a scenario from this project
-  export: Download a scenario from this project
+  export: Download/share a scenario from this project
   route: Route
   uploadBundle: Upload a new GTFS Bundle
   uploadOpportunityDataset: Upload a new Opportunity Dataset
@@ -152,7 +152,7 @@ variant:
   delete: Delete this scenario
   deleteConfirmation: Are you sure you want to delete this scenario? Proceeding will clear references to it from all modifications.
   activeIn: Active in scenario numbers
-  export: Select scenario to #followed by print, e.g.
+  export: Select scenario to download or share
 transitEditor:
   startEdit: Edit route geometry
   stopEdit: Stop editing

--- a/lib/components/modification/list.js
+++ b/lib/components/modification/list.js
@@ -162,25 +162,26 @@ export default class ModificationsList extends Component {
     return (
       <Application map={this._map}>
         <ProjectTitle />
-        <Title>
-          <Icon type='pencil' /> Modifications
+          <Title>
+            <VariantEditor />
+          </Title>
+          <Title>
+            Modifications
 
-          <IconLink
-            className={`ShowOnMap pull-right ${showAllOnMap ? 'active' : 'dim'} fa-btn`}
-            onClick={this._toggleShowAllOnMap}
-            title='Toggle all modifications map display'
-            type={showIcon}
-          />
-          <IconLink
-            className='pull-right'
-            to={`/regions/${regionId}/projects/${projectId}/import-modifications`}
-            title={message('project.importModifications')}
-            type='upload'
-          />
-        </Title>
-
-        <Dock>
-          <VariantEditor />
+            <IconLink
+              className={`ShowOnMap pull-right ${showAllOnMap ? 'active' : 'dim'} fa-btn`}
+              onClick={this._toggleShowAllOnMap}
+              title='Toggle all modifications map display'
+              type={showIcon}
+            />
+            <IconLink
+              className='pull-right'
+              to={`/regions/${regionId}/projects/${projectId}/import-modifications`}
+              title={message('project.importModifications')}
+              type='upload'
+            />
+          </Title>
+          <Dock>
 
           <Group>
             <Button

--- a/lib/components/project-title.js
+++ b/lib/components/project-title.js
@@ -7,6 +7,9 @@ import {Title} from './base'
 import Link, {IconLink} from './link'
 import Modal, {ModalBody, ModalTitle} from './modal'
 
+import {Button, Group as ButtonGroup} from './buttons'
+import Collapsible from './collapsible'
+
 type Props = {
   _id: string,
   downloadScenario: (index: number) => void,
@@ -48,40 +51,26 @@ export default class ProjectTitle extends Component {
         <Icon type='cube' /> {name}
         {project &&
           <span>
-            <Link
-              className='pull-right'
-              onClick={this._showPrintSelect}
-              title={message('project.print')}
-            >
-              <Icon type='print' />
-              {this.state.showPrintSelect &&
-                <SelectScenario
-                  label='print'
-                  onHide={() => this.setState({showPrintSelect: false})}
-                  regionId={project.regionId}
-                  projectId={_id}
-                  scenarios={project.variants}
-                />}
-            </Link>
-            <Link
-              className='pull-right'
-              onClick={this._showExportSelect}
-              title={message('project.export')}
-            >
-              <Icon type='download' />
-              {this.state.showExportSelect &&
-                <SelectScenario
-                  action={this._export}
-                  label='export'
-                  onHide={() => this.setState({showExportSelect: false})}
-                  scenarios={project.variants}
-                />}
-            </Link>
             <IconLink
               className='pull-right'
               title={message('project.editSettings')}
               to={`/regions/${project.regionId}/projects/${_id}/edit`}
               type='gear' />
+            <IconLink
+              className='pull-right'
+              onClick={this._showExportSelect}
+              title={message('project.export')}
+              type='share-alt-square' />
+              {this.state.showExportSelect &&
+                <SelectScenario
+                  action={this._export}
+                  label='export'
+                  onHide={() => this.setState({showExportSelect: false})}
+                  regionId={project.regionId}
+                  projectId={_id}
+                  scenarios={project.variants}
+                />}
+            </Link>
           </span>}
       </Title>
     )
@@ -92,22 +81,30 @@ function SelectScenario ({action, regionId, label, onHide, projectId, scenarios}
   return (
     <Modal onRequestClose={onHide}>
       <ModalTitle>
-        {message('variant.export')} {label}:
+        {message('variant.export')}
       </ModalTitle>
       <ModalBody>
-        <ul>
-          {scenarios.map((name, index) => (
-            <li key={`scenario-${index}`}>
-              <a
-                onClick={label === 'export' ? () => action(index) : () => {}}
-                href={label === 'print' ? `/reports/${regionId}/projects/${projectId}/variants/${index}` : ''}
-                tabIndex={0}
-                target={label === 'print' ? '_blank' : ''}>
-                {name}
-              </a>
-            </li>
-          ))}
-        </ul>
+        {scenarios.map((name, index) => (
+          <Collapsible title={name}>
+            <ButtonGroup justified>
+              <Button
+                style='info'
+                onClick={() => action(index)}
+              >
+                <Icon type='download' />
+                Scenario (.json)
+              </Button>
+              <Button
+                style='info'
+                href={`/reports/${regionId}/projects/${projectId}/variants/${index}`}
+                target='_blank'
+              >
+                <Icon type='print' />
+                Summary report
+              </Button>
+            </ButtonGroup>
+          </Collapsible>
+        ))}
       </ModalBody>
     </Modal>
   )

--- a/lib/components/variant-editor.js
+++ b/lib/components/variant-editor.js
@@ -4,6 +4,8 @@ import message from '@conveyal/woonerf/message'
 import memoize from 'lodash/memoize'
 import React, {Component} from 'react'
 
+import Collapsible from './collapsible'
+
 type Props = {
   createVariant: (name: string) => void,
   deleteVariant: (index: number) => void,
@@ -47,53 +49,68 @@ export default class Variants extends Component<void, Props, void> {
   render () {
     const {variants} = this.props
     return (
-      <div>
-        <div className='DockTitle'>
-          <Icon type='clone' /> {message('variant.plural')}
-          <a
-            className='pull-right'
-            onClick={this._create}
-            tabIndex={0}
-            title={message('variant.createAction')}
-          >
-            <Icon type='plus' /> Create
-          </a>
-        </div>
-        <div className='Variants'>
-          <ol>
-            {variants.map((name, index) => (
-              <div className='Variant' key={`variant-${index}`}>
-                <li> {name}
+      <div className='Variants'>
+        <Collapsible title={message('variant.plural')}>
+            <ol start="0">
+              <div className='Variant' key={message('variant.baseline')}>
+                <li>
+                  <i>{message('variant.baseline')}</i>
                   <a
                     className='pull-right'
-                    onClick={this._showVariant(index)}
+                    onClick={this._showVariant(0)} // TODO hide all variants
                     tabIndex={0}
-                    title={message('variant.showModifications')}
+                    title='Hide all'
                   >
                     <Icon type='eye' />
                   </a>
                   <a
                     className='pull-right'
-                    onClick={this._editVariantName(index)}
-                    tabIndex={0}
-                    title={message('variant.editName')}
+                    title='Baseline (empty scenario) cannot be modified'
                   >
-                    <Icon type='pencil' />
+                  <Icon type='lock'/>
                   </a>
-                  {index !== 0 &&
-                    <a
-                      className='pull-right'
-                      onClick={this._deleteVariant(index)}
-                      tabIndex={0}
-                      title={message('variant.delete')}
-                    >
-                      <Icon type='trash' />
-                    </a>}
                 </li>
               </div>
-            ))}
-          </ol>
-        </div>
+              {variants.map((name, index) => (
+                <div className='Variant' key={`variant-${index}`}>
+                  <li> {name}
+                    <a
+                      className='pull-right'
+                      onClick={this._showVariant(index)}
+                      tabIndex={0}
+                      title={message('variant.showModifications')}
+                    >
+                      <Icon type='eye' />
+                    </a>
+                    <a
+                      className='pull-right'
+                      onClick={this._editVariantName(index)}
+                      tabIndex={0}
+                      title={message('variant.editName')}
+                    >
+                      <Icon type='pencil' />
+                    </a>
+                    {index !== 0 &&
+                      <a
+                        className='pull-right'
+                        onClick={this._deleteVariant(index)}
+                        tabIndex={0}
+                        title={message('variant.delete')}
+                      >
+                        <Icon type='trash' />
+                      </a>}
+                  </li>
+                </div>
+              ))}
+              <div className='Variant'>
+                <li>
+                  <a onClick={this._create}>
+                    <i>{message('variant.createAction')}</i>
+                  </a>
+                </li>
+              </div>
+            </ol>
+        </Collapsible>
       </div>
     )
   }

--- a/lib/styles.css
+++ b/lib/styles.css
@@ -516,12 +516,14 @@ label {
 }
 
 .Variants {
-  margin-top: 12px;
+  margin-left: -6px;
+  margin-bottom: -6px;
 }
 
 .Variant {
   padding-bottom: 6px;
   line-height: 18px;
+  font-size: 12px;
 }
 
 .Variant > .pull-right {


### PR DESCRIPTION
In the current interface, the hierarchy of scenarios and modifications is confusing.  The modifications list title has the project name, then "Modifications", then a list of scenarios, then options for creating modifications.  This PR:
* Addresses that unclear flow using a collapsible scenario list

![image](https://user-images.githubusercontent.com/2173529/48035772-6d694f80-e133-11e8-8483-d3fdae5819b1.png)

* Reduces visual clutter, in part by combining the infrequently used export/reporting options in the project title
* Makes it clearer what the (previously hidden) Baseline scenario is.
* - [ ]  #746
* - [ ] initial pass at part of #255 