### PR TITLE
Re-enable bike egress mode selection in the analysis ui

### DIFF
--- a/lib/components/analysis/__tests__/__snapshots__/advanced-settings.js.snap
+++ b/lib/components/analysis/__tests__/__snapshots__/advanced-settings.js.snap
@@ -606,20 +606,19 @@ exports[`Components > Analysis > Advanced Settings should render correctly with 
                         Egress Modes
                       </label>
                       <br />
-                      <Group
-                        disabled={false}
-                      >
+                      <Group>
                         <div
                           className="btn-group"
-                          disabled={false}
                         >
                           <Button
                             active={true}
+                            disabled={false}
                             onClick={[Function]}
                             title="Walk"
                           >
                             <a
                               className="btn btn-default active"
+                              disabled={false}
                               href="#"
                               onClick={[Function]}
                               tabIndex={0}
@@ -680,17 +679,17 @@ exports[`Components > Analysis > Advanced Settings should render correctly with 
                           </Button>
                           <Button
                             active={false}
-                            disabled={true}
+                            disabled={false}
                             onClick={[Function]}
-                            title="CURRENTLY DISABLED: Bike"
+                            title="Bike"
                           >
                             <a
                               className="btn btn-default"
-                              disabled={true}
+                              disabled={false}
                               href="#"
                               onClick={[Function]}
                               tabIndex={0}
-                              title="CURRENTLY DISABLED: Bike"
+                              title="Bike"
                             >
                               <Icon
                                 icon={

--- a/lib/components/analysis/advanced-settings.js
+++ b/lib/components/analysis/advanced-settings.js
@@ -177,7 +177,7 @@ export default class AdvancedSettings extends Component {
           <div className='row'>
             <div className='col-xs-4'>
               <EgressModeSelector
-                disabled={p.disabled}
+                disabled={p.disabled || p.profileRequest.transitModes === ''}
                 egressModes={
                   p.profileRequest.transitModes !== ''
                     ? p.profileRequest.egressModes

--- a/lib/components/analysis/egress-mode-selector.js
+++ b/lib/components/analysis/egress-mode-selector.js
@@ -19,9 +19,10 @@ export default function EgressModeSelector(p) {
   return (
     <Group label='Egress Modes'>
       <br />
-      <ButtonGroup disabled={p.disabled}>
+      <ButtonGroup>
         <Button
           active={p.egressModes === WALK}
+          disabled={p.disabled}
           onClick={() => selectEgressMode(WALK)}
           title={message('analysis.modes.walk')}
         >
@@ -29,9 +30,9 @@ export default function EgressModeSelector(p) {
         </Button>
         <Button
           active={p.egressModes === BICYCLE}
-          disabled
+          disabled={p.disabled}
           onClick={() => selectEgressMode(BICYCLE)}
-          title={`CURRENTLY DISABLED: ${message('analysis.modes.bicycle')}`}
+          title={message('analysis.modes.bicycle')}
         >
           <Icon icon={faBicycle} />
         </Button>


### PR DESCRIPTION
Disabled if no transit modes are selected

fix #850