### PR TITLE
 Improve text clarity of Add and Copy timetable buttons

### DIFF
--- a/lib/components/modification/timetables.js
+++ b/lib/components/modification/timetables.js
@@ -93,12 +93,12 @@ export default class Timetables extends PureComponent {
         )}
         <P>
           <Button block onClick={this._create} style='success'>
-            <Icon icon={faPlus} /> Add timetable
+            <Icon icon={faPlus} /> Add new timetable
           </Button>
         </P>
         <P>
           <Button block onClick={this._showCopyModal} style='success'>
-            <Icon icon={faCopy} /> Copy timetable
+            <Icon icon={faCopy} /> Copy existing timetable
           </Button>
         </P>
         {timetables.map((tt, i) => (
@@ -119,7 +119,7 @@ export default class Timetables extends PureComponent {
         ))}
         {this.state.showCopyModal && (
           <Modal onRequestClose={this._hideCopyModal}>
-            <ModalTitle>Copy Timetable</ModalTitle>
+            <ModalTitle>Copy Existing Timetable</ModalTitle>
             <CopyTimetable create={this._createFromOther} />
           </Modal>
         )}


### PR DESCRIPTION
<img width="361" alt="Screen Shot 2020-01-16 at 5 30 34 PM" src="https://user-images.githubusercontent.com/776780/72511307-e9a60980-3885-11ea-8f0b-7b2c9c840f0c.png">

fix #822 
