### PR TITLE
Remove version restriction when for custom r5

### DIFF
--- a/lib/modules/r5-version/components/selector.js
+++ b/lib/modules/r5-version/components/selector.js
@@ -53,7 +53,7 @@ export default function SelectR5Version(props) {
   function _selectVersion(result) {
     const version = get(result, 'value', result)
     if (versionToNumber(version) < MIN_VERSION) {
-      return window.alert(
+      window.alert(
         message('r5Version.invalidVersion', {
           version,
           minimum: MINIMUM_R5_VERSION

--- a/lib/modules/r5-version/components/selector.js
+++ b/lib/modules/r5-version/components/selector.js
@@ -103,7 +103,6 @@ export default function SelectR5Version(props) {
         <Creatable
           formatCreateLabel={_promptTextCreator}
           isDisabled={props.disabled}
-          isValidNewOption={_isValidNewOption}
           onChange={_selectVersion}
           options={options}
           styles={selectStyles}


### PR DESCRIPTION
- [ ] Revert loosening restrictions in the UI element
- [ ] Allow editing r5 version in the custom JSON editor to anything the user wants