### PR TITLE
More freeform fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ env.yml-original
 .env
 .env.build
 .next
+
+# IDE settings
+.idea

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -308,6 +308,7 @@
     "latField": "Latitude field",
     "lonField": "Longitude field",
     "idField": "ID field",
+    "countField": "Opportunity count field",
     "travelTime": "Travel time",
     "errorsInProject": "Errors were found in the project:",
     "warningsInProject": "Warnings were found applying the project",

--- a/lib/modules/opportunity-datasets/components/upload.js
+++ b/lib/modules/opportunity-datasets/components/upload.js
@@ -27,7 +27,8 @@ export default function UploadOpportunityDataset() {
   function submit(e) {
     e.preventDefault()
     const body = new window.FormData(formRef.current)
-    // body.append('freeform', freeform)
+    body.append('freeform', freeform)
+    body.append('paired', paired)
     setUploading(true)
     dispatch(uploadOpportunityDataset(body))
   }
@@ -82,6 +83,10 @@ export default function UploadOpportunityDataset() {
               {freeform && (
                 <>
                   <Text name='idField' label={message('analysis.idField')} />
+                  <Text
+                    name='countField'
+                    label={message('analysis.countField')}
+                  />
 
                   <Checkbox
                     label={message('opportunityDatasets.paired')}
@@ -92,12 +97,12 @@ export default function UploadOpportunityDataset() {
                   {paired && (
                     <>
                       <Text
-                        name='latField1'
+                        name='latField2'
                         label={message('analysis.latField')}
                       />
 
                       <Text
-                        name='lonField1'
+                        name='lonField2'
                         label={message('analysis.lonField')}
                       />
                     </>


### PR DESCRIPTION
## Description
Some of the new hidden freeform fields were not sent in the request to the backend. I added them to the form. Also added a "count field" field and changed the names of the paired lat/lon field parameters to latField2 and lonField2 to match the backend.

## How to test
1. Choose a CSV file to upload as an opportunity dataset.
2. Select "freeform" option and in the red boxed hidden fields that appear, enter a specific field name in the CSV containing counts.
3. On upload, check that two datasets are created: one with (freeform) in the name and the other a matching grid.
4. Re-upload the data without specifying a counts column, but with freeform still selected.
5. Check that two datasets are created: one with (freeform) [COUNT] containing all 1s and the other a matching grid.
