### PR TITLE
Fix spinner that was no longer being displayed

### DIFF
--- a/lib/with-initial-fetch.js
+++ b/lib/with-initial-fetch.js
@@ -10,12 +10,10 @@ import getInitialAuth from './get-initial-auth'
 const spinnerStyle = {
   color: '#2389c9',
   fontSize: '36px',
-  left: '0',
-  marginTop: '-18px',
-  position: 'absolute',
+  marginTop: '82px',
   textAlign: 'center',
   top: '50%',
-  right: '0'
+  position: 'relative'
 }
 
 export default function withInitialFetch(Component, initialFetch, opts = {}) {


### PR DESCRIPTION
## Description

The loading spinner was no longer being displayed with updated CSS changes. This PR fixes that.

## How to test

1. Go to a a region.
2. Click on a project. Verify the spinner in the dock is displayed while the page transition is occuring.
