### PR TITLE
Include reroute in modification bounds

### DIFF
--- a/lib/selectors/modification-bounds.js
+++ b/lib/selectors/modification-bounds.js
@@ -1,8 +1,5 @@
 import lonlat from '@conveyal/lonlat'
-import get from 'lodash/get'
 import {createSelector} from 'reselect'
-
-import {ADD_TRIP_PATTERN} from 'lib/constants'
 
 // Can import Leaflet here as this is only used directly on the map
 import Leaflet from 'lib/leaflet'
@@ -14,12 +11,10 @@ export default createSelector(
   selectActiveModification,
   selectRoutePatterns,
   (m, patterns) => {
-    let geometries = []
-    if (get(m, 'type') !== ADD_TRIP_PATTERN) {
-      geometries = patterns.map(p => p.geometry)
-    } else if (get(m, 'segments[0].geometry.type') === 'LineString') {
-      geometries = m.segments.map(s => s.geometry)
-    }
+    const geometries = [
+      ...(m.segments || []).map(s => s.geometry),
+      ...(patterns || []).map(p => p.geometry)
+    ]
     const coords = geometries.reduce(
       (c, g) => c.concat(g.coordinates.map(lonlat.toLeaflet)),
       []

--- a/lib/with-initial-fetch.js
+++ b/lib/with-initial-fetch.js
@@ -50,7 +50,7 @@ export default function withInitialFetch(Component, initialFetch, opts = {}) {
 
     return (
       <div style={{height: size.height || minHeight, minWidth}}>
-        {loading ? <ShowSpinner /> : <div ssr={`${serverRendered}`} />}
+        {loading && <ShowSpinner />}
       </div>
     )
   }


### PR DESCRIPTION
Reroute geometries were excluded from modification bound calculations. This change adds them.

fix #959

## How to test

1. Create a modification of each type, with a selected route or a added geometry
2. Click the "Fit map to extents" button.
3. Ensure the entire modification is now shown on the map.
