### PR TITLE
Multiple route warnings

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -232,7 +232,7 @@
     "type": "Modification type",
     "create": "Create a modification",
     "plural": "Modifications",
-    "onlyOneRoute": "Only one route may be shown on the map, even if multiple routes are selected below. If segments are not selected, the modification will apply to all selected routes. If segments are selected, the modification will apply to hops shown on the map (for all selected routes using the hops).",
+    "onlyOneRoute": "Only one route will be shown on the map at a time, even if multiple routes are selected below.",
     "copyTimetable": {
       "noSegments": "The modification being copied to and/or from does not have any segments. The default segment speed of %(segmentSpeed) km/h will be used.",
       "curHasMoreSegments": "The modification of the timetable you are copying from has less segments than the modification you are copying to. The segment speeds will be copied %(numSegments) segment(s) and after that, the default segment speed of %(segmentSpeed) km/h will be used.",

--- a/lib/components/modification/__tests__/__snapshots__/adjust-dwell-time.js.snap
+++ b/lib/components/modification/__tests__/__snapshots__/adjust-dwell-time.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Component > Modification > AdjustDwellTime renders empty correctly 1`] = `
-<div>
+<Fragment>
   <SelectFeedRouteAndPatterns
     feeds={Array []}
     onChange={[Function]}
@@ -61,11 +61,11 @@ exports[`Component > Modification > AdjustDwellTime renders empty correctly 1`] 
     onChange={[Function]}
     units="seconds"
   />
-</div>
+</Fragment>
 `;
 
 exports[`Component > Modification > AdjustDwellTime renders with data correctly 1`] = `
-<div>
+<Fragment>
   <SelectFeedRouteAndPatterns
     feeds={Array []}
     onChange={[Function]}
@@ -185,5 +185,5 @@ exports[`Component > Modification > AdjustDwellTime renders with data correctly 
     onChange={[Function]}
     units="seconds"
   />
-</div>
+</Fragment>
 `;

--- a/lib/components/modification/__tests__/__snapshots__/adjust-speed.js.snap
+++ b/lib/components/modification/__tests__/__snapshots__/adjust-speed.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Component > Modification > AdjustSpeed renders correctly 1`] = `
-<form>
+<Fragment>
   <SelectFeedRouteAndPatterns
     allowMultipleRoutes={true}
     feeds={
@@ -171,5 +171,5 @@ exports[`Component > Modification > AdjustSpeed renders correctly 1`] = `
     onChange={[Function]}
     step="any"
   />
-</form>
+</Fragment>
 `;

--- a/lib/components/modification/__tests__/__snapshots__/reroute.js.snap
+++ b/lib/components/modification/__tests__/__snapshots__/reroute.js.snap
@@ -1145,7 +1145,6 @@ exports[`Component > Modification > Reroute renders correctly 1`] = `
           <S
             getOptionLabel={[Function]}
             getOptionValue={[Function]}
-            isDisabled={true}
             name="Route"
             onChange={[Function]}
             options={
@@ -1215,7 +1214,7 @@ exports[`Component > Modification > Reroute renders correctly 1`] = `
                 },
               ]
             }
-            placeholder="All routes selected"
+            placeholder="Select route"
             value={
               Object {
                 "label": "mock-route-label",
@@ -1285,7 +1284,6 @@ exports[`Component > Modification > Reroute renders correctly 1`] = `
             <ReactSelect
               getOptionLabel={[Function]}
               getOptionValue={[Function]}
-              isDisabled={true}
               name="Route"
               onChange={[Function]}
               options={
@@ -1355,7 +1353,7 @@ exports[`Component > Modification > Reroute renders correctly 1`] = `
                   },
                 ]
               }
-              placeholder="All routes selected"
+              placeholder="Select route"
               styles={
                 Object {
                   "control": [Function],

--- a/lib/components/modification/adjust-dwell-time.js
+++ b/lib/components/modification/adjust-dwell-time.js
@@ -1,4 +1,4 @@
-import React, {Component} from 'react'
+import React from 'react'
 
 import {NumberInput} from '../input'
 
@@ -8,90 +8,77 @@ import SelectStops from './select-stops'
 /**
  * Change dwell times
  */
-export default class AdjustDwellTimeComponent extends Component {
-  _onPatternSelectorChange = ({feed, routes, trips}) => {
-    this.props.updateAndRetrieveFeedData({feed, routes, trips, stops: null})
+export default function AdjustDwellTimeComponent(p) {
+  function _onPatternSelectorChange({feed, routes, trips}) {
+    p.updateAndRetrieveFeedData({feed, routes, trips, stops: null})
   }
 
-  /** we are setting a scale for existing speeds, not an actual speed */
-  _setScale = e => {
-    if (e.currentTarget.checked) this.props.update({scale: true})
+  // We are setting a scale for existing speeds, not an actual speed
+  function _setScale(e) {
+    if (e.currentTarget.checked) p.update({scale: true})
   }
 
-  /** we are setting a brand-new speed, throwing out any existing variation in speed */
-  _setSpeed = e => {
-    if (e.currentTarget.checked) this.props.update({scale: false})
+  // We are setting a brand-new speed, throwing out any existing variation in speed.
+  function _setSpeed(e) {
+    if (e.currentTarget.checked) p.update({scale: false})
   }
 
-  /** set the factor by which we are scaling, or the speed which we are replacing */
-  _setValue = e => {
-    this.props.update({value: e.currentTarget.value})
+  // Set the factor by which we are scaling, or the speed which we are replacing.
+  function _setValue(e) {
+    p.update({value: e.currentTarget.value})
   }
 
-  render() {
-    const {
-      feeds,
-      modification,
-      routePatterns,
-      routeStops,
-      selectedFeed,
-      selectedStops,
-      setMapState,
-      update
-    } = this.props
+  return (
+    <>
+      <SelectFeedRouteAndPatterns
+        feeds={p.feeds}
+        onChange={_onPatternSelectorChange}
+        routes={p.modification.routes}
+        routePatterns={p.routePatterns}
+        selectedFeed={p.selectedFeed}
+        trips={p.modification.trips}
+      />
 
-    return (
-      <div>
-        <SelectFeedRouteAndPatterns
-          feeds={feeds}
-          onChange={this._onPatternSelectorChange}
-          routes={modification.routes}
-          routePatterns={routePatterns}
-          selectedFeed={selectedFeed}
-          trips={modification.trips}
+      {p.modification.routes && (
+        <SelectStops
+          setMapState={p.setMapState}
+          routeStops={p.routeStops}
+          selectedStops={p.selectedStops}
+          update={p.update}
         />
+      )}
 
-        {modification.routes && (
-          <SelectStops
-            setMapState={setMapState}
-            routeStops={routeStops}
-            selectedStops={selectedStops}
-            update={update}
-          />
-        )}
-
-        <div className='radio'>
-          <label htmlFor='adjust-dwell-time-scale'>
-            <input
-              id='adjust-dwell-time-scale'
-              type='radio'
-              value='scale'
-              checked={modification.scale}
-              onChange={this._setScale}
-            />{' '}
-            Scale existing dwell times by
-          </label>
-        </div>
-        <div className='radio'>
-          <label htmlFor='adjust-dwell-time-speed'>
-            <input
-              id='adjust-dwell-time-speed'
-              type='radio'
-              value='speed'
-              checked={!modification.scale}
-              onChange={this._setSpeed}
-            />{' '}
-            Set new dwell time to
-          </label>
-        </div>
-
-        <NumberInput
-          min={0}
-          onChange={this._setValue}
-          units={modification.scale ? ' ' : 'seconds'}
-          value={modification.value}
-        />
+      <div className='radio'>
+        <label htmlFor='adjust-dwell-time-scale'>
+          <input
+            id='adjust-dwell-time-scale'
+            type='radio'
+            value='scale'
+            checked={p.modification.scale}
+            onChange={_setScale}
+          />{' '}
+          Scale existing dwell times by
+        </label>
       </div>
-    )
-  }
+      <div className='radio'>
+        <label htmlFor='adjust-dwell-time-speed'>
+          <input
+            id='adjust-dwell-time-speed'
+            type='radio'
+            value='speed'
+            checked={!p.modification.scale}
+            onChange={_setSpeed}
+          />{' '}
+          Set new dwell time to
+        </label>
+      </div>
+
+      <NumberInput
+        min={0}
+        onChange={_setValue}
+        units={p.modification.scale ? ' ' : 'seconds'}
+        value={p.modification.value}
+      />
+    </>
+  )
 }

--- a/lib/components/modification/adjust-speed.js
+++ b/lib/components/modification/adjust-speed.js
@@ -1,5 +1,6 @@
 import {faExclamationCircle} from '@fortawesome/free-solid-svg-icons'
-import React, {Component} from 'react'
+import get from 'lodash/get'
+import React from 'react'
 
 import message from 'lib/message'
 
@@ -13,95 +14,83 @@ import SelectFeedRouteAndPatterns from './select-feed-route-and-patterns'
 /**
  * Adjust speed on a route
  */
-export default class AdjustSpeedComponent extends Component {
-  onSelectorChange = value => {
+export default function AdjustSpeedComponent(p) {
+  function onSelectorChange(value) {
     const {feed, routes, trips} = value
-    this.props.updateAndRetrieveFeedData({feed, routes, trips, hops: null})
+    p.updateAndRetrieveFeedData({feed, routes, trips, hops: null})
   }
 
-  newSelection = () => {
-    const {modification, setMapState} = this.props
-    setMapState({
+  function newSelection() {
+    p.setMapState({
       state: MAP_STATE_HOP_SELECTION,
-      modification,
       action: 'new'
     })
   }
 
-  addToSelection = () => {
-    const {modification, setMapState} = this.props
-    setMapState({
+  function addToSelection() {
+    p.setMapState({
       state: MAP_STATE_HOP_SELECTION,
-      modification,
       action: 'add'
     })
   }
 
-  removeFromSelection = () => {
-    const {modification, setMapState} = this.props
-    setMapState({
+  function removeFromSelection() {
+    p.setMapState({
       state: MAP_STATE_HOP_SELECTION,
-      modification,
       action: 'remove'
     })
   }
 
-  clearSegment = () => {
-    this.props.update({hops: null})
+  function clearSegment() {
+    p.update({hops: null})
   }
 
-  /** set the factor by which we are scaling, or the speed which we are replacing */
-  setScale = e => {
-    this.props.update({scale: e.currentTarget.value})
+  /**
+   * Set the factor by which we are scaling, or the speed which we are
+   * replacing.
+   */
+  function setScale(e) {
+    p.update({scale: e.currentTarget.value})
   }
 
-  render() {
-    const {feeds, modification, routePatterns, selectedFeed} = this.props
-    return (
-      <form>
-        <SelectFeedRouteAndPatterns
-          allowMultipleRoutes
-          feeds={feeds}
-          onChange={this.onSelectorChange}
-          routePatterns={routePatterns}
-          routes={modification.routes}
-          selectedFeed={selectedFeed}
-          trips={modification.trips}
-        />
+  return (
+    <>
+      <SelectFeedRouteAndPatterns
+        allowMultipleRoutes
+        feeds={p.feeds}
+        onChange={onSelectorChange}
+        routePatterns={p.routePatterns}
+        routes={p.modification.routes}
+        selectedFeed={p.selectedFeed}
+        trips={p.modification.trips}
+      />
 
-        {modification.routes && (
-          <FormGroup>
-            <label htmlFor='Segment'>Segment</label>
-            <Group justified>
-              <Button onClick={this.newSelection}>
-                {message('common.select')}
-              </Button>
-              <Button onClick={this.addToSelection}>
-                {message('common.addTo')}
-              </Button>
-              <Button onClick={this.removeFromSelection}>
-                {message('common.removeFrom')}
-              </Button>
-              <Button onClick={this.clearSegment}>
-                {message('common.clear')}
-              </Button>
-            </Group>
-            <div className='alert alert-info' role='alert'>
-              <Icon icon={faExclamationCircle} />
-              {message('report.adjustSpeed.selectInstructions')}
-            </div>
-          </FormGroup>
-        )}
+      {get(p, 'modification.routes.length') === 1 && (
+        <FormGroup>
+          <label htmlFor='Segment'>Segment</label>
+          <Group justified>
+            <Button onClick={newSelection}>{message('common.select')}</Button>
+            <Button onClick={addToSelection}>{message('common.addTo')}</Button>
+            <Button onClick={removeFromSelection}>
+              {message('common.removeFrom')}
+            </Button>
+            <Button onClick={clearSegment}>{message('common.clear')}</Button>
+          </Group>
+          <div className='alert alert-info' role='alert'>
+            <Icon icon={faExclamationCircle} />
+            {message('report.adjustSpeed.selectInstructions')}
+          </div>
+        </FormGroup>
+      )}
 
-        <NumberInput
-          label={message('report.adjustSpeed.scaleLabel')}
-          name={message('report.adjustSpeed.scaleLabel')}
-          min={0}
-          onChange={this.setScale}
-          step='any'
-          value={modification.scale}
-        />
-      </form>
-    )
-  }
+      <NumberInput
+        label={message('report.adjustSpeed.scaleLabel')}
+        name={message('report.adjustSpeed.scaleLabel')}
+        min={0}
+        onChange={setScale}
+        step='any'
+        value={p.modification.scale}
+      />
+    </>
+  )
 }

--- a/lib/components/modification/editor.js
+++ b/lib/components/modification/editor.js
@@ -268,7 +268,7 @@ export default class ModificationEditor extends React.PureComponent {
                   </Group>
                 )}
 
-                {p.modification.routes && p.modification.routes.length > 1 && (
+                {get(p, 'modification.routes.length') > 1 && (
                   <div className='alert alert-warning' role='alert'>
                     {message('modification.onlyOneRoute')}
                   </div>

--- a/lib/components/modification/select-feed-and-routes.js
+++ b/lib/components/modification/select-feed-and-routes.js
@@ -11,6 +11,9 @@ import {Group as FormGroup} from '../input'
  * Select routes without selecting patterns
  */
 export default function SelectFeedAndRoutes(p) {
+  const selectedFeedId = get(p, 'selectedFeed.id')
+  const routeIds = get(p, 'selectedRouteIds', [])
+
   function _selectFeed(feed) {
     p.onChange({feed: get(feed, 'id'), routes: null})
   }
@@ -42,11 +45,13 @@ export default function SelectFeedAndRoutes(p) {
     }
   }
 
-  const selectedRoutes = (p.selectedRouteIds || []).map(id =>
+  const selectedRoutes = routeIds.map(id =>
     p.selectedFeed.routes.find(r => r.route_id === id)
   )
   const allRoutesSelected =
-    p.selectedFeed && selectedRoutes.length === p.selectedFeed.routes.length
+    p.selectedFeed &&
+    selectedRoutes.length > 1 &&
+    selectedRoutes.length === p.selectedFeed.routes.length
   return (
     <>
       <FormGroup>
@@ -62,32 +67,45 @@ export default function SelectFeedAndRoutes(p) {
         />
       </FormGroup>
 
-      {p.selectedFeed && !allRoutesSelected && (
-        <FormGroup>
-          <Select
-            getOptionLabel={r => r.label}
-            getOptionValue={r => r.route_id}
-            isMulti={p.allowMultipleRoutes}
-            name='Route'
-            onChange={_selectRoute}
-            options={p.selectedFeed.routes}
-            placeholder='Select route'
-            value={p.allowMultipleRoutes ? selectedRoutes : selectedRoutes[0]}
-          />
-        </FormGroup>
+      {p.selectedFeed && (
+        <>
+          {allRoutesSelected ? (
+            <div className='alert alert-warning'>
+              <strong>All routes selected</strong>
+              <p>
+                This modification will apply to all routes in this feed. Select
+                a single route to modify specific parts of that route.
+              </p>
+            </div>
+          ) : (
+            <FormGroup>
+              <Select
+                getOptionLabel={r => r.label}
+                getOptionValue={r => r.route_id}
+                isMulti={p.allowMultipleRoutes}
+                name='Route'
+                onChange={_selectRoute}
+                options={p.selectedFeed.routes}
+                placeholder='Select route'
+                value={
+                  p.allowMultipleRoutes ? selectedRoutes : selectedRoutes[0]
+                }
+              />
+            </FormGroup>
+          )}
+        </>
       )}
 
-      {p.selectedFeed && p.allowMultipleRoutes && (
+      {p.allowMultipleRoutes && (
         <>
-          {get(p.selectedRouteIds, 'length') > 0 && (
+          {routeIds.length > 1 && (
             <FormGroup>
               <Button block style='warning' onClick={_deselectAllRoutes}>
                 <Icon icon={faMinus} /> Deselect all routes
               </Button>
             </FormGroup>
           )}
-          {(!p.selectedRouteIds ||
-            p.selectedRouteIds.length < p.selectedFeed.routes.length) && (
+          {routeIds.length < p.selectedFeed.routes.length && (
             <FormGroup>
               <Button block style='info' onClick={_selectAllRoutes}>
                 <Icon icon={faPlus} /> Select all routes

--- a/lib/components/modification/select-feed-and-routes.js
+++ b/lib/components/modification/select-feed-and-routes.js
@@ -67,42 +67,34 @@ export default function SelectFeedAndRoutes(p) {
       </FormGroup>
 
       {p.selectedFeed && (
-        <>
-          {allRoutesSelected ? (
-            <div className='alert alert-warning'>
-              <strong>All routes selected</strong>
-              <p>
-                This modification will apply to all routes in this feed. Select
-                a single route to modify specific parts of that route.
-              </p>
-            </div>
-          ) : (
-            <FormGroup>
-              <Select
-                getOptionLabel={r => r.label}
-                getOptionValue={r => r.route_id}
-                isMulti={p.allowMultipleRoutes}
-                name='Route'
-                onChange={_selectRoute}
-                options={p.selectedFeed.routes}
-                placeholder='Select route'
-                value={
-                  p.allowMultipleRoutes ? selectedRoutes : selectedRoutes[0]
-                }
-              />
-            </FormGroup>
-          )}
-        </>
+        <FormGroup>
+          <Select
+            getOptionLabel={r => r.label}
+            getOptionValue={r => r.route_id}
+            isMulti={p.allowMultipleRoutes}
+            name='Route'
+            onChange={_selectRoute}
+            options={p.selectedFeed.routes}
+            placeholder='Select route'
+            value={p.allowMultipleRoutes ? selectedRoutes : selectedRoutes[0]}
+          />
+        </FormGroup>
       )}
 
       {p.allowMultipleRoutes && (
         <>
           {routeIds.length > 1 && (
-            <FormGroup>
-              <Button block style='warning' onClick={_deselectAllRoutes}>
-                <Icon icon={faMinus} /> Deselect all routes
-              </Button>
-            </FormGroup>
+            <>
+              <div className='alert alert-warning'>
+                This modification will apply to all routes selected. Select a
+                single route to modify specific parts of that route.
+              </div>
+              <FormGroup>
+                <Button block style='warning' onClick={_deselectAllRoutes}>
+                  <Icon icon={faMinus} /> Deselect all routes
+                </Button>
+              </FormGroup>
+            </>
           )}
           {routeIds.length < p.selectedFeed.routes.length && (
             <FormGroup>

--- a/lib/components/modification/select-feed-and-routes.js
+++ b/lib/components/modification/select-feed-and-routes.js
@@ -11,8 +11,7 @@ import {Group as FormGroup} from '../input'
  * Select routes without selecting patterns
  */
 export default function SelectFeedAndRoutes(p) {
-  const selectedFeedId = get(p, 'selectedFeed.id')
-  const routeIds = get(p, 'selectedRouteIds', [])
+  const routeIds = get(p, 'selectedRouteIds') || []
 
   function _selectFeed(feed) {
     p.onChange({feed: get(feed, 'id'), routes: null})

--- a/lib/components/modification/select-feed-and-routes.js
+++ b/lib/components/modification/select-feed-and-routes.js
@@ -1,6 +1,6 @@
 import {faMinus, faPlus} from '@fortawesome/free-solid-svg-icons'
 import get from 'lodash/get'
-import React, {PureComponent} from 'react'
+import React from 'react'
 
 import Select from '../select'
 import {Button} from '../buttons'
@@ -10,15 +10,14 @@ import {Group as FormGroup} from '../input'
 /**
  * Select routes without selecting patterns
  */
-export default class SelectFeedAndRoutes extends PureComponent {
-  _selectFeed = feed => {
-    this.props.onChange({feed: get(feed, 'id'), routes: null})
+export default function SelectFeedAndRoutes(p) {
+  function _selectFeed(feed) {
+    p.onChange({feed: get(feed, 'id'), routes: null})
   }
 
-  _selectRoute = routes => {
-    const {onChange, selectedFeed} = this.props
-    onChange({
-      feed: get(selectedFeed, 'id'),
+  function _selectRoute(routes) {
+    p.onChange({
+      feed: get(p.selectedFeed, 'id'),
       routes: !routes
         ? []
         : Array.isArray(routes)
@@ -27,90 +26,76 @@ export default class SelectFeedAndRoutes extends PureComponent {
     })
   }
 
-  _deselectAllRoutes = () => {
-    const {onChange, selectedFeed} = this.props
-    onChange({
-      feed: get(selectedFeed, 'id'),
+  function _deselectAllRoutes() {
+    p.onChange({
+      feed: get(p.selectedFeed, 'id'),
       routes: []
     })
   }
 
-  _selectAllRoutes = () => {
-    const {onChange, selectedFeed} = this.props
-    if (selectedFeed) {
-      onChange({
-        feed: selectedFeed.id,
-        routes: selectedFeed.routes.map(r => r.route_id)
+  function _selectAllRoutes() {
+    if (p.selectedFeed) {
+      p.onChange({
+        feed: p.selectedFeed.id,
+        routes: p.selectedFeed.routes.map(r => r.route_id)
       })
     }
   }
 
-  render() {
-    const {
-      allowMultipleRoutes,
-      feeds,
-      selectedFeed,
-      selectedRouteIds
-    } = this.props
+  const selectedRoutes = (p.selectedRouteIds || []).map(id =>
+    p.selectedFeed.routes.find(r => r.route_id === id)
+  )
+  const allRoutesSelected =
+    p.selectedFeed && selectedRoutes.length === p.selectedFeed.routes.length
+  return (
+    <>
+      <FormGroup>
+        <label htmlFor='Feed'>Select feed and routes</label>
+        <Select
+          name='Feed'
+          getOptionLabel={f => get(f, 'name', f.id)}
+          getOptionValue={f => f.id}
+          onChange={_selectFeed}
+          options={p.feeds}
+          placeholder='Select feed'
+          value={p.selectedFeed}
+        />
+      </FormGroup>
 
-    const selectedRoutes = (selectedRouteIds || []).map(id =>
-      selectedFeed.routes.find(r => r.route_id === id)
-    )
-    const allRoutesSelected =
-      selectedFeed && selectedRoutes.length === selectedFeed.routes.length
-    return (
-      <>
+      {p.selectedFeed && !allRoutesSelected && (
         <FormGroup>
-          <label htmlFor='Feed'>Select feed and routes</label>
           <Select
-            name='Feed'
-            getOptionLabel={f => get(f, 'name', f.id)}
-            getOptionValue={f => f.id}
-            onChange={this._selectFeed}
-            options={feeds}
-            placeholder='Select feed'
-            value={selectedFeed}
+            getOptionLabel={r => r.label}
+            getOptionValue={r => r.route_id}
+            isMulti={p.allowMultipleRoutes}
+            name='Route'
+            onChange={_selectRoute}
+            options={p.selectedFeed.routes}
+            placeholder='Select route'
+            value={p.allowMultipleRoutes ? selectedRoutes : selectedRoutes[0]}
           />
         </FormGroup>
+      )}
 
-        {selectedFeed && (
-          <FormGroup>
-            <Select
-              isDisabled={allRoutesSelected}
-              getOptionLabel={r => r.label}
-              getOptionValue={r => r.route_id}
-              isMulti={allowMultipleRoutes}
-              name='Route'
-              onChange={this._selectRoute}
-              options={selectedFeed.routes}
-              placeholder={
-                allRoutesSelected ? 'All routes selected' : 'Select route'
-              }
-              value={allowMultipleRoutes ? selectedRoutes : selectedRoutes[0]}
-            />
-          </FormGroup>
-        )}
-
-        {selectedFeed && allowMultipleRoutes && (
-          <>
-            {selectedRouteIds && selectedRouteIds.length > 0 && (
-              <FormGroup>
-                <Button block style='warning' onClick={this._deselectAllRoutes}>
-                  <Icon icon={faMinus} /> Deselect all routes
-                </Button>
-              </FormGroup>
-            )}
-            {(!selectedRouteIds ||
-              selectedRouteIds.length < selectedFeed.routes.length) && (
-              <FormGroup>
-                <Button block style='info' onClick={this._selectAllRoutes}>
-                  <Icon icon={faPlus} /> Select all routes
-                </Button>
-              </FormGroup>
-            )}
-          </>
-        )}
-      </>
-    )
-  }
+      {p.selectedFeed && p.allowMultipleRoutes && (
+        <>
+          {get(p.selectedRouteIds, 'length') > 0 && (
+            <FormGroup>
+              <Button block style='warning' onClick={_deselectAllRoutes}>
+                <Icon icon={faMinus} /> Deselect all routes
+              </Button>
+            </FormGroup>
+          )}
+          {(!p.selectedRouteIds ||
+            p.selectedRouteIds.length < p.selectedFeed.routes.length) && (
+            <FormGroup>
+              <Button block style='info' onClick={_selectAllRoutes}>
+                <Icon icon={faPlus} /> Select all routes
+              </Button>
+            </FormGroup>
+          )}
+        </>
+      )}
+    </>
+  )
 }

--- a/lib/components/modification/select-feed-route-and-patterns.js
+++ b/lib/components/modification/select-feed-route-and-patterns.js
@@ -30,7 +30,7 @@ export default function SelectFeedRouteAndPatterns(p) {
         selectedRouteIds={p.routes}
       />
 
-      {p.routes && p.routes.length < 2 && p.routePatterns.length > 0 && (
+      {get(p, 'routes.length') < 2 && p.routePatterns.length > 0 && (
         <SelectPatterns
           onChange={_selectTrips}
           routePatterns={p.routePatterns}

--- a/lib/components/modifications-map/adjust-speed-layer.js
+++ b/lib/components/modifications-map/adjust-speed-layer.js
@@ -6,22 +6,21 @@ import colors from '../../constants/colors'
 import PatternLayer from './pattern-layer'
 import HopLayer from './hop-layer'
 
-export default function AdjustSpeedLayer(props) {
-  const {modification, feed, dim} = props
-  if (modification.hops) {
+export default function AdjustSpeedLayer(p) {
+  if (p.modification.hops) {
     return (
       <>
         <PatternLayer
           color={colors.NEUTRAL}
-          dim={dim}
-          feed={feed}
-          modification={modification}
+          dim={p.dim}
+          feed={p.feed}
+          modification={p.modification}
         />
         <HopLayer
           color={colors.MODIFIED}
-          dim={dim}
-          feed={feed}
-          modification={modification}
+          dim={p.dim}
+          feed={p.feed}
+          modification={p.modification}
         />
       </>
     )
@@ -29,9 +28,9 @@ export default function AdjustSpeedLayer(props) {
     return (
       <PatternLayer
         color={colors.MODIFIED}
-        dim={dim}
-        feed={feed}
-        modification={modification}
+        dim={p.dim}
+        feed={p.feed}
+        modification={p.modification}
       />
     )
   }

--- a/lib/components/modifications-map/display.js
+++ b/lib/components/modifications-map/display.js
@@ -10,14 +10,6 @@ const PatternLayer = dynamic(() => import('./pattern-layer'))
 const RerouteLayer = dynamic(() => import('./reroute-layer'))
 const StopLayer = dynamic(() => import('./stop-layer'))
 
-/*
-import AddTripPatternLayer from './add-trip-pattern-layer'
-import AdjustSpeedLayer from './adjust-speed-layer'
-import PatternLayer from './pattern-layer'
-import RerouteLayer from './reroute-layer'
-import StopLayer from './stop-layer'
-*/
-
 export default function Display(p) {
   const m = p.modification
   switch (m.type) {


### PR DESCRIPTION
## Description

When multiple routes are selected, disallow selecting portions of the route displayed as the modification will be applied to the entirety of each route. This also updates the warning messages shown to reflect that.

Fixes #697 

## How to test
1. Create Adjust Speed modification.
2. Select all routes.
3. Run analysis ensuring the modification was applied for each route in the feed.
4. Repeat for Remove Trips.
