### PR TITLE
Check for 202 status on timeout and set state accordingly

### DIFF
--- a/lib/actions/analysis/index.js
+++ b/lib/actions/analysis/index.js
@@ -203,6 +203,8 @@ const handleGeoTIFF = (name, comparisonName) => (responses) => {
  * Handle response for a travel time surface request.
  */
 export const handleSurface = (profileRequest: any) => (error: any, responses: any) => {
+  debugger;
+  // In case of error or timeout
   if (error) {
     return [
       setScenarioApplicationWarnings(null),
@@ -214,6 +216,8 @@ export const handleSurface = (profileRequest: any) => (error: any, responses: an
         ? responses.value
         : [responses.value])
     ]
+  } else if (responses[0].status === 202) {
+    return setIsochroneFetchStatus(false)
   }
 
   try {


### PR DESCRIPTION
Fixes a bug where the response was still parsed even if it was a 202 response. This behavior will be handled more thoroughly on upcoming changes.

closes #811