### PR TITLE
Ensure auth is provided to the OD upload page

### DIFF
--- a/pages/regions/[regionId]/opportunities/upload.js
+++ b/pages/regions/[regionId]/opportunities/upload.js
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import getInitialAuth from 'lib/get-initial-auth'
 import Heading from 'lib/modules/opportunity-datasets/components/heading'
 import Upload from 'lib/modules/opportunity-datasets/components/upload'
 
@@ -10,3 +11,5 @@ export default function OpportunitiesUpload(p) {
     </Heading>
   )
 }
+
+OpportunitiesUpload.getInitialProps = getInitialAuth


### PR DESCRIPTION
Auth is needed to determine if DEV mode is enabled.

Fixes #1044 

### How to test
See attached issue
