### PR TITLE
Handle error caused by GTFS stops without coordinates

### DIFF
--- a/lib/components/modifications-map/gtfs-stop-gridlayer.js
+++ b/lib/components/modifications-map/gtfs-stop-gridlayer.js
@@ -7,6 +7,14 @@ import getStopRadius from 'lib/utils/get-stop-radius'
 
 const TZ = 256 // size of a tile
 
+// Limit errors shown
+let errorsLeft = 5
+function consoleError(...args) {
+  if (--errorsLeft > 0) {
+    console.error(...args)
+  }
+}
+
 /**
  * An optimized layer for drawing stops rapidly, adapted from
  * https://github.com/conveyal/leaflet-transit-editor/blob/master/lib/stop-layer.js
@@ -35,6 +43,7 @@ export default withLeaflet(GTFSStopGridLayer)
  * Generate the GridLayer.createTile function with the component props.
  */
 function createCreateTile(props) {
+  const validStops = props.filter(s => s.stop_lat && s.stop_lon)
   return function createTile(coords) {
     const canvas = document.createElement('canvas')
     canvas.width = canvas.height = TZ
@@ -42,7 +51,7 @@ function createCreateTile(props) {
     if (coords.z >= MINIMUM_SNAP_STOP_ZOOM_LEVEL && ctx) {
       ctx.strokeStyle = colors.NEUTRAL
       const SR = (getStopRadius(coords.z) * 2) / 3 // 2/3rds normal stops
-      drawStopsInTile(props.stops, coords, coords.z, s => {
+      drawStopsInTile(validStops, coords, coords.z, s => {
         const offset = SR / 2
         ctx.beginPath()
         // In the current tile, so modulo by the tile size and center it
@@ -68,12 +77,16 @@ export function drawStopsInTile(stops, tile, z, draw) {
 
   for (const stop of stops) {
     const sp = stopToPixel(stop, z)
-    if (stopInTile(sp, tileBounds)) draw(sp)
+    if (sp && stopInTile(sp, tileBounds)) draw(sp)
   }
 }
 
 export function stopToPixel(stop, z) {
-  return lonlat.toPixel([stop.stop_lon, stop.stop_lat], z)
+  try {
+    return lonlat.toPixel([stop.stop_lon, stop.stop_lat], z)
+  } catch (e) {
+    consoleError(e)
+  }
 }
 
 /**

--- a/lib/components/modifications-map/gtfs-stop-gridlayer.js
+++ b/lib/components/modifications-map/gtfs-stop-gridlayer.js
@@ -3,17 +3,13 @@ import {GridLayer, withLeaflet} from 'react-leaflet'
 
 import {MINIMUM_SNAP_STOP_ZOOM_LEVEL} from 'lib/constants'
 import colors from 'lib/constants/colors'
+import createLogError from 'lib/utils/log-error'
 import getStopRadius from 'lib/utils/get-stop-radius'
 
 const TZ = 256 // size of a tile
 
 // Limit errors shown
-let errorsLeft = 5
-function consoleError(...args) {
-  if (--errorsLeft > 0) {
-    console.error(...args)
-  }
-}
+const logError = createLogError()
 
 /**
  * An optimized layer for drawing stops rapidly, adapted from
@@ -43,7 +39,7 @@ export default withLeaflet(GTFSStopGridLayer)
  * Generate the GridLayer.createTile function with the component props.
  */
 function createCreateTile(props) {
-  const validStops = props.filter(s => s.stop_lat && s.stop_lon)
+  const validStops = props.stops.filter(s => s.stop_lat && s.stop_lon)
   return function createTile(coords) {
     const canvas = document.createElement('canvas')
     canvas.width = canvas.height = TZ
@@ -85,7 +81,7 @@ export function stopToPixel(stop, z) {
   try {
     return lonlat.toPixel([stop.stop_lon, stop.stop_lat], z)
   } catch (e) {
-    consoleError(e)
+    logError(e)
   }
 }
 

--- a/lib/utils/log-error.js
+++ b/lib/utils/log-error.js
@@ -1,0 +1,9 @@
+// Set a limit for logging errors so that we can log high usage functions that
+// would usually slow the application down from too much I/O
+export default function createLogError(maxLimit = 50, delayMs = 1) {
+  return function logError(...args) {
+    if (--maxLimit > 0) {
+      setTimeout(() => console.error(...args), delayMs)
+    }
+  }
+}


### PR DESCRIPTION
## Description

Valid GTFS stops have a lat/lon. Some invalid GTFS stops are uploaded by our system causing the GTFS stop display to break. This PR handles that error.

Fixes #1052

## How to test

1. Go to a project that uses the GTFS in the attached issue.
2. Ensure that a reroute modification does not show a white screen while editing geometry.

