### PR TITLE
Set travel time percentile correctly

### DIFF
--- a/lib/actions/analysis/regional.js
+++ b/lib/actions/analysis/regional.js
@@ -5,7 +5,9 @@ import {createAction} from 'redux-actions'
 
 import {API} from 'lib/constants'
 import {routeTo} from 'lib/router'
-import * as select from 'lib/selectors'
+import selectCurrentRegionId from 'lib/selectors/current-region-id'
+import selectMaxTripDurationMinutes from 'lib/selectors/max-trip-duration-minutes'
+import selectTravelTimePercentile from 'lib/selectors/travel-time-percentile'
 import R5Version from 'lib/modules/r5-version'
 import createGrid from 'lib/utils/create-grid'
 import predictJobTimeRemaining from 'lib/utils/predict-job-time-remaining'
@@ -113,8 +115,9 @@ export const createRegionalAnalysis = (settings) => async (
   getState
 ) => {
   const state = getState()
-  const currentRegionId = select.currentRegionId(state, {})
-  const maxTripDurationMinutes = select.maxTripDurationMinutes(state)
+  const currentRegionId = selectCurrentRegionId(state)
+  const maxTripDurationMinutes = selectMaxTripDurationMinutes(state)
+  const travelTimePercentile = selectTravelTimePercentile(state)
 
   const createResult = await dispatch(
     fetch({
@@ -123,7 +126,7 @@ export const createRegionalAnalysis = (settings) => async (
         body: {
           ...settings,
           maxTripDurationMinutes,
-          percentiles: [settings.travelTimePercentile || 50]
+          percentiles: [travelTimePercentile || 50]
         }
       },
       url: REGIONAL_URL


### PR DESCRIPTION
Fixes a bug introduced in the latest release that always set travel time percentiles for multi-point analyses to 50.

## How to test

1. Create a multi-point analysis with a percentile of 50 and one with 95.
2. Ensure they have different results.
