### PR TITLE
Option to process uploaded .csv files into freeform (non-grid) pointsets

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -279,7 +279,9 @@
     "enterName": "Please enter a new name.",
     "confirmDelete": "Are you sure you would like to delete this dataset?",
     "confirmDeleteSource": "Are you sure you would like to delete all opportunity datasets from this source?",
-    "editName": "Edit Dataset Name"
+    "editName": "Edit Dataset Name",
+    "freeform": "Process as discrete (non-grid) points (beta)",
+    "paired": "Paired origin/destination file (beta)"
   },
   "analysis": {
     "mode": "Mode of travel",
@@ -305,7 +307,7 @@
     "gridFiles": "Select opportunity dataset",
     "latField": "Latitude field",
     "lonField": "Longitude field",
-    "idField": "Id field",
+    "idField": "ID field",
     "travelTime": "Travel time",
     "errorsInProject": "Errors were found in the project:",
     "warningsInProject": "Warnings were found applying the project",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -305,6 +305,7 @@
     "gridFiles": "Select opportunity dataset",
     "latField": "Latitude field",
     "lonField": "Longitude field",
+    "idField": "Id field",
     "travelTime": "Travel time",
     "errorsInProject": "Errors were found in the project:",
     "warningsInProject": "Warnings were found applying the project",

--- a/lib/modules/opportunity-datasets/components/upload.js
+++ b/lib/modules/opportunity-datasets/components/upload.js
@@ -68,20 +68,21 @@ export default function UploadOpportunityDataset(p) {
             <Text name='lonField' label={message('analysis.lonField')} />
 
             <Checkbox
-              label='Process as discrete (non-grid) points (beta)'
+              label={message('opportunityDatasets.freeform')}
               checked={freeform}
               onChange={e => setFreeForm(e.target.checked)}
-            />
-
-            <Checkbox
-              label='Paired origin/destination file (beta)'
-              checked={paired}
-              onChange={e => setPaired(e.target.checked)}
             />
 
             {freeform && (
               <>
                 <Text name='idField' label={message('analysis.idField')} />
+
+                <Checkbox
+                  label={message('opportunityDatasets.paired')}
+                  checked={paired}
+                  onChange={e => setPaired(e.target.checked)}
+                />
+
                 {paired && (
                   <>
                     <Text

--- a/lib/modules/opportunity-datasets/components/upload.js
+++ b/lib/modules/opportunity-datasets/components/upload.js
@@ -5,7 +5,7 @@ import {useDispatch} from 'react-redux'
 
 import {Button} from 'lib/components/buttons'
 import Icon from 'lib/components/icon'
-import {File, Text} from 'lib/components/input'
+import {File, Text, Checkbox} from 'lib/components/input'
 import message from 'lib/message'
 
 import {uploadOpportunityDataset} from '../actions'
@@ -16,12 +16,15 @@ export default function UploadOpportunityDataset(p) {
   const [files, setFiles] = React.useState()
   const [uploading, setUploading] = React.useState(false)
   const [isCSV, setIsCSV] = React.useState(false)
+  const [freeform, setFreeForm] = React.useState(false)
+  const [paired, setPaired] = React.useState(false)
   const formRef = React.useRef()
   const dispatch = useDispatch()
 
   function submit(e) {
     e.preventDefault()
     const body = new window.FormData(formRef.current)
+    body.append('freeform', freeform)
     setUploading(true)
     dispatch(uploadOpportunityDataset(body))
   }
@@ -63,6 +66,37 @@ export default function UploadOpportunityDataset(p) {
             <Text name='latField' label={message('analysis.latField')} />
 
             <Text name='lonField' label={message('analysis.lonField')} />
+
+            <Checkbox
+              label='Process as discrete (non-grid) points (beta)'
+              checked={freeform}
+              onChange={e => setFreeForm(e.target.checked)}
+            />
+
+            <Checkbox
+              label='Paired origin/destination file (beta)'
+              checked={paired}
+              onChange={e => setPaired(e.target.checked)}
+            />
+
+            {freeform && (
+              <>
+                <Text name='idField' label={message('analysis.idField')} />
+                {paired && (
+                  <>
+                    <Text
+                      name='latField1'
+                      label={message('analysis.latField')}
+                    />
+
+                    <Text
+                      name='lonField1'
+                      label={message('analysis.lonField')}
+                    />
+                  </>
+                )}
+              </>
+            )}
           </>
         )}
 


### PR DESCRIPTION
## Description

Adds two checkboxes to the opportunity dataset page, allowing singals to the backend that a csv should be converted to a freeform pointset (see https://github.com/conveyal/r5/pull/529):

- [ ] Process as discrete (non-grid) points (beta) [if checked, the checkbox below and an Id field appear]
- [ ] Paired origin/destination file (beta) [if checked, an extra set of lat/lon fields appear]

We expect two common use cases to be:
1. Calculating accessibility or travel times using discrete points as origins (rather than all points in our web mercator grid)
1. Calculating travel times for known origin-destination pairs.

For the former case, it makes sense to specify latitude, longitude, and id columns in the uploaded shapefile.  For the latter case, each row would have a second latitude/longitude (hence the second checkbox)

As a side note, we're getting closer to having OD = origin/destination (instead of the jargony "opportunity dataset")

Fixes #345 (at least for the UI)

## How to test
1. On the opportunity dataset page, enter a name and select a csv file
1. Check the "Process as a discrete..." box
1. Enter lat, lon, and id fields
1. Check the "Paired origin/destination" box
1. Enter secondary lat, lon fields
1. Upload
1. After refreshing, the dropdown should have grid and freeform versions of the file available.
