### PR TITLE
Cache the yarn install to speed up Github Actions workflow

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,21 +9,26 @@ jobs:
       - uses: actions/checkout@v2
       - run: yarn install --frozen-lockfile --check-files
 
+      # Install the cypress binary
+      - run: yarn run cypress install
+
+      - id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
       - uses: actions/cache@v1
-        id: cache-build
         with:
-          path: '.'
-          key: ${{ github.sha }}
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ hashFiles('**/yarn.lock') }}
 
   codeLinter:
     runs-on: ubuntu-latest
     needs: install
     steps:
+      - id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
       - uses: actions/cache@v1
-        id: restore-build
         with:
-          path: '.'
-          key: ${{ github.sha }}
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ hashFiles('**/yarn.lock') }}
 
       - run: yarn lint
       - run: yarn check-format
@@ -32,11 +37,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: install
     steps:
+      - id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
       - uses: actions/cache@v1
-        id: restore-build
         with:
-          path: '.'
-          key: ${{ github.sha }}
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ hashFiles('**/yarn.lock') }}
 
       - run: yarn jest
         env:
@@ -46,19 +52,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: install
     steps:
+      - id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
       - uses: actions/cache@v1
-        id: restore-build
         with:
-          path: '.'
-          key: ${{ github.sha }}
-
-      # Install the binary
-      - run: yarn run cypress install
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ hashFiles('**/yarn.lock') }}
 
       # Build then run the next.js server in the background
-      - run: |
-          yarn build
-          yarn start &
+      - run: yarn build
         env:
           API_URL: ${{ secrets.API_URL }}
           AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
@@ -67,10 +69,11 @@ jobs:
 
       - uses: cypress-io/github-action@v1
         with:
+          env: ${{ secrets.CYPRESS_GITHUB_ENV }}
           install: false
+          start: yarn start
           wait-on: 'http://localhost:3000'
           wait-on-timeout: 60
-          env: ${{ secrets.CYPRESS_GITHUB_ENV }}
 
       - uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,4 +1,4 @@
-name: Build, Test, Deploy
+name: Install, Lint, Unit test, Build, Cypress Test
 
 on: [pull_request, push]
 

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,6 +1,6 @@
 name: Build, Test, Deploy
 
-on: [pull_request]
+on: [pull_request, push]
 
 jobs:
   install:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -7,28 +7,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: yarn install --frozen-lockfile --check-files
-
-      # Install the cypress binary
-      - run: yarn run cypress install
-
       - id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
       - uses: actions/cache@v1
+        id: cache
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ hashFiles('**/yarn.lock') }}
-
+          key: yarn-${{ hashFiles('**/yarn.lock') }}
+          
+      - if: steps.cache.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile --check-files
+        
   codeLinter:
     runs-on: ubuntu-latest
     needs: install
     steps:
+      - uses: actions/checkout@v2
       - id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
       - uses: actions/cache@v1
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ hashFiles('**/yarn.lock') }}
+          key: yarn-${{ hashFiles('**/yarn.lock') }}
 
       - run: yarn lint
       - run: yarn check-format
@@ -37,35 +37,56 @@ jobs:
     runs-on: ubuntu-latest
     needs: install
     steps:
+      - uses: actions/checkout@v2
       - id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
       - uses: actions/cache@v1
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ hashFiles('**/yarn.lock') }}
+          key: yarn-${{ hashFiles('**/yarn.lock') }}
 
       - run: yarn jest
         env:
           CI: true
-
-  cypress:
+          
+  nextBuild:
     runs-on: ubuntu-latest
     needs: install
     steps:
+      - uses: actions/checkout@v2
       - id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
       - uses: actions/cache@v1
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ hashFiles('**/yarn.lock') }}
-
-      # Build then run the next.js server in the background
+          key: yarn-${{ hashFiles('**/yarn.lock') }}
+      
+      # Cache the entire working directory
+      - uses: actions/cache@v1
+        with:
+          path: '.'
+          key: ${{ github.sha }}
+        
+      # Build the next.js app
       - run: yarn build
         env:
           API_URL: ${{ secrets.API_URL }}
           AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
           AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
           MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
+          
+      # TODO: Add build stats
+  cypress:
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - uses: actions/cache@v1
+        with:
+          path: '.'
+          key: ${{ github.sha }}
+          
+       # Install the cypress binary
+      - run: yarn run cypress install
 
       - uses: cypress-io/github-action@v1
         with:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -32,7 +32,6 @@ jobs:
           path: '.'
           key: ${{ github.sha }}
 
-      - run: yarn install
       - run: yarn lint
       - run: yarn check-format
 

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -10,13 +10,12 @@ jobs:
       - id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
       - uses: actions/cache@v1
-        id: cache
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          
-      - if: steps.cache.outputs.cache-hit != 'true'
-        run: yarn install --frozen-lockfile --check-files
+        
+      # Should be fast with the yarn cache restored
+      - run: yarn install --frozen-lockfile --check-files
       
       # Cache the entire working directory for subsequent steps
       - uses: actions/cache@v1

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,14 +13,10 @@ jobs:
         id: cache
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-cypress-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
         
       # Should be fast with the yarn cache restored
       - run: yarn install --frozen-lockfile --check-files
-    
-      # Install the cypress binary if the cache hit failed
-      - if: steps.cache.outputs.cache-hit != 'true'
-        run: yarn cypress install
       
       # Cache the entire working directory for subsequent steps
       - uses: actions/cache@v1
@@ -69,6 +65,9 @@ jobs:
           AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
           AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
           MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
+          
+      # Install the cypress binary
+      - run: yarn cypress install
 
       - uses: cypress-io/github-action@v1
         with:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -65,14 +65,11 @@ jobs:
           AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
           AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
           MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
-          
-      # Install the cypress binary
-      - run: yarn cypress install
 
-      - uses: cypress-io/github-action@v1
+      - uses: trevorgerhardt/github-action@patch-1
         with:
           env: ${{ secrets.CYPRESS_GITHUB_ENV }}
-          install: false
+          installDependencies: false
           start: yarn start
           wait-on: 'http://localhost:3000'
           wait-on-timeout: 60

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -66,10 +66,9 @@ jobs:
           AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
           MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
 
-      - uses: trevorgerhardt/github-action@patch-1
+      - uses: cypress-io/github-action@v1
         with:
           env: ${{ secrets.CYPRESS_GITHUB_ENV }}
-          installDependencies: false
           start: yarn start
           wait-on: 'http://localhost:3000'
           wait-on-timeout: 60

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -57,6 +57,15 @@ jobs:
         with:
           path: '.'
           key: ${{ github.sha }}
+          
+      - uses: actions/cache@v1
+        id: cypress-cache
+        with:
+          path: ~/.cache/Cypress
+          key: cypress-${{ hashFiles('**/yarn.lock') }} 
+          
+      - if: steps.cypress-cache.outputs.cache-hit != 'true'
+        run: yarn run cypress install
       
       # Build the next.js app
       - run: yarn build
@@ -69,6 +78,7 @@ jobs:
       - uses: cypress-io/github-action@v1
         with:
           env: ${{ secrets.CYPRESS_GITHUB_ENV }}
+          install: false          
           start: yarn start
           wait-on: 'http://localhost:3000'
           wait-on-timeout: 60

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -17,18 +17,21 @@ jobs:
           
       - if: steps.cache.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile --check-files
+      
+      # Cache the entire working directory for subsequent steps
+      - uses: actions/cache@v1
+        with:
+          path: '.'
+          key: ${{ github.sha }}
         
   codeLinter:
     runs-on: ubuntu-latest
     needs: install
     steps:
-      - uses: actions/checkout@v2
-      - id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
       - uses: actions/cache@v1
         with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: yarn-${{ hashFiles('**/yarn.lock') }}
+          path: '.'
+          key: ${{ github.sha }}
 
       - run: yarn lint
       - run: yarn check-format
@@ -37,45 +40,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: install
     steps:
-      - uses: actions/checkout@v2
-      - id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
       - uses: actions/cache@v1
         with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: yarn-${{ hashFiles('**/yarn.lock') }}
+          path: '.'
+          key: ${{ github.sha }}
 
       - run: yarn jest
         env:
           CI: true
           
-  nextBuild:
-    runs-on: ubuntu-latest
-    needs: install
-    steps:
-      - uses: actions/checkout@v2
-      - id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v1
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: yarn-${{ hashFiles('**/yarn.lock') }}
-      
-      # Cache the entire working directory
-      - uses: actions/cache@v1
-        with:
-          path: '.'
-          key: ${{ github.sha }}
-        
-      # Build the next.js app
-      - run: yarn build
-        env:
-          API_URL: ${{ secrets.API_URL }}
-          AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
-          AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
-          MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
-          
-      # TODO: Add build stats
   cypress:
     runs-on: ubuntu-latest
     needs: install
@@ -84,6 +57,14 @@ jobs:
         with:
           path: '.'
           key: ${{ github.sha }}
+      
+      # Build the next.js app
+      - run: yarn build
+        env:
+          API_URL: ${{ secrets.API_URL }}
+          AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
+          AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
+          MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
           
        # Install the cypress binary
       - run: yarn run cypress install

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -10,12 +10,17 @@ jobs:
       - id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
       - uses: actions/cache@v1
+        id: cache
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-yarn-cypress-${{ hashFiles('**/yarn.lock') }}
         
       # Should be fast with the yarn cache restored
       - run: yarn install --frozen-lockfile --check-files
+    
+      # Install the cypress binary if the cache hit failed
+      - if: steps.cache.outputs.cache-hit != 'true'
+        run: yarn cypress install
       
       # Cache the entire working directory for subsequent steps
       - uses: actions/cache@v1
@@ -64,9 +69,6 @@ jobs:
           AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
           AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
           MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
-          
-       # Install the cypress binary
-      - run: yarn run cypress install
 
       - uses: cypress-io/github-action@v1
         with:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,7 +13,7 @@ jobs:
         id: cache
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
-          key: yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           
       - if: steps.cache.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile --check-files
@@ -33,6 +33,7 @@ jobs:
           path: '.'
           key: ${{ github.sha }}
 
+      - run: yarn install
       - run: yarn lint
       - run: yarn check-format
 

--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,5 @@
+const {PHASE_PRODUCTION_BUILD} = require('next/constants')
+
 const withMDX = require('@zeit/next-mdx')({
   extension: /\.mdx?$/
 })
@@ -22,35 +24,43 @@ const env = {
   MAPBOX_ACCESS_TOKEN: process.env.MAPBOX_ACCESS_TOKEN
 }
 
-if (Object.values(env).findIndex(v => v === undefined || v === null) !== -1) {
-  console.error(
-    'Please ensure required environment variables can be found. If running locally, copy the `.env.build.tmp` to `.env.build` and ensure all variables (' +
-      Object.keys(env).join(', ') +
-      ') are set.'
-  )
-  process.exit(1)
-}
-
-module.exports = withMDX(
-  withBundleAnalyzer({
-    target: 'serverless',
-    pageExtensions: ['js', 'jsx', 'mdx'],
-    env,
-    webpack: config => {
-      // Allow `import 'lib/message'`
-      config.resolve.alias['lib'] = path.join(__dirname, 'lib')
-
-      // ESLint on build
-      config.module.rules.push({
-        test: /\.js$/,
-        loader: 'eslint-loader',
-        exclude: /node_modules/
-      })
-
-      // Ignore moment locales
-      config.plugins.push(new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/))
-
-      return config
+module.exports = phase => {
+  if (phase === PHASE_PRODUCTION_BUILD) {
+    if (
+      Object.values(env).findIndex(v => v === undefined || v === null) !== -1
+    ) {
+      console.error(
+        ```
+Please ensure required environment variables can be found. If running locally,
+copy '.env.build.tmp' to '.env.build' and ensure following variables are set:
+${Object.keys(env).join(', ')}
+```
+      )
+      process.exit(1)
     }
-  })
-)
+  }
+
+  return withMDX(
+    withBundleAnalyzer({
+      target: 'serverless',
+      pageExtensions: ['js', 'jsx', 'mdx'],
+      env,
+      webpack: config => {
+        // Allow `import 'lib/message'`
+        config.resolve.alias['lib'] = path.join(__dirname, 'lib')
+
+        // ESLint on build
+        config.module.rules.push({
+          test: /\.js$/,
+          loader: 'eslint-loader',
+          exclude: /node_modules/
+        })
+
+        // Ignore moment locales
+        config.plugins.push(new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/))
+
+        return config
+      }
+    })
+  )
+}

--- a/next.config.js
+++ b/next.config.js
@@ -14,21 +14,22 @@ if (process.env.API_URL === undefined) {
   require('dotenv').config({path: '.env.build'})
 }
 
+// Add defaults for AUTH0 if auth is disabled
+const AUTH_DISABLED = process.env.AUTH_DISABLED === 'true'
+
 const env = {
   ADMIN_ACCESS_GROUP: process.env.ADMIN_ACCESS_GROUP || 'conveyal',
-  API_URL: process.env.API_URL,
-  AUTH_DISABLED: process.env.AUTH_DISABLED === 'true',
-  AUTH0_CLIENT_ID: process.env.AUTH0_CLIENT_ID,
-  AUTH0_DOMAIN: process.env.AUTH0_DOMAIN,
+  API_URL: process.env.API_URL || 'http://localhost:3000',
+  AUTH_DISABLED,
+  AUTH0_CLIENT_ID: AUTH_DISABLED ? 'unrequired' : process.env.AUTH0_CLIENT_ID,
+  AUTH0_DOMAIN: AUTH_DISABLED ? 'unrequired' : process.env.AUTH0_DOMAIN,
   LOGROCKET: process.env.LOGROCKET || false,
   MAPBOX_ACCESS_TOKEN: process.env.MAPBOX_ACCESS_TOKEN
 }
 
 module.exports = phase => {
   if (phase === PHASE_PRODUCTION_BUILD) {
-    if (
-      Object.values(env).findIndex(v => v === undefined || v === null) !== -1
-    ) {
+    if (Object.values(env).find(v => v === undefined || v === null)) {
       console.error(
         ```
 Please ensure required environment variables can be found. If running locally,

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -69,7 +69,7 @@ export default withRedux(createStore)(
         return {pageProps}
       } catch (e) {
         console.error('Error getting initial props', e)
-        return {error: e}
+        return {error: e, pageProps: {}}
       } finally {
         timeApp.end()
       }


### PR DESCRIPTION
1. Cache yarn install (checking if yarn.lock has changed) to speed up the `install` job of the workflow.
2. Add smart default environment variables (only `MAPBOX_ACCESS_TOKEN` is necessary to start now).
3. Only require environment variables to be set on the build step (they aren't needed for other Next.js phases). This will allow us to further separate out the Next.js build step from the cypress test step in the future. 
