### PR TITLE
Add Union option for aggregation areas

### DIFF
--- a/lib/actions/aggregation-areas.js
+++ b/lib/actions/aggregation-areas.js
@@ -36,5 +36,8 @@ export const uploadAggregationArea = (formData, regionId) =>
       method: 'post',
       body: formData
     },
-    next: res => addAggregationAreaLocally(res.value)
+    next: res => {
+      const newAgAreas = res.value
+      return newAgAreas.map(aa => addAggregationAreaLocally(aa))
+    }
   })

--- a/lib/components/analysis/aggregation-area.js
+++ b/lib/components/analysis/aggregation-area.js
@@ -27,6 +27,8 @@ export default function AggregationArea(p) {
   const aas = useSelector(state => state.region.aggregationAreas)
   const [showUpload, setShowUpload] = React.useState(false)
   const [name, setName] = React.useState('')
+  const [nameAttribute, setNameAttribute] = React.useState('attribute')
+  const [union, setUnion] = React.useState(true)
   const [files, setFiles] = React.useState()
   const [uploading, setUploading] = React.useState(false)
 
@@ -44,6 +46,8 @@ export default function AggregationArea(p) {
 
     const formData = new window.FormData()
     formData.append('name', name)
+    formData.append('nameProperty', nameAttribute)
+    formData.append('union', union)
     ;[...files].forEach(file => formData.append('files', file))
 
     dispatch(uploadAggregationArea(formData, p.regionId))
@@ -112,6 +116,27 @@ export default function AggregationArea(p) {
             name='files'
             onChange={e => setFiles(e.target.files)}
           />
+
+          <Checkbox
+            label='Union'
+            checked={union}
+            onChange={e => setUnion(e.target.checked)}
+          />
+
+          <p>
+            <em>
+              If unchecked, a separate aggregation area will be created for each
+              feature (up to 60) in the uploaded shapefile.
+            </em>
+          </p>
+
+          {!union && (
+            <Text
+              label='Attribute name to lookup on the shapefile'
+              value={nameProperty}
+              onChange={e => setNameProperty(e.target.value)}
+            />
+          )}
 
           <Button
             block

--- a/lib/components/analysis/aggregation-area.js
+++ b/lib/components/analysis/aggregation-area.js
@@ -51,8 +51,8 @@ export default function AggregationArea(p) {
     ;[...files].forEach(file => formData.append('files', file))
 
     dispatch(uploadAggregationArea(formData, p.regionId))
-      .then(newAA => {
-        setActive(newAA)
+      .then(newAAs => {
+        setActive(newAAs[0])
         setName('')
         setFiles()
         setShowUpload(false)

--- a/lib/components/analysis/aggregation-area.js
+++ b/lib/components/analysis/aggregation-area.js
@@ -18,7 +18,7 @@ import selectActiveAggregationArea from 'lib/selectors/active-aggregation-area'
 
 import {Button} from '../buttons'
 import Icon from '../icon'
-import {File, Group, Text} from '../input'
+import {Checkbox, File, Group, Text} from '../input'
 import Select from '../select'
 
 export default function AggregationArea(p) {
@@ -133,8 +133,8 @@ export default function AggregationArea(p) {
           {!union && (
             <Text
               label='Attribute name to lookup on the shapefile'
-              value={nameProperty}
-              onChange={e => setNameProperty(e.target.value)}
+              value={nameAttribute}
+              onChange={e => setNameAttribute(e.target.value)}
             />
           )}
 

--- a/lib/components/modification/select-feed-and-routes.js
+++ b/lib/components/modification/select-feed-and-routes.js
@@ -47,10 +47,6 @@ export default function SelectFeedAndRoutes(p) {
   const selectedRoutes = routeIds.map(id =>
     p.selectedFeed.routes.find(r => r.route_id === id)
   )
-  const allRoutesSelected =
-    p.selectedFeed &&
-    selectedRoutes.length > 1 &&
-    selectedRoutes.length === p.selectedFeed.routes.length
   return (
     <>
       <FormGroup>


### PR DESCRIPTION
## Description

Add's two new field's to the aggregation area form. A checkbox to control whether or not the upload will union all of the features and a text field for setting the attribute name when not unioning.

Fixes #862 

Note: also removes an unused variable that ESLint was warning about. This variable was no longer in use from #917 

## How to test
1. Upload a shapefile with multiple attributes, leave the union box checked.
2. Upload a shapefile with multiple attributes, uncheck the union box and ensure that new aggregation areas were created for each attribute. 
