### PR TITLE
Use `get` for finding the feed id

### DIFF
--- a/lib/components/modification/list.js
+++ b/lib/components/modification/list.js
@@ -99,27 +99,24 @@ export default function ModificationsList(p) {
     )
   }
 
-  const create = React.useCallback(
-    ({name, type}) => {
-      return dispatch(
-        createModification({
-          feedId: p.feeds[0].id, // default to the first feed
-          name,
-          projectId,
-          type,
-          variants: project.variants.map(() => true)
-        })
-      ).then(m => {
-        const {href, as} = routeTo('modificationEdit', {
-          regionId,
-          projectId,
-          modificationId: m._id
-        })
-        router.push(href, as)
+  function create({name, type}) {
+    return dispatch(
+      createModification({
+        feedId: get(p, 'feeds[0].id'), // default to the first feed
+        name,
+        projectId,
+        type,
+        variants: project.variants.map(() => true)
       })
-    },
-    [dispatch, p.feeds, project, router, projectId, regionId]
-  )
+    ).then(m => {
+      const {href, as} = routeTo('modificationEdit', {
+        regionId,
+        projectId,
+        modificationId: m._id
+      })
+      router.push(href, as)
+    })
+  }
 
   // Render into map
   const {setMapChildren} = p


### PR DESCRIPTION
If a user attempted to create a modification on a slow connection, there is a chance the feeds did
not load yet. Use `get` to prevent an NPE that was being swallowed here. Reported via LogRocket

Discovered here: https://app.logrocket.com/7kj4kr/conveyal-analysis-production/issue/10031519/event/255188332?from=errors

## How to test
On a slow connection...
1. Go to a region
2. Open a project
3. Before the page can fully load the feeds, create a modification