### PR TITLE
fix(region): Fix region bounds editing

### DIFF
--- a/lib/components/edit-region.js
+++ b/lib/components/edit-region.js
@@ -39,7 +39,7 @@ export function EditRegion(p) {
   }
 
   // Save region action
-  const _save = React.useCallback(() => {
+  function _save() {
     setSaving(true)
 
     // Save will redirect back to main region page when complete
@@ -52,11 +52,13 @@ export function EditRegion(p) {
       const {as, href} = routeTo('regionSettings', {regionId: region._id})
       router.push(href, as)
     })
-  }, [dispatch, region, router])
+  }
 
   // Helper function to set a specific direction of the bounds
-  const setBoundsFor = direction => e =>
-    setRegion(r => ({...r, bounds: {...r.bounds, [direction]: e.target.value}}))
+  function setBoundsFor(direction, e) {
+    const newValue = e.target.value
+    setRegion(r => ({...r, bounds: {...r.bounds, [direction]: newValue}}))
+  }
 
   const spin = saving || !region.statusCode || region.statusCode !== 'DONE'
   const buttonText = spin ? (
@@ -68,15 +70,15 @@ export function EditRegion(p) {
     message('region.editAction')
   )
 
-  const onChangeName = React.useCallback(e => {
+  function onChangeName(e) {
     const name = e.target.value
     setRegion(r => ({...r, name}))
-  }, [])
+  }
 
-  const onChangeDescription = React.useCallback(e => {
+  function onChangeDescription(e) {
     const description = e.target.value
     setRegion(r => ({...r, description}))
-  }, [])
+  }
 
   // Render into map
   const {setMapChildren} = p
@@ -122,7 +124,7 @@ export function EditRegion(p) {
           key={`bound-${direction}`}
           label={`${direction} bound`}
           name={`${direction} bound`}
-          onChange={setBoundsFor(direction.toLowerCase())}
+          onChange={e => setBoundsFor(direction.toLowerCase(), e)}
           value={region.bounds[direction.toLowerCase()]}
         />
       ))}


### PR DESCRIPTION
Event target was not being persisted in the setState closure created by the useState hook for the
region. This change copies that new value from the target before "closing over" it.

fix #909