### PR TITLE
Split nextjs build from cypress running

### DIFF
--- a/.github/workflows/lint-jest-build.yml
+++ b/.github/workflows/lint-jest-build.yml
@@ -53,8 +53,35 @@ jobs:
         env:
           CI: true
 
+  # Keep separate from
+  nextjsBuild:
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - uses: actions/cache@v1
+        with:
+          path: '.'
+          key: ${{ github.sha }}
+
+      # Cache the next.js cache folder per os/dependency change
+      - uses: actions/cache@v1
+        with:
+          path: ${{ github.workspace }}/.next/cache
+          key: ${{ runner.os }}-nextjs-cache-${{ hashFiles('**/yarn.lock') }}
+
+      - run: yarn build
+        env:
+          NEXT_PUBLIC_BASEMAP_DISABLED: true
+          NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
+
+      # Cache entire .next folder for subsequent steps
+      - uses: actions/cache@v1
+        with:
+          path: ${{ github.workspace }}/.next
+          key: ${{ runner.os }}-${{ github.sha }}-nextjs
+
   cypressIntegration:
-    needs: [codeLinter, jestUnitTests, typeCheck] # only run if these all pass
+    needs: [codeLinter, jestUnitTests, nextjsBuild, typeCheck] # only run if these all pass
     services:
       mongo:
         image: mongo
@@ -73,16 +100,11 @@ jobs:
           # just perform install
           runTests: false
 
-      # Build outside of Cypress's build command to enable caching the next.js cache folder
+      # Restore entire .next folder from previous step
       - uses: actions/cache@v1
         with:
-          path: ${{ github.workspace }}/.next/cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/yarn.lock') }}
-      - name: Next.js build
-        run: yarn build
-        env:
-          NEXT_PUBLIC_BASEMAP_DISABLED: true
-          NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
+          path: ${{ github.workspace }}/.next
+          key: ${{ runner.os }}-${{ github.sha }}-nextjs
 
       - uses: actions/setup-java@v1
         with:

--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,6 @@
 {
   "baseUrl": "http://localhost:3000",
+  "video": false,
   "viewportWidth": 1400,
   "viewportHeight": 900,
   "env": {


### PR DESCRIPTION
Since the build takes two minutes or so it should speed up the completion time because this will run in parallel with jest / lint / type check before Cypress runs.