### PR TITLE
Delete region locally before sending

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -73,7 +73,7 @@
       "title": "GTFS",
       "description": "Reuse existing GTFS from other bundles or upload new GTFS.",
       "existingTitle": "Reuse existing GTFS",
-      "existingLabel": "Select existing Network Bundle to reuse OSM from.",
+      "existingLabel": "Select existing Network Bundle to reuse GTFS from.",
       "existingPlaceholder": "Select a Network Bundle",
       "uploadNewTitle": "Upload new GTFS",
       "uploadNewLabel": "Select one or more .zip files containing valid GTFS"

--- a/lib/actions/__tests__/region.js
+++ b/lib/actions/__tests__/region.js
@@ -15,7 +15,7 @@ test('region.create', () => {
 
   const store = makeMockStore()
   return store.dispatch(region.create(mockRegion)).then(r => {
-    expect(store.getActions()).toHaveLength(3)
+    expect(store.getActions()).toHaveLength(2)
     expect(r).toEqual(mockRegion)
   })
 })
@@ -86,6 +86,6 @@ test('region.save', async () => {
   const store = makeMockStore()
   return store.dispatch(region.save(mockRegion)).then(r => {
     expect(r).toEqual(mockRegion)
-    expect(store.getActions()).toHaveLength(3)
+    expect(store.getActions()).toHaveLength(2)
   })
 })

--- a/lib/actions/region.js
+++ b/lib/actions/region.js
@@ -34,14 +34,18 @@ export const save = region =>
   })
 
 export const deleteLocally = createAction('delete region')
-export const deleteRegion = _id =>
-  fetch({
-    options: {
-      method: 'delete'
-    },
-    url: `${API.Region}/${_id}`,
-    next: () => deleteLocally(_id)
-  })
+export const deleteRegion = _id => dispatch => {
+  dispatch(deleteLocally(_id))
+
+  return dispatch(
+    fetch({
+      options: {
+        method: 'delete'
+      },
+      url: `${API.Region}/${_id}`
+    })
+  )
+}
 
 export const loadRegion = id =>
   fetch({

--- a/lib/actions/region.js
+++ b/lib/actions/region.js
@@ -1,15 +1,12 @@
 import {createAction} from 'redux-actions'
 
 import {API} from 'lib/constants'
-import timeout from 'lib/utils/timeout'
 
 import fetch from './fetch'
 import {loadProjects} from './project'
 import {loadProfileRequestSettings} from './analysis/profile-request'
 
 import {loadBundles} from './'
-
-const CHECK_STATUS_TIMEOUT = 10 * 1000
 
 export const clear = createAction('clear current region')
 
@@ -19,8 +16,7 @@ export const create = formData =>
     options: {
       body: formData,
       method: 'post'
-    },
-    next: response => checkLoadStatus(response.value)
+    }
   })
 
 export const save = region =>
@@ -29,8 +25,7 @@ export const save = region =>
     options: {
       body: region,
       method: 'put'
-    },
-    next: response => checkLoadStatus(response.value)
+    }
   })
 
 export const deleteLocally = createAction('delete region')
@@ -67,24 +62,6 @@ export const load = id => async dispatch => {
   dispatch(loadProfileRequestSettings(id))
 
   return {bundles, projects, region}
-}
-
-const checkLoadStatus = region => async dispatch => {
-  if (region.statusCode === 'DONE') return dispatch(loadRegion(region._id))
-
-  // Set locally
-  dispatch(setLocally(region))
-  if (region.statusCode === 'ERROR') return
-
-  // Wait, then fetch and check again
-  await timeout(CHECK_STATUS_TIMEOUT)
-
-  return dispatch(
-    fetch({
-      url: `${API.Region}/${region._id}`,
-      next: r => checkLoadStatus(r.value)
-    })
-  )
 }
 
 export const loadAll = () =>

--- a/lib/components/__tests__/__snapshots__/edit-region.js.snap
+++ b/lib/components/__tests__/__snapshots__/edit-region.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Component > EditRegion 1`] = `
-<Memo(ConnectedEditRegion)
+<ConnectedEditRegion
   region={
     Object {
       "_id": "1",
@@ -1500,5 +1500,5 @@ exports[`Component > EditRegion 1`] = `
       </div>
     </InnerDock>
   </EditRegion>
-</Memo(ConnectedEditRegion)>
+</ConnectedEditRegion>
 `;

--- a/lib/components/__tests__/__snapshots__/edit-region.js.snap
+++ b/lib/components/__tests__/__snapshots__/edit-region.js.snap
@@ -1347,119 +1347,152 @@ exports[`Component > EditRegion 1`] = `
                     </button>
                   </PseudoBox>
                 </Button>
-                <Button
+                <ConfirmButton
+                  action="DANGER! Delete this region"
                   block={true}
+                  description="Are you sure you would like to delete this region? This will delete all associated projects and modifications."
                   key=".5"
                   leftIcon="delete"
                   mb={null}
-                  onClick={[Function]}
+                  onConfirm={[Function]}
                   size="lg"
                   variantColor="red"
                 >
-                  <PseudoBox
-                    _active={
-                      Object {
-                        "bg": "red.700",
-                      }
-                    }
-                    _disabled={
-                      Object {
-                        "boxShadow": "none",
-                        "cursor": "not-allowed",
-                        "opacity": "40%",
-                      }
-                    }
-                    _focus={
-                      Object {
-                        "boxShadow": "outline",
-                      }
-                    }
-                    _hover={
-                      Object {
-                        "bg": "red.600",
-                      }
-                    }
-                    alignItems="center"
-                    appearance="none"
-                    as="button"
-                    bg="red.500"
+                  <Button
                     block={true}
-                    borderRadius="md"
-                    color="white"
-                    display="inline-flex"
-                    fontSize="lg"
-                    fontWeight="semibold"
-                    height={12}
-                    justifyContent="center"
-                    lineHeight="1.2"
+                    leftIcon="delete"
                     mb={null}
-                    minWidth={12}
                     onClick={[Function]}
-                    outline="none"
-                    position="relative"
-                    px={6}
-                    transition="all 250ms"
-                    type="button"
-                    userSelect="none"
-                    verticalAlign="middle"
-                    whiteSpace="nowrap"
+                    size="lg"
+                    variantColor="red"
                   >
-                    <button
-                      className="css-1sjt7cz"
+                    <PseudoBox
+                      _active={
+                        Object {
+                          "bg": "red.700",
+                        }
+                      }
+                      _disabled={
+                        Object {
+                          "boxShadow": "none",
+                          "cursor": "not-allowed",
+                          "opacity": "40%",
+                        }
+                      }
+                      _focus={
+                        Object {
+                          "boxShadow": "outline",
+                        }
+                      }
+                      _hover={
+                        Object {
+                          "bg": "red.600",
+                        }
+                      }
+                      alignItems="center"
+                      appearance="none"
+                      as="button"
+                      bg="red.500"
+                      block={true}
+                      borderRadius="md"
+                      color="white"
+                      display="inline-flex"
+                      fontSize="lg"
+                      fontWeight="semibold"
+                      height={12}
+                      justifyContent="center"
+                      lineHeight="1.2"
+                      mb={null}
+                      minWidth={12}
                       onClick={[Function]}
+                      outline="none"
+                      position="relative"
+                      px={6}
+                      transition="all 250ms"
                       type="button"
+                      userSelect="none"
+                      verticalAlign="middle"
+                      whiteSpace="nowrap"
                     >
-                      <ButtonIcon
-                        icon="delete"
-                        ml={-1}
-                        mr={2}
+                      <button
+                        className="css-1sjt7cz"
+                        onClick={[Function]}
+                        type="button"
                       >
-                        <Icon
-                          aria-hidden="true"
-                          color="currentColor"
-                          focusable="false"
+                        <ButtonIcon
+                          icon="delete"
                           ml={-1}
                           mr={2}
-                          name="delete"
                         >
-                          <Styled(div)
+                          <Icon
                             aria-hidden="true"
-                            as="svg"
                             color="currentColor"
-                            display="inline-block"
                             focusable="false"
                             ml={-1}
                             mr={2}
-                            role="presentation"
-                            size="1em"
-                            verticalAlign="middle"
-                            viewBox="0 0 24 24"
+                            name="delete"
                           >
-                            <svg
+                            <Styled(div)
                               aria-hidden="true"
-                              className="css-yxiis9"
+                              as="svg"
+                              color="currentColor"
+                              display="inline-block"
                               focusable="false"
+                              ml={-1}
+                              mr={2}
                               role="presentation"
+                              size="1em"
+                              verticalAlign="middle"
                               viewBox="0 0 24 24"
                             >
-                              <g
-                                fill="currentColor"
+                              <svg
+                                aria-hidden="true"
+                                className="css-yxiis9"
+                                focusable="false"
+                                role="presentation"
+                                viewBox="0 0 24 24"
                               >
-                                <path
-                                  d="M19.452,7.5H4.547a.5.5,0,0,0-.5.545L5.334,22.181A2,2,0,0,0,7.326,24h9.347a2,2,0,0,0,1.992-1.819L19.95,8.045a.5.5,0,0,0-.129-.382A.5.5,0,0,0,19.452,7.5Zm-9.2,13a.75.75,0,0,1-1.5,0v-9a.75.75,0,0,1,1.5,0Zm5,0a.75.75,0,0,1-1.5,0v-9a.75.75,0,0,1,1.5,0Z"
-                                />
-                                <path
-                                  d="M22,4H17.25A.25.25,0,0,1,17,3.75V2.5A2.5,2.5,0,0,0,14.5,0h-5A2.5,2.5,0,0,0,7,2.5V3.75A.25.25,0,0,1,6.75,4H2A1,1,0,0,0,2,6H22a1,1,0,0,0,0-2ZM9,3.75V2.5A.5.5,0,0,1,9.5,2h5a.5.5,0,0,1,.5.5V3.75a.25.25,0,0,1-.25.25H9.25A.25.25,0,0,1,9,3.75Z"
-                                />
-                              </g>
-                            </svg>
-                          </Styled(div)>
-                        </Icon>
-                      </ButtonIcon>
-                      DANGER! Delete this region
-                    </button>
-                  </PseudoBox>
-                </Button>
+                                <g
+                                  fill="currentColor"
+                                >
+                                  <path
+                                    d="M19.452,7.5H4.547a.5.5,0,0,0-.5.545L5.334,22.181A2,2,0,0,0,7.326,24h9.347a2,2,0,0,0,1.992-1.819L19.95,8.045a.5.5,0,0,0-.129-.382A.5.5,0,0,0,19.452,7.5Zm-9.2,13a.75.75,0,0,1-1.5,0v-9a.75.75,0,0,1,1.5,0Zm5,0a.75.75,0,0,1-1.5,0v-9a.75.75,0,0,1,1.5,0Z"
+                                  />
+                                  <path
+                                    d="M22,4H17.25A.25.25,0,0,1,17,3.75V2.5A2.5,2.5,0,0,0,14.5,0h-5A2.5,2.5,0,0,0,7,2.5V3.75A.25.25,0,0,1,6.75,4H2A1,1,0,0,0,2,6H22a1,1,0,0,0,0-2ZM9,3.75V2.5A.5.5,0,0,1,9.5,2h5a.5.5,0,0,1,.5.5V3.75a.25.25,0,0,1-.25.25H9.25A.25.25,0,0,1,9,3.75Z"
+                                  />
+                                </g>
+                              </svg>
+                            </Styled(div)>
+                          </Icon>
+                        </ButtonIcon>
+                        DANGER! Delete this region
+                      </button>
+                    </PseudoBox>
+                  </Button>
+                  <AlertDialog
+                    isOpen={false}
+                    leastDestructiveRef={
+                      Object {
+                        "current": undefined,
+                      }
+                    }
+                    onClose={[Function]}
+                    size="lg"
+                  >
+                    <Modal
+                      formatIds={[Function]}
+                      initialFocusRef={
+                        Object {
+                          "current": undefined,
+                        }
+                      }
+                      isOpen={false}
+                      onClose={[Function]}
+                      size="lg"
+                    />
+                  </AlertDialog>
+                </ConfirmButton>
               </div>
             </Box>
           </Flex>

--- a/lib/components/__tests__/__snapshots__/select-region.js.snap
+++ b/lib/components/__tests__/__snapshots__/select-region.js.snap
@@ -145,9 +145,9 @@ exports[`Component SelectRegion snapshot(mount) 1`] = `
                     >
                       <span>
                         <strong>
-                          February 28, 2020
+                          April 18, 2020
                         </strong>
-                         — We fixed bugs and made changes to the application.
+                         — We have improved ways to manage your transportation network data.
                          
                         <ForwardRef
                           href="/changelog"

--- a/lib/components/edit-region.js
+++ b/lib/components/edit-region.js
@@ -37,8 +37,11 @@ export function EditRegion(p) {
 
   // Delete region action
   function _delete() {
-    dispatch(deleteRegion(region._id))
-    router.push('/')
+    // Felete that region
+    return dispatch(deleteRegion(region._id)).then(() => {
+      // Then go to the region selection page
+      router.push('/')
+    })
   }
 
   // Save region action
@@ -140,11 +143,11 @@ export function EditRegion(p) {
 }
 
 /**
- * Export a connected, memoized version by default.
+ * Export a connected version by default.
  */
-export default React.memo(function ConnectedEditRegion(p) {
+export default function ConnectedEditRegion(p) {
   const dispatch = useDispatch()
   const router = useRouter()
 
   return <EditRegion {...p} dispatch={dispatch} router={router} />
-})
+}

--- a/lib/components/edit-region.js
+++ b/lib/components/edit-region.js
@@ -17,6 +17,7 @@ import {SPACING_FORM} from 'lib/constants/chakra'
 import message from 'lib/message'
 import reprojectCoordinates from 'lib/utils/reproject-coordinates'
 
+import ConfirmButton from './confirm-button'
 import EditBoundsForm from './edit-bounds-form'
 import InnerDock from './inner-dock'
 
@@ -36,11 +37,8 @@ export function EditRegion(p) {
 
   // Delete region action
   function _delete() {
-    if (window.confirm(message('region.deleteConfirmation'))) {
-      dispatch(deleteRegion(region._id)).then(() => {
-        router.push('/')
-      })
-    }
+    dispatch(deleteRegion(region._id))
+    router.push('/')
   }
 
   // Save region action
@@ -127,15 +125,15 @@ export function EditRegion(p) {
           {message('region.editAction')}
         </Button>
 
-        <Button
+        <ConfirmButton
+          action={message('region.deleteAction')}
           block
+          description={message('region.deleteConfirmation')}
           leftIcon='delete'
-          onClick={_delete}
+          onConfirm={_delete}
           size='lg'
           variantColor='red'
-        >
-          {message('region.deleteAction')}
-        </Button>
+        />
       </Stack>
     </InnerDock>
   )

--- a/lib/components/edit-region.js
+++ b/lib/components/edit-region.js
@@ -37,7 +37,7 @@ export function EditRegion(p) {
 
   // Delete region action
   function _delete() {
-    // Felete that region
+    // Delete that region
     return dispatch(deleteRegion(region._id)).then(() => {
       // Then go to the region selection page
       router.push('/')

--- a/lib/components/error-modal.js
+++ b/lib/components/error-modal.js
@@ -33,6 +33,9 @@ const ExternalLink = ({children, href}) => (
   </Link>
 )
 
+const toString = o =>
+  typeof o !== 'string' ? JSON.stringify(o, null, '\t') : o
+
 function mapState(state, ownProps) {
   if (ownProps.error) {
     return {
@@ -40,16 +43,16 @@ function mapState(state, ownProps) {
         ownProps.error.environment === 'server'
           ? 'Server Error'
           : 'Application Error',
-      errorMessage: ownProps.error.message || ownProps.error,
-      stack: ownProps.error.stack
+      errorMessage: toString(ownProps.error.message || ownProps.error),
+      stack: toString(ownProps.error.stack)
     }
   } else {
     const error = get(state, 'network.error')
     return {
-      error: get(error, 'error'),
-      errorMessage: get(error, 'detailMessage'),
-      url: get(error, 'url'),
-      stack: get(error, 'stack')
+      error: toString(get(error, 'error')),
+      errorMessage: toString(get(error, 'detailMessage')),
+      url: toString(get(error, 'url')),
+      stack: toString(get(error, 'stack'))
     }
   }
 }

--- a/lib/components/select-region.js
+++ b/lib/components/select-region.js
@@ -32,8 +32,9 @@ export default function SelectRegion() {
         </Box>
         <Alert status='info' borderRadius='4px'>
           <span>
-            <strong>April 18, 2020</strong> — Conveyal has improved ways to manage your
-            transportation network data. <A href='/changelog'>Click here to learn more.</A>
+            <strong>April 18, 2020</strong> — We have improved ways to manage
+            your transportation network data.{' '}
+            <A href='/changelog'>Click here to learn more.</A>
           </span>
         </Alert>
         <Box>

--- a/lib/containers/__tests__/__snapshots__/modification-editor.js.snap
+++ b/lib/containers/__tests__/__snapshots__/modification-editor.js.snap
@@ -29,7 +29,7 @@ exports[`Container > Modification Editor render just the title if not loaded 1`]
       <p
         className="css-1r2f04i"
       >
-        If you deleted the GTFS bundle underlying this modification, you will need to clear the bundle or delete this modification.
+        If you deleted the network bundle underlying this modification, you will need to clear the bundle or delete this modification.
       </p>
     </Box>
   </P>

--- a/lib/reducers/__tests__/__snapshots__/region.js.snap
+++ b/lib/reducers/__tests__/__snapshots__/region.js.snap
@@ -11,6 +11,8 @@ Object {
 
 exports[`reducers > region should handle delete region 1`] = `
 Object {
+  "aggregationAreas": Array [],
+  "bookmarks": Array [],
   "bundles": Array [],
   "regions": Array [],
 }

--- a/lib/reducers/region.js
+++ b/lib/reducers/region.js
@@ -12,8 +12,7 @@ const createInitialState = () => ({
 export const reducers = {
   'delete region'(state, action) {
     return {
-      ...state,
-      bundles: [],
+      ...createInitialState(),
       regions: state.regions.filter(p => p._id !== action.payload)
     }
   },
@@ -94,8 +93,11 @@ export const reducers = {
       bundles: action.payload
     }
   },
-  'clear current region'() {
-    return createInitialState()
+  'clear current region'(state) {
+    return {
+      ...createInitialState(),
+      regions: state.regions
+    }
   }
 }
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -4,7 +4,7 @@ import withInitialFetch from 'lib/with-initial-fetch'
 
 async function initialFetch(store) {
   // If navigating to this page, reset the store and clear region specific data.
-  // This very important for the application behaving correctly after switching.
+  // This important for the application behaving correctly after switching.
   store.dispatch(clear())
 
   // Load all regions

--- a/pages/index.js
+++ b/pages/index.js
@@ -4,7 +4,7 @@ import withInitialFetch from 'lib/with-initial-fetch'
 
 async function initialFetch(store) {
   // If navigating to this page, reset the store and clear region specific data.
-  // This important for the application behaving correctly after switching.
+  // This is important for the application behaving correctly after switching.
   store.dispatch(clear())
 
   // Load all regions

--- a/pages/regions/[regionId]/regional/index.js
+++ b/pages/regions/[regionId]/regional/index.js
@@ -99,7 +99,12 @@ function RegionalPage(p) {
 }
 
 async function initialFetch(store, query) {
-  const [regionalAnalyses, opportunityDatasets, region] = await Promise.all([
+  const [
+    aggregationAreas,
+    regionalAnalyses,
+    opportunityDatasets,
+    region
+  ] = await Promise.all([
     store.dispatch(loadAggregationAreas(query.regionId)),
     store.dispatch(loadAllAnalyses(query.regionId)),
     store.dispatch(loadOpportunityDatasets(query.regionId)),
@@ -108,6 +113,7 @@ async function initialFetch(store, query) {
   ])
 
   return {
+    aggregationAreas,
     analysis: regionalAnalyses.find(a => a._id === query.analysisId),
     opportunityDatasets,
     region,

--- a/pages/regions/create.js
+++ b/pages/regions/create.js
@@ -4,6 +4,7 @@ import {useDispatch} from 'react-redux'
 
 import {create} from 'lib/actions/region'
 import CreateRegion from 'lib/components/create-region'
+import getInitialAuth from 'lib/get-initial-auth'
 import {routeTo} from 'lib/router'
 
 export default function CreateRegionPage(p) {
@@ -19,3 +20,5 @@ export default function CreateRegionPage(p) {
 
   return <CreateRegion create={_create} setMapChildren={p.setMapChildren} />
 }
+
+CreateRegionPage.getInitialProps = getInitialAuth


### PR DESCRIPTION
- The culprit here was the `checkLoadStatus` function that was left over from when OSM was uploaded and the region creation took longer than one `fetch`.
- Also fixes a bug that caused opportunity dataset's names not to show