### PR TITLE
Add a transit mode selector for add trip pattern modifications

### DIFF
--- a/lib/components/flex-container.js
+++ b/lib/components/flex-container.js
@@ -1,0 +1,21 @@
+import React from 'react'
+
+export default function FlexContainer(p) {
+  return (
+    <div className='flex-container'>
+      {p.children}
+
+      <style jsx>{`
+        .flex-container {
+          position: fixed;
+          left: 0;
+          right: 0;
+          top: 0;
+          bottom: 0;
+          display: flex;
+          flex-wrap: nowrap;
+        }
+      `}</style>
+    </div>
+  )
+}

--- a/lib/components/modification/add-trip-pattern.js
+++ b/lib/components/modification/add-trip-pattern.js
@@ -1,5 +1,7 @@
 import React from 'react'
 
+import TransitModeSelector from '../transit-mode-selector'
+
 import EditAlignment from './edit-alignment'
 import Timetables from './timetables'
 
@@ -9,6 +11,11 @@ import Timetables from './timetables'
 export default function AddTripPattern(p) {
   return (
     <>
+      <TransitModeSelector
+        onChange={transitMode => p.update({transitMode})}
+        value={p.modification.transitMode}
+      />
+
       <EditAlignment
         allStops={p.allStops}
         disabled={false}

--- a/lib/components/transit-mode-selector.js
+++ b/lib/components/transit-mode-selector.js
@@ -1,0 +1,32 @@
+import startCase from 'lodash/startCase'
+import React from 'react'
+
+import {ALL_TRANSIT_MODES} from '../constants'
+
+import {Select} from './input'
+
+const toStartCase = o => startCase(o.toLowerCase())
+
+/**
+ * Only show an empty option if no mode has been selected. Do not allow de-selection.
+ */
+export default function TransitModeSelector(p) {
+  const value = parseInt(p.value)
+  return (
+    <Select
+      label='Transit Mode'
+      onChange={e => {
+        const mode = parseInt(e.target.value)
+        if (mode >= 0) p.onChange(mode)
+      }}
+      value={p.value}
+    >
+      {(isNaN(value) || value === -1) && <option value={-1} />}
+      {ALL_TRANSIT_MODES.map((m, i) => (
+        <option key={m} value={i}>
+          {toStartCase(m)}
+        </option>
+      ))}
+    </Select>
+  )
+}

--- a/lib/constants/index.js
+++ b/lib/constants/index.js
@@ -99,6 +99,28 @@ export const MODIFICATION_TYPES = [
 ]
 
 /**
+ * Transit Modes
+ */
+export const BUS = 'BUS'
+export const RAIL = 'RAIL'
+export const TRAM = 'TRAM'
+export const SUBWAY = 'SUBWAY'
+export const FERRY = 'FERRY'
+export const CABLE_CAR = 'CABLE_CAR'
+export const GONDOLA = 'GONDOLA'
+export const FUNICULAR = 'FUNICULAR'
+export const ALL_TRANSIT_MODES = [
+  TRAM,
+  SUBWAY,
+  RAIL,
+  BUS,
+  FERRY,
+  CABLE_CAR,
+  GONDOLA,
+  FUNICULAR
+]
+
+/**
  * Fetch types
  */
 export const FETCH_TRAVEL_TIME_SURFACE = 'FETCH_TRAVEL_TIME_SURFACE'

--- a/lib/constants/index.js
+++ b/lib/constants/index.js
@@ -109,6 +109,8 @@ export const FERRY = 'FERRY'
 export const CABLE_CAR = 'CABLE_CAR'
 export const GONDOLA = 'GONDOLA'
 export const FUNICULAR = 'FUNICULAR'
+
+// The mode index corresponds to the GTFS route_type integer
 export const ALL_TRANSIT_MODES = [
   TRAM,
   SUBWAY,

--- a/lib/utils/modification.js
+++ b/lib/utils/modification.js
@@ -38,7 +38,8 @@ export function create({feedId, name, projectId, type, variants}) {
         ...base,
         bidirectional: true,
         segments: [],
-        timetables: []
+        timetables: [],
+        transitMode: 3 // BUS, same as the R5 default
       }
     case ADJUST_DWELL_TIME:
       return {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
     "@turf/line-slice": "^5.1.5",
     "@turf/nearest-point-on-line": "^6.0.2",
     "@turf/point-to-line-distance": "^6.0.0",
+    "@types/lodash": "^4.14.136",
+    "@types/react": "^16.8.23",
     "auth0-js": "^9.11.1",
     "babel-plugin-lodash": "^3.3.4",
     "browsochrones": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1757,6 +1757,11 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
+"@types/lodash@^4.14.136":
+  version "4.14.136"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.136.tgz#413e85089046b865d960c9ff1d400e04c31ab60f"
+  integrity sha512-0GJhzBdvsW2RUccNHOBkabI8HZVdOXmXbXhuKlDEd5Vv12P7oAVGfomGp3Ne21o5D/qu1WmthlNKFaoZJJeErA==
+
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -1771,6 +1776,19 @@
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
   integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
+
+"@types/prop-types@*":
+  version "15.7.1"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.1.tgz#f1a11e7babb0c3cad68100be381d1e064c68f1f6"
+  integrity sha512-CFzn9idOEpHrgdw8JsoTkaDDyRWk1jrzIV8djzcgpq0y9tG4B4lFT+Nxh52DVpDXV+n4+NPNv7M1Dj5uMp6XFg==
+
+"@types/react@^16.8.23":
+  version "16.8.23"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.23.tgz#ec6be3ceed6353a20948169b6cb4c97b65b97ad2"
+  integrity sha512-abkEOIeljniUN9qB5onp++g0EY38h7atnDHxwKUFz1r3VH1+yG1OKi2sNPTyObL40goBmfKFpdii2lEzwLX1cA==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
 
 "@types/retry@^0.12.0":
   version "0.12.0"
@@ -3679,6 +3697,11 @@ cssstyle@^1.0.0:
   integrity sha512-43wY3kl1CVQSvL7wUY1qXkxVGkStjpkDmVjiIKX8R97uhajy8Bybay78uOtqvh7Q5GK75dNPfW0geWjE6qQQow==
   dependencies:
     cssom "0.3.x"
+
+csstype@^2.2.0:
+  version "2.6.6"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.6.tgz#c34f8226a94bbb10c32cc0d714afdf942291fc41"
+  integrity sha512-RpFbQGUE74iyPgvr46U9t1xoQBM8T4BL8SxrN66Le2xYAPSaDJJKeztV3awugusb3g3G9iL8StmkBBXhcbbXhg==
 
 csstype@^2.5.7:
   version "2.6.5"


### PR DESCRIPTION
Defaults new Add Trip Modifications to BUS (same as the R5 default). Old modifications will still not have anything set and get the r5 default. Backend change adding a `transitMode` parameter to the AddTripPattern model is necessary for the changes to work (https://github.com/conveyal/analysis-backend/pull/235).

close #806