### PR TITLE
Force travel time percentile to be set when it is null

### DIFF
--- a/lib/actions/analysis/index.js
+++ b/lib/actions/analysis/index.js
@@ -118,6 +118,11 @@ export const fetchTravelTimeSurface = (asGeoTIFF?: boolean) =>
       projectId: currentProjectId
     }
 
+    // Previous versions of Analysis (pre v4.0.0) would allow this to be null
+    if (profileRequest.travelTimePercentile == null) {
+      profileRequest.travelTimePercentile = 50
+    }
+
     // Store the profile request settings for the user/region
     dispatch(storeProfileRequestSettings(profileRequest))
 


### PR DESCRIPTION
In the past, travel time percentile could be null, this forces it be set on each single point request.

closes https://github.com/conveyal/analysis-ui/issues/613