### PR TITLE
Fix selected project in Analysis screen

### DIFF
--- a/lib/components/sidebar.js
+++ b/lib/components/sidebar.js
@@ -105,8 +105,8 @@ export default function Sidebar() {
     return React.memo(function ItemLink(p) {
       function goToLink() {
         const {to, ...rest} = p.link
-        const {href, as} = routeTo(to, rest)
-        router.push(href, as)
+        const {href, as, query} = routeTo(to, rest)
+        router.push({pathname: href, query}, as)
       }
 
       const navItemProps = isActive(p.link)

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -23,9 +23,16 @@ const isAdmin = user =>
   user && user.accessGroup === process.env.ADMIN_ACCESS_GROUP
 
 // DEV Bar Style
-function DevBar() {
-  return <Box className='DEV' mt='-4px' />
-}
+const DevBar = () => (
+  <Box
+    className='DEV'
+    mt='-4px'
+    position='absolute'
+    left='0'
+    right='0'
+    zIndex='10000'
+  />
+)
 
 /**
  * Function to check if the path needs the map.


### PR DESCRIPTION
Fixes #941 

## How to test

1. Navigate to a project.
2. Click Analysis in the sidebar. 
3. Ensure the project is preselected in the dropdown.
