### PR TITLE
Fix opportunity dataset name display in a regional analysis

### DIFF
--- a/lib/components/analysis/regional.js
+++ b/lib/components/analysis/regional.js
@@ -22,6 +22,7 @@ export default class RegionalAnalysis extends React.PureComponent {
     const p = this.props
     p.loadRegionalAnalyses(p.regionId)
     p.setActiveRegionalAnalysis({_id: p.analysisId})
+    if (p.opportunityDatasets.length === 0) p.loadOpportunityDatasets()
   }
 
   _deleteAnalysis = () => {

--- a/lib/containers/regional-analysis-results.js
+++ b/lib/containers/regional-analysis-results.js
@@ -15,16 +15,16 @@ import {
 } from '../actions/analysis/regional'
 import RegionalAnalysis from '../components/analysis/regional'
 import * as select from '../selectors'
+import {loadOpportunityDatasets} from '../modules/opportunity-datasets/actions'
 import {activeOpportunityDataset, opportunityDatasets} from '../modules/opportunity-datasets/selectors'
 
 function mapStateToProps (state, ownProps) {
   const regionId = select.currentRegionId(state, ownProps)
   const region = select.currentRegion(state, ownProps)
-  const od = activeOpportunityDataset(state, ownProps)
   return {
     analysis: select.activeRegionalAnalysis(state, ownProps),
-    analysisId: ownProps.params.regionalAnalysisId,
-    regionalAnalyses: state.region.regionalAnalyses,
+    analysisId: get(ownProps, 'params.regionalAnalysisId'),
+    regionalAnalyses: get(state, 'region.regionalAnalyses'),
     regionId,
     comparisonAnalysis: select.comparisonRegionalAnalysis(state, ownProps),
     origin: get(state, 'analysis.regional.origin'),
@@ -35,7 +35,7 @@ function mapStateToProps (state, ownProps) {
     aggregationAreas: get(region, 'aggregationAreas'),
     aggregationAreaUploading: get(state, 'analysis.regional.aggregationAreaUploading'),
     aggregationAreaId: get(state, 'analysis.regional.aggregationAreaId'),
-    aggregationWeightsId: od && od._id,
+    aggregationWeightsId: get(activeOpportunityDataset(state, ownProps), '_id'),
     aggregateAccessibility: select.aggregateAccessibility(state),
     comparisonAggregateAccessibility: select.comparisonAggregateAccessibility(
       state
@@ -50,6 +50,7 @@ function mapDispatchToProps (dispatch: Dispatch, ownProps) {
       push(`/regions/${analysis.regionId}/regional`)
     ]),
     fetch: opts => dispatch(fetch(opts)),
+    loadOpportunityDatasets: () => dispatch(loadOpportunityDatasets()),
     loadRegionalAnalyses: regionId => dispatch(load(regionId)),
     loadRegionalAnalysisGrids: (ids) =>
       dispatch(loadRegionalAnalysisGrids(ids)),


### PR DESCRIPTION
Load opportunity datasets when needed to show the name in a regional analysis instead of just the
ID.

closes #796