### PR TITLE
Fix bug causing long modification names to change layout 

### DIFF
--- a/lib/components/analysis/__tests__/__snapshots__/title.js.snap
+++ b/lib/components/analysis/__tests__/__snapshots__/title.js.snap
@@ -3,6 +3,11 @@
 exports[`Components > Analysis > Title should render properly given different states 1`] = `
 <div
   className="ApplicationDockTitle"
+  style={
+    Object {
+      "width": "640px",
+    }
+  }
 >
   <div>
     <Icon
@@ -64,6 +69,11 @@ exports[`Components > Analysis > Title should render properly given different st
 exports[`Components > Analysis > Title should render properly given different states 2`] = `
 <div
   className="ApplicationDockTitle"
+  style={
+    Object {
+      "width": "640px",
+    }
+  }
 >
   <div>
     <Icon
@@ -125,6 +135,11 @@ exports[`Components > Analysis > Title should render properly given different st
 exports[`Components > Analysis > Title should render properly given different states 3`] = `
 <div
   className="ApplicationDockTitle"
+  style={
+    Object {
+      "width": "640px",
+    }
+  }
 >
   <div>
     <Icon
@@ -186,6 +201,11 @@ exports[`Components > Analysis > Title should render properly given different st
 exports[`Components > Analysis > Title should render properly given different states 4`] = `
 <div
   className="ApplicationDockTitle"
+  style={
+    Object {
+      "width": "640px",
+    }
+  }
 >
   <div>
     <Icon

--- a/lib/components/analysis/title.js
+++ b/lib/components/analysis/title.js
@@ -14,7 +14,7 @@ import Icon from '../icon'
 export default function AnalysisTitle(p) {
   const isFetchingIsochrone = !!p.isochroneFetchStatus
   return (
-    <div className='ApplicationDockTitle'>
+    <div className='ApplicationDockTitle' style={{width: '640px'}}>
       <div>
         <Icon icon={faChartArea} />{' '}
         {isFetchingIsochrone ? p.isochroneFetchStatus : 'Analysis'}

--- a/lib/components/modification/__tests__/__snapshots__/editor.js.snap
+++ b/lib/components/modification/__tests__/__snapshots__/editor.js.snap
@@ -5,7 +5,9 @@ exports[`Components > Modification > Editor should render and execute functions 
   <div
     className="ApplicationDockTitle"
   >
-    <div>
+    <div
+      className=""
+    >
       <IconTip
         icon={
           Object {

--- a/lib/components/modification/editor.js
+++ b/lib/components/modification/editor.js
@@ -189,14 +189,12 @@ export default class ModificationEditor extends React.PureComponent {
     const showDescription =
       s.showDescription || get(modification, 'description')
     const {showEditName} = this.state
-    const title = p.saveInProgress
-      ? 'Saving...'
-      : get(modification, 'name', 'Loading...')
+    const title = get(modification, 'name', 'Loading...')
     const disableAndDim = `block ${p.saveInProgress ? 'disableAndDim' : ''}`
     return (
       <>
         <div className='ApplicationDockTitle'>
-          <div>
+          <div className={p.saveInProgress ? 'disableAndDim' : ''}>
             <IconTip
               tip='Modifications'
               link={{

--- a/lib/containers/__tests__/__snapshots__/single-point-analysis.js.snap
+++ b/lib/containers/__tests__/__snapshots__/single-point-analysis.js.snap
@@ -206,6 +206,11 @@ exports[`constainers/single-point-analysis 1`] = `
     >
       <div
         className="ApplicationDockTitle"
+        style={
+          Object {
+            "width": "640px",
+          }
+        }
       >
         <div>
           <Icon

--- a/styles.css
+++ b/styles.css
@@ -25,6 +25,11 @@ body,
   outline-offset: 4px;
 }
 
+.disableAndDim {
+  opacity: 0.4;
+  pointer-events: none;
+}
+
 .monospace {
   font-family: monospace;
   font-size: 12px;

--- a/styles.css
+++ b/styles.css
@@ -224,6 +224,7 @@ input[type='range'].form-control {
   align-items: center;
   display: flex;
   justify-content: space-between;
+  width: var(--dock-width);
 }
 
 .ApplicationDockTitle .btn {


### PR DESCRIPTION
see #1013

This also re-enables `disableAndDim`