### PR TITLE
Decrease polling delays

### DIFF
--- a/lib/actions/analysis/index.js
+++ b/lib/actions/analysis/index.js
@@ -108,7 +108,7 @@ export const fetchTravelTimeSurface = asGeoTIFF => (dispatch, getState) => {
         } else {
           // Wait `seconds` and try again
           setTimeout(() => {
-            if (seconds < 10) seconds *= 2
+            if (seconds < 10) seconds += 1
             resolve(true)
           }, seconds * 1000)
         }

--- a/lib/actions/analysis/index.js
+++ b/lib/actions/analysis/index.js
@@ -89,6 +89,7 @@ export const fetchTravelTimeSurface = asGeoTIFF => (dispatch, getState) => {
   // Double the retry time until it hits 20 seconds
   const initializingMsg = message('analysis.fetchStatus.INITIALIZING_CLUSTER')
   const createRetry = () => {
+    let retryCount = 0
     let seconds = 1
     return response =>
       new Promise(resolve => {
@@ -98,11 +99,19 @@ export const fetchTravelTimeSurface = asGeoTIFF => (dispatch, getState) => {
         const status = get(response, 'value.message', initializingMsg)
         dispatch(setIsochroneFetchStatus(status))
 
-        // Wait `seconds` and try again
-        setTimeout(() => {
-          if (seconds < 20) seconds *= 2
-          resolve(true)
-        }, seconds * 1000)
+        // First ten times, wait one second
+        if (retryCount < 10) {
+          setTimeout(() => {
+            retryCount++
+            resolve(true)
+          }, seconds * 1000)
+        } else {
+          // Wait `seconds` and try again
+          setTimeout(() => {
+            if (seconds < 10) seconds *= 2
+            resolve(true)
+          }, seconds * 1000)
+        }
       })
   }
 

--- a/lib/components/analysis/regional-results-list.js
+++ b/lib/components/analysis/regional-results-list.js
@@ -17,7 +17,7 @@ import InnerDock from '../inner-dock'
 
 import Selector from './regional-analysis-selector'
 
-const REFETCH_INTERVAL = 60 * 1000 // 60 seconds
+const REFETCH_INTERVAL = 15 * 1000 // 60 seconds
 
 export default function RegionalAnalysisResultsList(p) {
   const dispatch = useDispatch()

--- a/lib/components/analysis/regional-results-list.js
+++ b/lib/components/analysis/regional-results-list.js
@@ -17,7 +17,7 @@ import InnerDock from '../inner-dock'
 
 import Selector from './regional-analysis-selector'
 
-const REFETCH_INTERVAL = 15 * 1000 // 60 seconds
+const REFETCH_INTERVAL = 15 * 1000 // 15 seconds
 
 export default function RegionalAnalysisResultsList(p) {
   const dispatch = useDispatch()


### PR DESCRIPTION
Perceived speed of single point and regional analyses is drastically reduced due to how we poll. Currently we poll 1 second * the retry count (up to 20 seconds) for single point analyses. For regional we poll every minute. Since we implemented these delays the system has become more robust. This PR changes the single point to delay for one second after the first 10 tries and then increase the delay up to 10 seconds after. It also decreases the regional polling delay to 15 seconds.

## How to test

1. Ensure no errors while running a single point request
2. Ensure no errors while running a regional analysis
