### PR TITLE
Add AUTH_DISABLED config option

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -16,6 +16,8 @@ const isAdmin = group => group === process.env.ADMIN_ACCESS_GROUP
 
 // Create a style element that changes the display of elements with the .DEV CSS class
 function showDevFeatures() {
+  if (!process.browser) return
+  // Don't add it twice
   if (document.getElementById('DEVSTYLE')) return
   const styleNode = document.createElement('style')
   styleNode.id = 'DEVSTYLE'
@@ -33,7 +35,8 @@ const clientID = process.env.AUTH0_CLIENT_ID
 const domain = process.env.AUTH0_DOMAIN
 
 // If client & domain exist, then require authentication
-const authIsRequired = process.env.NODE_ENV !== 'test' && !!(clientID && domain)
+const authIsRequired =
+  process.env.NODE_ENV !== 'test' && !process.env.AUTH_DISABLED
 
 // Check if auth result is valid
 const resultIsValid = r => r && r.accessToken && r.idToken
@@ -52,7 +55,10 @@ function setUser(user) {
 // Handle auth
 export async function isAuthenticated(ctx) {
   // Always show dev features in offline mode
-  if (!authIsRequired) return showDevFeatures()
+  if (!authIsRequired) {
+    ctx.store.dispatch(setUser({accessGroup: 'local', email: 'local'}))
+    return showDevFeatures()
+  }
 
   const now = new Date().getTime()
   // Check if a valid user is in the store
@@ -76,7 +82,7 @@ export async function isAuthenticated(ctx) {
     ctx.store.dispatch(setUser({...user, adminTempAccessGroup}))
   }
 
-  if (process.browser && isAdmin(user.accessGroup)) showDevFeatures()
+  if (isAdmin(user.accessGroup)) showDevFeatures()
   return user
 }
 

--- a/next.config.js
+++ b/next.config.js
@@ -17,7 +17,7 @@ const env = {
   LOGROCKET: process.env.LOGROCKET,
   MAPBOX_ACCESS_TOKEN: process.env.MAPBOX_ACCESS_TOKEN
 }
-console.log(env)
+
 module.exports = withMDX(
   withBundleAnalyzer({
     target: 'serverless',

--- a/next.config.js
+++ b/next.config.js
@@ -11,12 +11,13 @@ const webpack = require('webpack')
 const env = {
   ADMIN_ACCESS_GROUP: process.env.ADMIN_ACCESS_GROUP,
   API_URL: process.env.API_URL,
+  AUTH_DISABLED: process.env.AUTH_DISABLED === 'true',
   AUTH0_CLIENT_ID: process.env.AUTH0_CLIENT_ID,
   AUTH0_DOMAIN: process.env.AUTH0_DOMAIN,
   LOGROCKET: process.env.LOGROCKET,
   MAPBOX_ACCESS_TOKEN: process.env.MAPBOX_ACCESS_TOKEN
 }
-
+console.log(env)
 module.exports = withMDX(
   withBundleAnalyzer({
     target: 'serverless',

--- a/now.json
+++ b/now.json
@@ -12,7 +12,7 @@
     "env": {
       "ADMIN_ACCESS_GROUP": "@admin-access-group",
       "API_URL": "@staging-api-url",
-      "AUTH_DISABLED": false,
+      "AUTH_DISABLED": "false",
       "AUTH0_CLIENT_ID": "@auth0-client-id",
       "AUTH0_DOMAIN": "@auth0-domain",
       "LOGROCKET": "@logrocket-staging",

--- a/now.json
+++ b/now.json
@@ -12,6 +12,7 @@
     "env": {
       "ADMIN_ACCESS_GROUP": "@admin-access-group",
       "API_URL": "@staging-api-url",
+      "AUTH_DISABLED": false,
       "AUTH0_CLIENT_ID": "@auth0-client-id",
       "AUTH0_DOMAIN": "@auth0-domain",
       "LOGROCKET": "@logrocket-staging",

--- a/now.production.json
+++ b/now.production.json
@@ -12,7 +12,7 @@
     "env": {
       "ADMIN_ACCESS_GROUP": "@admin-access-group",
       "API_URL": "@api-url",
-      "AUTH_DISABLED": false,
+      "AUTH_DISABLED": "false",
       "AUTH0_CLIENT_ID": "@auth0-client-id",
       "AUTH0_DOMAIN": "@auth0-domain",
       "LOGROCKET": "@logrocket",

--- a/now.production.json
+++ b/now.production.json
@@ -12,6 +12,7 @@
     "env": {
       "ADMIN_ACCESS_GROUP": "@admin-access-group",
       "API_URL": "@api-url",
+      "AUTH_DISABLED": false,
       "AUTH0_CLIENT_ID": "@auth0-client-id",
       "AUTH0_DOMAIN": "@auth0-domain",
       "LOGROCKET": "@logrocket",


### PR DESCRIPTION
Add `AUTH_DISABLED=true` to your `.env.build` to disable auth for local usage.

Recent changes made disabling authentication impossible. When auth is disabled email and accessGroup are both set to `local`. This may cause you to see an empty set of regions.
