### PR TITLE
Template OSM crop/filter commands

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -124,6 +124,8 @@
     "boundsNotice": "Bounds are snapped to points on our regular grid.",
     "updatesDisabled": "OSM updates have been temporarily disabled and will be moved to the bundle management page.",
     "r5Version": "Analysis backend version",
+    "osmConvertCommand": "osmconvert file.pbf -b=\"%(west), %(south), %(east), %(north)\" --complete-ways -o=file-cropped.pbf",
+    "osmosisCommand": "osmosis --read-pbf file.pbf --bounding-box left=%(west) bottom=%(south) right=%(east) top=%(north) --tf accept-ways highway=* public_transport=platform railway=platform par_ride=* --tf accept-relations type=restriction --used-node --write-pbf file-cropped.pbf",
     "statusCode": {
       "STARTED": "Setting up region…",
       "UPLOADING_OSM": "Uploading OpenStreetMap data…",

--- a/lib/components/create-region.js
+++ b/lib/components/create-region.js
@@ -7,7 +7,7 @@ import {
   Input,
   Stack
 } from '@chakra-ui/core'
-import {faMap} from '@fortawesome/free-solid-svg-icons'
+import {faMap, faInfoCircle} from '@fortawesome/free-solid-svg-icons'
 import dynamic from 'next/dynamic'
 import {withRouter} from 'next/router'
 import React from 'react'
@@ -21,6 +21,8 @@ import {routeTo} from 'lib/router'
 import EditBoundsForm from './edit-bounds-form'
 import Icon from './icon'
 import InnerDock from './inner-dock'
+
+import A from './a'
 
 const EditBounds = dynamic(() => import('./map/edit-bounds'), {ssr: false})
 
@@ -120,9 +122,46 @@ function CreateRegion(p) {
           onChange={(d, v) => setBounds(b => ({...b, [d]: v}))}
         />
 
-        <Heading size='sm'>osmconvert crop command</Heading>
+        <Heading size='sm'>
+          Crop with osmconvert
+          <A
+            href='http://docs.analysis.conveyal.com/en/latest/prepare-inputs/index.html#preparing-the-osm-data'
+            rel='noopener noreferrer'
+            target='_blank'
+          >
+            <Icon icon={faInfoCircle} />
+          </A>
+        </Heading>
         <Alert status='info'>
-          {`osmconvert [file].pbf -b="${bounds.west}, ${bounds.south}, ${bounds.east}, ${bounds.north}" --complete-ways -o=[file]-cropped.pbf`}
+          <div className='all-copy'>
+            {message('region.osmConvertCommand', {
+              north: bounds.north,
+              south: bounds.south,
+              east: bounds.east,
+              west: bounds.west
+            })}
+          </div>
+        </Alert>
+
+        <Heading size='sm'>
+          Crop and filter with osmosis
+          <A
+            href='http://docs.analysis.conveyal.com/en/latest/prepare-inputs/index.html#preparing-the-osm-data'
+            rel='noopener noreferrer'
+            target='_blank'
+          >
+            <Icon icon={faInfoCircle} />
+          </A>
+        </Heading>
+        <Alert status='info'>
+          <div className='all-copy'>
+            {message('region.osmosisCommand', {
+              north: bounds.north,
+              south: bounds.south,
+              east: bounds.east,
+              west: bounds.west
+            })}
+          </div>
         </Alert>
 
         <FormControl isDisabled={uploading} isRequired>

--- a/lib/components/edit-bounds-form.js
+++ b/lib/components/edit-bounds-form.js
@@ -10,9 +10,12 @@ import {
 import startCase from 'lodash/startCase'
 import React from 'react'
 
+import {faInfoCircle} from '@fortawesome/free-solid-svg-icons'
+
 import {SPACING_FORM} from 'lib/constants/chakra'
 import message from 'lib/message'
 
+import Icon from './icon'
 import A from './a'
 
 const directions = [
@@ -77,7 +80,7 @@ export default function EditBoundsForm(p) {
           rel='noopener noreferrer'
           target='_blank'
         >
-          Learn more about spatial resolution here.
+          <Icon icon={faInfoCircle} />
         </A>
       </Text>
       {directions.map(d => (


### PR DESCRIPTION
This PR cleans up the template OSM prep commands, and adds a template for osmosis, which should save advanced users a few seconds when setting up new regions.

Also, added/replaced links to the user manual with consistent ℹ icons.

I expect this will conflict with some of the osm creation pages.  These template commands should be copied over to the region settings page (and maybe removed from the region creation page?)