### PR TITLE
Format stack traces shown for shapefile upload errors

### DIFF
--- a/lib/modules/opportunity-datasets/components/status.js
+++ b/lib/modules/opportunity-datasets/components/status.js
@@ -50,7 +50,9 @@ export default function Status(p) {
           })}
         </P>
       )}
-      {p.message && p.message.length > 0 && <P>{p.message}</P>}
+      <div className='upload-error'>
+        {p.message && p.message.length > 0 && <P>{p.message}</P>}
+      </div>
     </div>
   )
 }

--- a/styles.css
+++ b/styles.css
@@ -159,6 +159,11 @@ input[type='range'].form-control {
   margin-bottom: 0;
 }
 
+.alert .upload-error p {
+  word-wrap: break-word;
+  white-space: pre-wrap;
+}
+
 .InputWithUnits {
   position: relative;
 }


### PR DESCRIPTION
## Description

Currently, the exceptions that bubble up from shapefile uploads look a bit ragged:
![image](https://user-images.githubusercontent.com/2173529/75496055-1d4c7700-598e-11ea-9e1e-0cb9b1e6defd.png)


This PR adds some CSS to clean that up:
![image](https://user-images.githubusercontent.com/2173529/75496079-2c332980-598e-11ea-8a3f-cfeda498ebd3.png)


## How to test

1. Try uploading a problematic shapefile (e.g. the one with topology errors [here](https://www.dropbox.com/sh/zznknms3dcvmlju/AADzJzm5vWKkS9avxgt66JmKa?dl=0))
