### PR TITLE
Add Navigation bar to top of the application

### DIFF
--- a/lib/components/select-project.js
+++ b/lib/components/select-project.js
@@ -2,7 +2,6 @@ import {Box, Stack} from '@chakra-ui/core'
 import {
   faDatabase,
   faCube,
-  faMap,
   faPlus,
   faSpinner
 } from '@fortawesome/free-solid-svg-icons'
@@ -40,11 +39,6 @@ export default function SelectProject(p) {
   const statusCode = get(p, 'region.statusCode')
   return (
     <InnerDock className='block'>
-      <legend>
-        <span>
-          <Icon icon={faMap} /> {p.region.name}
-        </span>
-      </legend>
       {statusCode && <Status code={statusCode} />}
 
       <Group>

--- a/lib/components/sidebar.js
+++ b/lib/components/sidebar.js
@@ -134,25 +134,8 @@ export default function Sidebar() {
       width='40px'
     >
       <div>
-        <Box fontSize='20px' py={10} textAlign='center' width='40px'>
-          <LogoSpinner routeChanging={routeChanging} />
-        </Box>
-
-        <ItemLink
-          icon={faGlobe}
-          label={message('nav.regions')}
-          link={{to: 'regions'}}
-        />
         {regionId && regionId !== CREATING_ID && (
           <>
-            <ItemLink
-              icon={faMap}
-              label={message('nav.regionSettings')}
-              link={{
-                to: 'regionSettings',
-                regionId
-              }}
-            />
             <ItemLink
               icon={faCubes}
               label={message('nav.projects')}
@@ -218,23 +201,6 @@ export default function Sidebar() {
       </div>
 
       <div>
-        {username && (
-          <ItemLink
-            icon={faSignOutAlt}
-            label={
-              message('authentication.logOut') +
-              ' - ' +
-              message('authentication.username', {username: username})
-            }
-            link={{to: 'logout'}}
-          />
-        )}
-        <ExternalLink
-          icon={faQuestionCircle}
-          label={message('nav.help')}
-          href='http://docs.analysis.conveyal.com/'
-        />
-
         <ErrorTip />
         <OnlineIndicator />
       </div>

--- a/lib/components/topbar.js
+++ b/lib/components/topbar.js
@@ -1,0 +1,70 @@
+import {Box, Flex, Heading, Image, Stack} from '@chakra-ui/core'
+import {
+  faChevronRight,
+  faQuestionCircle,
+  faSignOutAlt
+} from '@fortawesome/free-solid-svg-icons'
+import Link from 'next/link'
+import React from 'react'
+import {useSelector} from 'react-redux'
+
+import Icon from 'lib/components/icon'
+import selectRegion from 'lib/selectors/current-region'
+
+const height = 42
+
+export default function Topbar(p) {
+  const region = useSelector(selectRegion)
+
+  return (
+    <Flex
+      backgroundColor='gray.900'
+      color='#fff'
+      fontWeight={700}
+      height={height + 'px'}
+      justify='space-between'
+    >
+      <Flex align='center' height='100%'>
+        <Image
+          backgroundColor='#fff'
+          borderRadius='100%'
+          display='inline-block'
+          mx='10px'
+          size={height / 2 + 'px'}
+          src='/logo.svg'
+        />
+        <Stack align='center' height='100%' isInline ml='10px' spacing={1}>
+          <Box>
+            <Link href='/'>
+              <a>Regions</a>
+            </Link>
+          </Box>
+          {region && (
+            <>
+              <Box opacity={0.5} mb='-4px'>
+                <Icon icon={faChevronRight} />
+              </Box>
+              <Box>{region.name}</Box>
+            </>
+          )}
+        </Stack>
+      </Flex>
+      <Stack align='center' height='100%' isInline pr='10px' spacing={2}>
+        <Box>
+          <a href='https://docs.analysis.conveyal.com'>
+            <Box px='5px'>
+              <Icon icon={faQuestionCircle} /> User Manual
+            </Box>
+          </a>
+        </Box>
+        <Box>
+          <a href='https://docs.analysis.conveyal.com'>
+            <Box px='5px'>
+              <Icon icon={faSignOutAlt} /> Log out
+            </Box>
+          </a>
+        </Box>
+      </Stack>
+    </Flex>
+  )
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -19,6 +19,7 @@ import '../styles.css'
 const ErrorModal = dynamic(() => import('lib/components/error-modal'))
 const Map = dynamic(() => import('lib/components/map'), {ssr: false})
 const Sidebar = dynamic(() => import('lib/components/sidebar'))
+const Topbar = dynamic(() => import('lib/components/topbar'))
 
 // Check if the passed in group matches the environment variable
 const isAdmin = user =>
@@ -116,30 +117,33 @@ function ComponentWithMap(p) {
   return (
     <State initialState={noopFragment}>
       {(mapChildren, setMapChildren) => (
-        <Flex pointerEvents={routeChanging ? 'none' : 'inherit'}>
-          <style jsx global>{`
-            body {
-              height: 100vh;
-              overflow: hidden;
-              width: 100vw;
-            }
-          `}</style>
-          <Sidebar />
-          <Box
-            borderRight='1px solid #ddd'
-            bg='#fff'
-            opacity={routeChanging ? 0.4 : 1}
-          >
-            <p.Component {...p.pageProps} setMapChildren={setMapChildren} />
-          </Box>
-          <Box
-            flexGrow='1'
-            opacity={routeChanging ? 0.4 : 1}
-            position='relative'
-          >
-            <Map>{mapChildren}</Map>
-          </Box>
-        </Flex>
+        <>
+          <Topbar />
+          <Flex pointerEvents={routeChanging ? 'none' : 'inherit'}>
+            <style jsx global>{`
+              body {
+                height: 100vh;
+                overflow: hidden;
+                width: 100vw;
+              }
+            `}</style>
+            <Sidebar />
+            <Box
+              borderRight='1px solid #ddd'
+              bg='#fff'
+              opacity={routeChanging ? 0.4 : 1}
+            >
+              <p.Component {...p.pageProps} setMapChildren={setMapChildren} />
+            </Box>
+            <Box
+              flexGrow='1'
+              opacity={routeChanging ? 0.4 : 1}
+              position='relative'
+            >
+              <Map>{mapChildren}</Map>
+            </Box>
+          </Flex>
+        </>
       )}
     </State>
   )


### PR DESCRIPTION
This PR adds a persistent navigation bar to the top of the screen. Items moved from the side bar include the logo/activity spinner, "Regions" button, "Region Settings" button, documentation link, log out link, error message button, and wifi status indicator.
