### PR TITLE
Fix bug preventing users from selecting phasing options

### DIFF
--- a/lib/components/modification/__tests__/__snapshots__/timetable.js.snap
+++ b/lib/components/modification/__tests__/__snapshots__/timetable.js.snap
@@ -832,6 +832,76 @@ exports[`Component > Timetable renders correctly 2`] = `
                 timetableHeadway={900}
                 update={[MockFunction]}
               >
+                <h4
+                  style={
+                    Object {
+                      "display": "flex",
+                      "justifyContent": "space-between",
+                    }
+                  }
+                >
+                  <span>
+                    Phasing 
+                  </span>
+                  <a
+                    href="http://docs.analysis.conveyal.com/en/latest/edit-scenario/phasing.html"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                    title="Learn more about phasing"
+                  >
+                    <Icon
+                      icon={
+                        Object {
+                          "icon": Array [],
+                          "iconName": "info-circle",
+                          "prefix": "fas",
+                        }
+                      }
+                    >
+                      <FontAwesomeIcon
+                        border={false}
+                        className=""
+                        fixedWidth={true}
+                        flip={null}
+                        icon={
+                          Object {
+                            "icon": Array [],
+                            "iconName": "info-circle",
+                            "prefix": "fas",
+                          }
+                        }
+                        inverse={false}
+                        listItem={false}
+                        mask={null}
+                        pull={null}
+                        pulse={false}
+                        rotation={null}
+                        size={null}
+                        spin={false}
+                        symbol={false}
+                        title=""
+                        transform={null}
+                      >
+                        <svg
+                          aria-hidden="true"
+                          className="svg-inline--fa fa-info-circle fa-w-NaN fa-fw "
+                          data-icon="info-circle"
+                          data-prefix="fas"
+                          focusable="false"
+                          role="img"
+                          style={Object {}}
+                          viewBox="0 0 undefined undefined"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            fill="currentColor"
+                            style={Object {}}
+                          />
+                        </svg>
+                      </FontAwesomeIcon>
+                    </Icon>
+                  </a>
+                </h4>
                 <Group
                   label="Phase at stop"
                 >
@@ -846,7 +916,7 @@ exports[`Component > Timetable renders correctly 2`] = `
                     </label>
                     <S
                       getOptionLabel={[Function]}
-                      getOptionValue={[Function]}
+                      isClearable={true}
                       isDisabled={false}
                       name="Phase at stop"
                       onChange={[Function]}
@@ -855,7 +925,7 @@ exports[`Component > Timetable renders correctly 2`] = `
                     >
                       <ReactSelect
                         getOptionLabel={[Function]}
-                        getOptionValue={[Function]}
+                        isClearable={true}
                         isDisabled={false}
                         name="Phase at stop"
                         onChange={[Function]}

--- a/lib/components/modification/__tests__/__snapshots__/timetable.js.snap
+++ b/lib/components/modification/__tests__/__snapshots__/timetable.js.snap
@@ -916,6 +916,7 @@ exports[`Component > Timetable renders correctly 2`] = `
                     </label>
                     <S
                       getOptionLabel={[Function]}
+                      getOptionValue={[Function]}
                       isClearable={true}
                       isDisabled={false}
                       name="Phase at stop"
@@ -925,6 +926,7 @@ exports[`Component > Timetable renders correctly 2`] = `
                     >
                       <ReactSelect
                         getOptionLabel={[Function]}
+                        getOptionValue={[Function]}
                         isClearable={true}
                         isDisabled={false}
                         name="Phase at stop"

--- a/lib/components/modification/phase.js
+++ b/lib/components/modification/phase.js
@@ -1,104 +1,79 @@
+import {faInfoCircle} from '@fortawesome/free-solid-svg-icons'
 import get from 'lodash/get'
-import React, {PureComponent} from 'react'
+import React from 'react'
 
 import message from 'lib/message'
 import {toString as timetableToString} from 'lib/utils/timetable'
 
+import Icon from '../icon'
 import Select from '../select'
 import {Group as FormGroup} from '../input'
 import MinutesSeconds from '../minutes-seconds'
 
-export default class Phase extends PureComponent {
-  state = {}
+export default function Phase(p) {
+  const {phaseFromTimetable, update} = p
+  const selectedTimetableId = (phaseFromTimetable || '').split(':')[1]
+  const selectedTimetable = p.availableTimetables.find(
+    tt => tt._id === selectedTimetableId
+  )
 
-  static getDerivedStateFromProps(props) {
-    return {selectedTimetable: getSelectedTimetable(props)}
-  }
-
-  componentDidUpdate(prevProps) {
-    if (
-      this.props.phaseFromTimetable !== prevProps.phaseFromTimetable &&
-      !this.state.selectedTimetable
-    ) {
-      this._setPhaseFromTimetable(null) // timetable does not exist
-    }
-  }
-
-  componentDidMount() {
-    if (this.props.phaseFromTimetable && !this.state.selectedTimetable) {
-      this._setPhaseFromTimetable(null)
-    }
-  }
-
-  _setPhaseAtStop = stop => {
-    this.props.update({phaseAtStop: get(stop, 'stop_id')})
-  }
-
-  _setPhaseFromTimetable = timetable => {
-    this.props.update({
-      phaseFromTimetable: timetable && timetable.value,
-      phaseFromStop: null
+  function _setPhaseFromTimetable(tt) {
+    update({
+      phaseFromStop: null,
+      phaseFromTimetable: tt ? `${tt.modificationId}:${tt._id}` : null
     })
   }
 
-  _setPhaseFromStop = stop => {
-    this.props.update({phaseFromStop: stop && stop.value})
-  }
-
-  _setPhaseSeconds = phaseSeconds => {
-    this.props.update({phaseSeconds})
-  }
-
-  render() {
-    const {
-      availableTimetables,
-      disabled,
-      phaseAtStop,
-      phaseFromStop,
-      phaseFromTimetable,
-      phaseSeconds,
-      modificationStops,
-      selectedPhaseFromTimetableStops,
-      timetableHeadway
-    } = this.props
-    const {selectedTimetable} = this.state
-    return (
-      <>
-        <FormGroup label={message('phasing.atStop')}>
-          <Select
-            isDisabled={disabled}
-            name={message('phasing.atStop')}
-            getOptionLabel={s => s.stop_name}
-            getOptionValue={s => s.stop_id}
-            onChange={this._setPhaseAtStop}
-            options={modificationStops}
-            placeholder={message('phasing.atStop')}
-            value={modificationStops.find(s => s.stop_id === phaseAtStop)}
-          />
-        </FormGroup>
-        {disabled && (
-          <div className='alert alert-info' role='alert'>
-            {message('phasing.disabled')}
-          </div>
-        )}
-        {phaseAtStop && (
-          <>
-            <FormGroup label={message('phasing.fromTimetable')}>
-              <Select
-                name={message('phasing.fromTimetable')}
-                getOptionLabel={t =>
-                  `${t.modificationName}: ${timetableToString(t)}`
-                }
-                getOptionValue={t => `${t.modificationId}:${t._id}`}
-                onChange={this._setPhaseFromTimetable}
-                options={availableTimetables}
-                placeholder={message('phasing.fromTimetable')}
-                value={selectedTimetable}
-              />
-            </FormGroup>
-            {phaseFromTimetable && selectedTimetable && (
+  return (
+    <>
+      <h4 style={{display: 'flex', justifyContent: 'space-between'}}>
+        <span>Phasing </span>
+        <a
+          href='http://docs.analysis.conveyal.com/en/latest/edit-scenario/phasing.html'
+          rel='noopener noreferrer'
+          target='_blank'
+          title='Learn more about phasing'
+        >
+          <Icon icon={faInfoCircle} />
+        </a>
+      </h4>
+      <FormGroup label={message('phasing.atStop')}>
+        <Select
+          isClearable
+          isDisabled={p.disabled}
+          name={message('phasing.atStop')}
+          getOptionLabel={s => s.stop_name}
+          onChange={s => update({phaseAtStop: get(s, 'stop_id')})}
+          options={p.modificationStops}
+          placeholder={message('phasing.atStop')}
+          value={p.modificationStops.find(s => s.stop_id === p.phaseAtStop)}
+        />
+      </FormGroup>
+      {p.disabled && (
+        <div className='alert alert-info' role='alert'>
+          {message('phasing.disabled')}
+        </div>
+      )}
+      {p.phaseAtStop && (
+        <>
+          <FormGroup label={message('phasing.fromTimetable')}>
+            <Select
+              isClearable
+              isDisabled={p.disabled}
+              name={message('phasing.fromTimetable')}
+              getOptionLabel={t =>
+                `${t.modificationName}: ${timetableToString(t)}`
+              }
+              onChange={_setPhaseFromTimetable}
+              options={p.availableTimetables}
+              placeholder={message('phasing.fromTimetable')}
+              value={selectedTimetable}
+            />
+          </FormGroup>
+          {p.phaseFromTimetable &&
+            (selectedTimetable ? (
               <>
-                {selectedTimetable.headwaySecs !== timetableHeadway && (
+                {selectedTimetable.headwaySecs !== p.timetableHeadway && (
                   <div className='alert alert-danger' role='alert'>
                     {message('phasing.headwayMismatchWarning', {
                       selectedTimetableHeadway:
@@ -106,18 +81,16 @@ export default class Phase extends PureComponent {
                     })}
                   </div>
                 )}
-                {selectedPhaseFromTimetableStops &&
-                selectedPhaseFromTimetableStops.length > 0 ? (
+                {get(p.selectedPhaseFromTimetableStops, 'length') > 0 ? (
                   <FormGroup label={message('phasing.fromStop')}>
                     <Select
                       getOptionLabel={s => s.stop_name}
-                      getOptionValue={s => s.stop_id}
                       name={message('phasing.fromStop')}
-                      onChange={this._setPhaseFromStop}
-                      options={selectedPhaseFromTimetableStops}
+                      onChange={s => update({phaseFromStop: get(s, 'stop_id')})}
+                      options={p.selectedPhaseFromTimetableStops}
                       placeholder={message('phasing.fromStop')}
-                      value={selectedPhaseFromTimetableStops.find(
-                        s => s.stop_id === phaseFromStop
+                      value={p.selectedPhaseFromTimetableStops.find(
+                        s => s.stop_id === p.phaseFromStop
                       )}
                     />
                   </FormGroup>
@@ -126,26 +99,22 @@ export default class Phase extends PureComponent {
                     {message('phasing.noAvailableStopsWarning')}
                   </div>
                 )}
-                {phaseFromStop && (
+                {p.phaseFromStop && (
                   <MinutesSeconds
                     label={message('phasing.minutes')}
-                    onChange={this._setPhaseSeconds}
-                    seconds={phaseSeconds}
+                    onChange={phaseSeconds => update({phaseSeconds})}
+                    seconds={p.phaseSeconds}
                   />
                 )}
               </>
-            )}
-          </>
-        )}
-      </>
-    )
-  }
-}
-
-function getSelectedTimetable(opts) {
-  return opts.availableTimetables.find(
-    tt =>
-      opts.phaseFromTimetable &&
-      tt._id === opts.phaseFromTimetable.split(':')[1]
+            ) : (
+              <div className='alert alert-danger'>
+                <strong>Selected timetable no longer exists.</strong> Please
+                clear the timetable or there will be errors during analysis.
+              </div>
+            ))}
+        </>
+      )}
+    </>
   )
 }

--- a/lib/components/modification/phase.js
+++ b/lib/components/modification/phase.js
@@ -113,7 +113,8 @@ export default function Phase(p) {
             ) : (
               <div className='alert alert-danger'>
                 <strong>Selected timetable no longer exists.</strong> Please
-                clear the timetable or there will be errors during analysis.
+                clear or change your phasing options or there will be errors
+                during analysis.
               </div>
             ))}
         </>

--- a/lib/components/modification/phase.js
+++ b/lib/components/modification/phase.js
@@ -43,6 +43,7 @@ export default function Phase(p) {
           isDisabled={p.disabled}
           name={message('phasing.atStop')}
           getOptionLabel={s => s.stop_name}
+          getOptionValue={s => s.stop_id}
           onChange={s => update({phaseAtStop: get(s, 'stop_id')})}
           options={p.modificationStops}
           placeholder={message('phasing.atStop')}
@@ -64,6 +65,7 @@ export default function Phase(p) {
               getOptionLabel={t =>
                 `${t.modificationName}: ${timetableToString(t)}`
               }
+              getOptionValue={t => `${t.modificationId}:${t._id}`}
               onChange={_setPhaseFromTimetable}
               options={p.availableTimetables}
               placeholder={message('phasing.fromTimetable')}
@@ -85,6 +87,7 @@ export default function Phase(p) {
                   <FormGroup label={message('phasing.fromStop')}>
                     <Select
                       getOptionLabel={s => s.stop_name}
+                      getOptionValue={s => s.stop_id}
                       name={message('phasing.fromStop')}
                       onChange={s => update({phaseFromStop: get(s, 'stop_id')})}
                       options={p.selectedPhaseFromTimetableStops}


### PR DESCRIPTION
## Description

The upgrade to the latest version of react-select required new props for capturing the selected value and for setting if the component is clearable. The Phasing select's were not updated correctly during the process. This PR:

1. Makes the Phasing Select boxes clearable
2. Fixes the passed values to be the correct ID's when selected.
3. Disables the auto-clearing of non-existing Timetables and instead shows a warning.
4. Refactors the code to be a bit simpler and use hooks.

fix #912 

## How to test
1. Create an Add Trips modification with two timetables.
2. Phase one timetable to the other timetable and vise-versa.
3. Delete one timetable and ensure that the warning message is now shown for the remaining timetable.
