### PR TITLE
Add custom modification type

### DIFF
--- a/lib/components/modification/__tests__/__snapshots__/group.js.snap
+++ b/lib/components/modification/__tests__/__snapshots__/group.js.snap
@@ -16,7 +16,7 @@ exports[`Component > Modification > ModificationGroup renders correctly 1`] = `
         className="fa fa-caret-down fa-fw "
       />
        
-      Add trips
+      Add Trip Pattern
     </a>
   </div>
   <div

--- a/lib/components/modification/editor.js
+++ b/lib/components/modification/editor.js
@@ -43,20 +43,21 @@ type Props = {
   updateLocally: (modification: any) => void
 }
 
-const modificationTypeToComponentMap = {
-  'add-trip-pattern': AddTripPattern,
-  'adjust-dwell-time': AdjustDwellTime,
-  'adjust-speed': AdjustSpeed,
-  'convert-to-frequency': ConvertToFrequency,
-  'custom': () => <div />,
-  'remove-stops': RemoveStops,
-  'remove-trips': RemoveTrips,
-  reroute: Reroute
+const getComponentForType = type => {
+  switch (type) {
+    case 'add-trip-pattern': return AddTripPattern
+    case 'adjust-dwell-time': return AdjustDwellTime
+    case 'adjust-speed': return AdjustSpeed
+    case 'convert-to-frequency': return ConvertToFrequency
+    case 'remove-stops': return RemoveStops
+    case 'remove-trips': return RemoveTrips
+    case 'reroute': return Reroute
+  }
 }
 
 const ModificationType = (props) => {
-  const M = modificationTypeToComponentMap[props.type]
-  return <M {...props} />
+  const M = getComponentForType(props.type)
+  return M ? <M {...props} /> : <div />
 }
 
 const omitAttributes = (m) => omit(m, [
@@ -66,7 +67,6 @@ const omitAttributes = (m) => omit(m, [
   'createdBy',
   'nonce',
   'projectId',
-  'type',
   'updatedAt',
   'updatedBy'
 ])

--- a/lib/components/modification/group.js
+++ b/lib/components/modification/group.js
@@ -1,6 +1,6 @@
 // @flow
 import Icon from '@conveyal/woonerf/components/icon'
-import message from '@conveyal/woonerf/message'
+import toStartCase from 'lodash/startCase'
 import React, {PureComponent} from 'react'
 
 import type {Modification} from '../../types'
@@ -50,7 +50,7 @@ export default class ModificationGroup extends PureComponent {
             tabIndex={0}
             title={`${showOrHide} modification group`}
           >
-            <Icon type={iconName} /> {message(`modificationType.${type}`)}
+            <Icon type={iconName} /> {toStartCase(type)}
           </a>
         </div>
         {expanded &&

--- a/lib/components/modification/list.js
+++ b/lib/components/modification/list.js
@@ -88,11 +88,7 @@ export default class ModificationsList extends Component {
   }
 
   _createModification = () => {
-    let {newModificationName, newModificationType} = this.state
-    if (newModificationType === CUSTOM_MODIFICATION) {
-      newModificationType = toKebabCase(newModificationName)
-    }
-
+    const {newModificationName, newModificationType} = this.state
     this.props.createModification({
       name: newModificationName,
       type: newModificationType

--- a/lib/components/modification/list.js
+++ b/lib/components/modification/list.js
@@ -198,9 +198,7 @@ export default class ModificationsList extends Component {
             />
           </Group>
 
-          {MODIFICATION_TYPES.filter(
-            type => filteredModificationsByType[type]
-          ).map(type => (
+          {Object.keys(filteredModificationsByType).map(type => (
             <ModificationGroup
               goToEditModification={this._goToEditModification}
               key={`modification-group-${type}`}

--- a/lib/components/modification/list.js
+++ b/lib/components/modification/list.js
@@ -1,12 +1,13 @@
 // @flow
 import Icon from '@conveyal/woonerf/components/icon'
+import toKebabCase from 'lodash/kebabCase'
 import toStartCase from 'lodash/startCase'
 import React, {Component} from 'react'
 import message from '@conveyal/woonerf/message'
 
 import {Application, Dock, Title} from '../base'
 import {Button} from '../buttons'
-import {MODIFICATION_TYPES} from '../../constants'
+import {CUSTOM_MODIFICATION, MODIFICATION_TYPES} from '../../constants'
 import LabelLayer from '../map/label-layer'
 import {IconLink} from '../link'
 import Modal, {ModalBody, ModalTitle} from '../modal'
@@ -87,7 +88,11 @@ export default class ModificationsList extends Component {
   }
 
   _createModification = () => {
-    const {newModificationName, newModificationType} = this.state
+    let {newModificationName, newModificationType} = this.state
+    if (newModificationType === CUSTOM_MODIFICATION) {
+      newModificationType = toKebabCase(newModificationName)
+    }
+
     this.props.createModification({
       name: newModificationName,
       type: newModificationType

--- a/lib/components/modification/list.js
+++ b/lib/components/modification/list.js
@@ -1,13 +1,12 @@
 // @flow
 import Icon from '@conveyal/woonerf/components/icon'
-import toKebabCase from 'lodash/kebabCase'
 import toStartCase from 'lodash/startCase'
 import React, {Component} from 'react'
 import message from '@conveyal/woonerf/message'
 
 import {Application, Dock, Title} from '../base'
 import {Button} from '../buttons'
-import {CUSTOM_MODIFICATION, MODIFICATION_TYPES} from '../../constants'
+import {MODIFICATION_TYPES} from '../../constants'
 import LabelLayer from '../map/label-layer'
 import {IconLink} from '../link'
 import Modal, {ModalBody, ModalTitle} from '../modal'

--- a/lib/constants/index.js
+++ b/lib/constants/index.js
@@ -24,6 +24,7 @@ export const ADD_TRIP_PATTERN = 'add-trip-pattern'
 export const ADJUST_DWELL_TIME = 'adjust-dwell-time'
 export const ADJUST_SPEED = 'adjust-speed'
 export const CONVERT_TO_FREQUENCY = 'convert-to-frequency'
+export const CUSTOM_MODIFICATION = 'custom'
 export const REMOVE_STOPS = 'remove-stops'
 export const REMOVE_TRIPS = 'remove-trips'
 export const REROUTE = 'reroute'
@@ -34,7 +35,8 @@ export const MODIFICATION_TYPES = [
   CONVERT_TO_FREQUENCY,
   REMOVE_STOPS,
   REMOVE_TRIPS,
-  REROUTE
+  REROUTE,
+  CUSTOM_MODIFICATION
 ]
 
 /**

--- a/lib/utils/modification.js
+++ b/lib/utils/modification.js
@@ -6,7 +6,6 @@ import {
   ADJUST_DWELL_TIME,
   ADJUST_SPEED,
   CONVERT_TO_FREQUENCY,
-  CUSTOM_MODIFICATION,
   DEFAULT_ADD_STOPS_DWELL,
   DEFAULT_ADJUST_DWELL_TIME_VALUE,
   DEFAULT_ADJUST_SPEED_SCALE,
@@ -82,8 +81,6 @@ export function create ({
         feed: feedId,
         routes: null
       }
-    case CUSTOM_MODIFICATION:
-      return base
     case REMOVE_STOPS:
       return {
         ...base,
@@ -100,7 +97,7 @@ export function create ({
         trips: null
       }
     default:
-      throw new Error(`Modification type "${type}" does not exist.`)
+      return base
   }
 }
 

--- a/lib/utils/modification.js
+++ b/lib/utils/modification.js
@@ -6,6 +6,7 @@ import {
   ADJUST_DWELL_TIME,
   ADJUST_SPEED,
   CONVERT_TO_FREQUENCY,
+  CUSTOM_MODIFICATION,
   DEFAULT_ADD_STOPS_DWELL,
   DEFAULT_ADJUST_DWELL_TIME_VALUE,
   DEFAULT_ADJUST_SPEED_SCALE,
@@ -80,6 +81,11 @@ export function create ({
         entries: [],
         feed: feedId,
         routes: null
+      }
+    case CUSTOM_MODIFICATION:
+      return {
+        ...base,
+        r5type: ''
       }
     case REMOVE_STOPS:
       return {

--- a/lib/utils/modification.js
+++ b/lib/utils/modification.js
@@ -6,6 +6,7 @@ import {
   ADJUST_DWELL_TIME,
   ADJUST_SPEED,
   CONVERT_TO_FREQUENCY,
+  CUSTOM_MODIFICATION,
   DEFAULT_ADD_STOPS_DWELL,
   DEFAULT_ADJUST_DWELL_TIME_VALUE,
   DEFAULT_ADJUST_SPEED_SCALE,
@@ -81,6 +82,8 @@ export function create ({
         feed: feedId,
         routes: null
       }
+    case CUSTOM_MODIFICATION:
+      return base
     case REMOVE_STOPS:
       return {
         ...base,


### PR DESCRIPTION
Will just have a freeform text field and variant editor. Custom types are created with an empty `r5type` parameter that can be used on the R5 side to convert it into corresponding types. This should be useful for testing modifications by updating r5 without needing to update the UI or backend.

TODO:

- [x] Show new modification types in the type list
- [x] Have a catch-all for any new modification types

re #845 