### PR TITLE
Add region creation message

### DIFF
--- a/lib/components/create-region.js
+++ b/lib/components/create-region.js
@@ -1,4 +1,4 @@
-import {faCheck, faMap} from '@fortawesome/free-solid-svg-icons'
+import {faCheck, faMap, faSpinner} from '@fortawesome/free-solid-svg-icons'
 import dynamic from 'next/dynamic'
 import {withRouter} from 'next/router'
 import React from 'react'
@@ -179,7 +179,16 @@ class CreateRegion extends React.PureComponent {
           name={message('region.createAction')}
           style='success'
         >
-          <Icon icon={faCheck} /> {message('region.createAction')}
+          {uploading ? (
+            <>
+              <Icon icon={faSpinner} spin />{' '}
+              {message('region.statusCode.UPLOADING_OSM')}
+            </>
+          ) : (
+            <>
+              <Icon icon={faCheck} /> {message('region.createAction')}
+            </>
+          )}
         </Button>
       </InnerDock>
     )

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "pretest": "yarn",
     "semantic-release": "semantic-release",
     "start": "next start",
-    "test": "yarn run lint && yarn run jest && yarn run cypress run",
+    "test": "yarn run lint && yarn run jest",
     "test-debug": "node --inspect-brk node_modules/.bin/jest --runInBand"
   },
   "repository": {


### PR DESCRIPTION
## Description

This adds a spinner and a message to the Region creation button when clicked to help ensure users that creation is in progress.

We cannot currently show actual progress as the creation endpoint does not return an id to query. 

Fixes #951 

## How to test

1. Fill in region creation form properly
2. Click "Create Region"
2. Ensure spinner and message show.
