### PR TITLE
Calculate id and style outside of render call to prevent unnecessary re-renders

### DIFF
--- a/lib/components/analysis/map.js
+++ b/lib/components/analysis/map.js
@@ -43,8 +43,26 @@ const isochroneStyle = (fillColor) => ({
   stroke: false
 })
 
+const mainIsochroneStyle = isochroneStyle(colors.PROJECT_ISOCHRONE_COLOR)
+const compIsochroneStyle = isochroneStyle(colors.COMPARISON_ISOCHRONE_COLOR)
+
 export default class AnalysisMap extends React.Component {
   props: Props
+  state = {
+    mainIsochroneKey: uuid.v4(),
+    compIsochroneKey: uuid.v4()
+  }
+
+  componentWillReceiveProps (np: Props) {
+    const p = this.props
+    if (p.isochrone !== np.isochrone) {
+      this.setState({mainIsochroneKey: uuid.v4()})
+    }
+    if (p.comparisonIsochrone !== np.comparisonIsochrone) {
+      this.setState({compIsochroneKey: uuid.v4()})
+    }
+  }
+
   // Leaflet bug that causes a map click when dragging a marker fast:
   // https://github.com/Leaflet/Leaflet/issues/4457#issuecomment-351682174
   _avoidClick = false
@@ -75,6 +93,7 @@ export default class AnalysisMap extends React.Component {
 
   render () {
     const p = this.props
+    const s = this.state
     return (
       <Map onClick={this._clickMap}>
         <OpportunityDatasets.components.DotMap />
@@ -92,15 +111,15 @@ export default class AnalysisMap extends React.Component {
         {p.displayedDataIsCurrent && p.isochrone &&
           <GeoJSON
             data={p.isochrone}
-            key={uuid.v4()}
-            style={isochroneStyle(colors.PROJECT_ISOCHRONE_COLOR)}
+            key={s.mainIsochroneKey}
+            style={mainIsochroneStyle}
           />}
 
         {p.displayedDataIsCurrent && p.comparisonIsochrone &&
           <GeoJSON
             data={p.comparisonIsochrone}
-            key={uuid.v4()}
-            style={isochroneStyle(colors.COMPARISON_ISOCHRONE_COLOR)}
+            key={s.compIsochroneKey}
+            style={compIsochroneStyle}
           />}
 
         <LabelLayer />


### PR DESCRIPTION
Displaying isochrones has been eating up resources and this should help keep that down.