### PR TITLE
Fix issue causing half the map not to show

### DIFF
--- a/lib/components/map/index.js
+++ b/lib/components/map/index.js
@@ -35,6 +35,14 @@ export default function Map(p) {
   React.useEffect(() => {
     if (leafletMapRef.current && !routeChanging) {
       leafletMapRef.current.leafletElement.invalidateSize()
+
+      // Delay an additional inalidation to allow for elements to change the
+      // viewport size. This is hacky, but we don't currently have an application
+      // state to indicate that all elements have been drawn.
+      const id = setTimeout(() => {
+        leafletMapRef.current.leafletElement.invalidateSize()
+      }, 100)
+      return () => clearTimeout(id)
     }
   }, [routeChanging, leafletMapRef])
 
@@ -46,7 +54,7 @@ export default function Map(p) {
         setViewport({center: regionBounds.getCenter(), zoom: ZOOM})
       }
     }
-  }, [regionBounds, viewport])
+  }, [leafletMapRef, regionBounds, viewport])
 
   // Set geolocation to users current position on initial use
   useOnMount(() => {


### PR DESCRIPTION
When the page change is complete we invalidate the map to resize it and redraw it. A lot of this is
done automatically by leaflet, but due to the type of elements we use and due to using a mapbox gl
tile layer we need to do it manually. This adds an additional size invalidation after a delay to wait for all other elements to be drawn.

fix #971

## How to test

1. Go to a region. Verify the entire map is shown.
2. Without reloading the page, go to a different region. Verify the new region map is shown.
