### PR TITLE
Fix r5 version warning

### DIFF
--- a/lib/components/analysis/__tests__/__snapshots__/profile-request-editor.js.snap
+++ b/lib/components/analysis/__tests__/__snapshots__/profile-request-editor.js.snap
@@ -70,7 +70,7 @@ exports[`Components > Analysis > Profile Request Editor should render correctly 
     <div
       className="col-xs-12"
     >
-      <Connect(SelectR5Version)
+      <SelectR5Version
         disabled={false}
       />
     </div>

--- a/lib/containers/__tests__/__snapshots__/single-point-analysis.js.snap
+++ b/lib/containers/__tests__/__snapshots__/single-point-analysis.js.snap
@@ -2470,66 +2470,54 @@ exports[`constainers/single-point-analysis 1`] = `
             <div
               className="col-xs-12"
             >
-              <Connect(SelectR5Version)
+              <SelectR5Version
                 disabled={false}
               >
-                <SelectR5Version
-                  currentVersion="v4.7.0"
-                  disabled={false}
-                  setCurrentR5Version={[Function]}
-                  usedVersions={Array []}
+                <Group
+                  label="Routing engine"
                 >
-                  <Group
-                    label="Routing engine"
+                  <div
+                    className="form-group"
                   >
-                    <div
-                      className="form-group"
+                    <label
+                      className="control-label"
+                      htmlFor="routing-engine-input-16"
                     >
-                      <label
-                        className="control-label"
-                        htmlFor="routing-engine-input-14"
-                      >
-                        Routing engine
-                      </label>
-                      <div
-                        className="alert alert-warning"
-                      >
-                        WARNING! You have completed regional analyses with a different routing engine. Using different routing engines may change results.
-                      </div>
-                      <Creatable
-                        formatCreateLabel={[Function]}
-                        isDisabled={false}
-                        isValidNewOption={[Function]}
-                        onChange={[Function]}
-                        options={
-                          Array [
-                            Object {
-                              "label": "v4.7.0 (recommended)",
-                              "value": "v4.7.0",
-                            },
-                          ]
-                        }
-                        styles={
-                          Object {
-                            "control": [Function],
-                            "option": [Function],
-                          }
-                        }
-                        value={
+                      Routing engine
+                    </label>
+                    <Creatable
+                      formatCreateLabel={[Function]}
+                      isDisabled={false}
+                      isValidNewOption={[Function]}
+                      onChange={[Function]}
+                      options={
+                        Array [
                           Object {
                             "label": "v4.7.0 (recommended)",
                             "value": "v4.7.0",
-                          }
+                          },
+                        ]
+                      }
+                      styles={
+                        Object {
+                          "control": [Function],
+                          "option": [Function],
                         }
-                      >
-                        <div
-                          className="ReactSelect/Creatable"
-                        />
-                      </Creatable>
-                    </div>
-                  </Group>
-                </SelectR5Version>
-              </Connect(SelectR5Version)>
+                      }
+                      value={
+                        Object {
+                          "label": "v4.7.0 (recommended)",
+                          "value": "v4.7.0",
+                        }
+                      }
+                    >
+                      <div
+                        className="ReactSelect/Creatable"
+                      />
+                    </Creatable>
+                  </div>
+                </Group>
+              </SelectR5Version>
             </div>
           </div>
         </ProfileRequestEditor>

--- a/lib/modules/r5-version/components/__tests__/__snapshots__/selector.js.snap
+++ b/lib/modules/r5-version/components/__tests__/__snapshots__/selector.js.snap
@@ -13,61 +13,50 @@ exports[`R5 Version > Components > Selector should render 1`] = `
     }
   }
 >
-  <Connect(SelectR5Version)>
-    <SelectR5Version
-      currentVersion="v4.7.0"
-      setCurrentR5Version={[Function]}
-      usedVersions={Array []}
+  <SelectR5Version>
+    <Group
+      label="Routing engine"
     >
-      <Group
-        label="Routing engine"
+      <div
+        className="form-group"
       >
-        <div
-          className="form-group"
+        <label
+          className="control-label"
+          htmlFor="routing-engine-input-1"
         >
-          <label
-            className="control-label"
-            htmlFor="routing-engine-input-0"
-          >
-            Routing engine
-          </label>
-          <div
-            className="alert alert-warning"
-          >
-            WARNING! You have completed regional analyses with a different routing engine. Using different routing engines may change results.
-          </div>
-          <Creatable
-            formatCreateLabel={[Function]}
-            isValidNewOption={[Function]}
-            onChange={[Function]}
-            options={
-              Array [
-                Object {
-                  "label": "v4.7.0 (recommended)",
-                  "value": "v4.7.0",
-                },
-              ]
-            }
-            styles={
-              Object {
-                "control": [Function],
-                "option": [Function],
-              }
-            }
-            value={
+          Routing engine
+        </label>
+        <Creatable
+          formatCreateLabel={[Function]}
+          isValidNewOption={[Function]}
+          onChange={[Function]}
+          options={
+            Array [
               Object {
                 "label": "v4.7.0 (recommended)",
                 "value": "v4.7.0",
-              }
+              },
+            ]
+          }
+          styles={
+            Object {
+              "control": [Function],
+              "option": [Function],
             }
-          >
-            <div
-              className="ReactSelect/Creatable"
-            />
-          </Creatable>
-        </div>
-      </Group>
-    </SelectR5Version>
-  </Connect(SelectR5Version)>
+          }
+          value={
+            Object {
+              "label": "v4.7.0 (recommended)",
+              "value": "v4.7.0",
+            }
+          }
+        >
+          <div
+            className="ReactSelect/Creatable"
+          />
+        </Creatable>
+      </div>
+    </Group>
+  </SelectR5Version>
 </Provider>
 `;

--- a/lib/modules/r5-version/components/selector.js
+++ b/lib/modules/r5-version/components/selector.js
@@ -1,8 +1,7 @@
 import get from 'lodash/get'
 import React from 'react'
-import {connect} from 'react-redux'
+import {useDispatch, useSelector} from 'react-redux'
 import Creatable from 'react-select/creatable'
-import {createStructuredSelector} from 'reselect'
 
 import {Group} from 'lib/components/input'
 import {selectStyles} from 'lib/components/select'
@@ -37,7 +36,20 @@ const lineThrough = text => (
 /**
  * Select an R5 version, based on what is available in S3
  */
-export function SelectR5Version(props) {
+export default function SelectR5Version(props) {
+  const currentVersion = useSelector(select.currentVersion)
+  const dispatch = useDispatch()
+  const usedVersions = useSelector(select.usedVersions)
+
+  const currentVersionNumber = versionToNumber(currentVersion)
+  const lastUsedVersion = get(usedVersions, '[0].version')
+  const options = [
+    {
+      value: RECOMMENDED_R5_VERSION,
+      label: `${RECOMMENDED_R5_VERSION} (recommended)`
+    }
+  ]
+
   function _selectVersion(result) {
     const version = get(result, 'value', result)
     if (versionToNumber(version) < MIN_VERSION) {
@@ -48,29 +60,20 @@ export function SelectR5Version(props) {
         })
       )
     }
-    props.setCurrentR5Version(version)
+    dispatch(setCurrentR5Version(version))
   }
 
-  const options = [
-    {
-      value: RECOMMENDED_R5_VERSION,
-      label: `${RECOMMENDED_R5_VERSION} (recommended)`
-    }
-  ]
-
-  const currentVersionNumber = versionToNumber(props.currentVersion)
-
-  if (props.currentVersion !== RECOMMENDED_R5_VERSION) {
+  if (currentVersion !== RECOMMENDED_R5_VERSION) {
     options.push({
-      value: props.currentVersion,
+      value: currentVersion,
       label:
         currentVersionNumber < MIN_VERSION
-          ? lineThrough(props.currentVersion)
-          : props.currentVersion
+          ? lineThrough(currentVersion)
+          : currentVersion
     })
   }
 
-  props.usedVersions.forEach(uv => {
+  usedVersions.forEach(uv => {
     if (
       uv.version === RECOMMENDED_R5_VERSION ||
       versionToNumber(uv.version) < MIN_VERSION
@@ -91,7 +94,7 @@ export function SelectR5Version(props) {
           </div>
         )}
 
-        {get(props.usedVersions, '[0].version') !== props.currentVersion && (
+        {lastUsedVersion && lastUsedVersion !== currentVersion && (
           <div className='alert alert-warning'>
             {message('r5Version.analysisVersionDifferent')}
           </div>
@@ -104,16 +107,9 @@ export function SelectR5Version(props) {
           onChange={_selectVersion}
           options={options}
           styles={selectStyles}
-          value={options.find(v => v.value === props.currentVersion)}
+          value={options.find(v => v.value === currentVersion)}
         />
       </Group>
     </>
   )
 }
-
-export default connect(
-  createStructuredSelector(select),
-  {
-    setCurrentR5Version
-  }
-)(SelectR5Version)

--- a/lib/modules/r5-version/constants.js
+++ b/lib/modules/r5-version/constants.js
@@ -1,5 +1,3 @@
-//
-
 // Bucket where R5 JARs are to be found
 export const R5_BUCKET = 'https://r5-builds.s3.amazonaws.com'
 

--- a/lib/modules/r5-version/selectors.js
+++ b/lib/modules/r5-version/selectors.js
@@ -1,4 +1,3 @@
-//
 import flow from 'lodash/flow'
 
 import {initialState} from './reducer'


### PR DESCRIPTION
## Description

When there were no previously used versions of r5 we would display an unnecessary warning saying there was a mismatch. This PR fixes that.

Fixes #914

## How to test
1. Verify no warning message is shown when no previous analyses have been run or the previous analyses have been run with the recommended version (currently v4.7.0)
2. Verify a warning message is shown when previously run analyses have been run with something other than the currently selected version.
