### PR TITLE
Fix no opportunity dataset error

### DIFF
--- a/lib/actions/analysis/regional.js
+++ b/lib/actions/analysis/regional.js
@@ -1,15 +1,9 @@
 /** Actions for regional analysis */
 import get from 'lodash/get'
 import sortBy from 'lodash/sortBy'
-import Router from 'next/router'
 import {createAction} from 'redux-actions'
 
 import {API} from 'lib/constants'
-import {routeTo} from 'lib/router'
-import selectCurrentRegionId from 'lib/selectors/current-region-id'
-import selectMaxTripDurationMinutes from 'lib/selectors/max-trip-duration-minutes'
-import selectTravelTimePercentile from 'lib/selectors/travel-time-percentile'
-import {activeOpportunityDataset as selectActiveOpportunityDataset} from 'lib/modules/opportunity-datasets/selectors'
 import R5Version from 'lib/modules/r5-version'
 import createGrid from 'lib/utils/create-grid'
 import predictJobTimeRemaining from 'lib/utils/predict-job-time-remaining'
@@ -121,41 +115,11 @@ export const loadRegionalAnalysisGrid = (
   }
 }
 
-export const createRegionalAnalysis = (settings) => async (
-  dispatch,
-  getState
-) => {
-  const state = getState()
-  const currentRegionId = selectCurrentRegionId(state)
-  const maxTripDurationMinutes = selectMaxTripDurationMinutes(state)
-  const travelTimePercentile = selectTravelTimePercentile(state)
-  const opportunityDataset = selectActiveOpportunityDataset(state)
-  // Copy the settings for the request body
-  const body = {...settings}
-
-  // Set the cutoffs, destinations, percentiles if they were not set manually
-  if (get(body, 'destinationPointSetIds.length', 0) < 1) {
-    body.destinationPointSetIds = [opportunityDataset._id]
-  }
-  if (get(body, 'percentiles.length', 0) < 1) {
-    body.percentiles = [travelTimePercentile || 50]
-  }
-  if (get(body, 'cutoffsMinutes.length', 0) < 1) {
-    body.cutoffsMinutes = [maxTripDurationMinutes || 60]
-  }
-
-  const createResult = await dispatch(
-    fetch({
-      options: {method: 'POST', body},
-      url: REGIONAL_URL
-    })
-  )
-
-  const {as, href} = routeTo('regionalAnalyses', {regionId: currentRegionId})
-  Router.push(href, as)
-
-  return createResult
-}
+export const createRegionalAnalysis = (settings) =>
+  fetch({
+    options: {method: 'POST', body: settings},
+    url: REGIONAL_URL
+  })
 
 const deleteRegionalAnalysisLocally = createAction('delete regional analysis')
 export const deleteRegionalAnalysis = (analysisId) => (dispatch) => {

--- a/lib/actions/analysis/regional.js
+++ b/lib/actions/analysis/regional.js
@@ -113,8 +113,8 @@ export const loadRegionalAnalysisGrid = (
     const grid = createGrid(rawGrid)
     // Assign the regional analysis _id and display parameters
     grid.analysisId = analysis._id
-    grid.cutoff = cutoff
-    grid.percentile = percentile
+    grid.cutoff = cutoff || get(analysis, 'cutoffMinutes')
+    grid.percentile = percentile || get(analysis, 'travelTimePercentile')
     grid.pointSetId = pointSetId
     // Pass into the store
     dispatch(setRegionalAnalysisGrid(grid))

--- a/lib/components/analysis/create-regional.tsx
+++ b/lib/components/analysis/create-regional.tsx
@@ -135,8 +135,10 @@ function CreateModal({onClose, profileRequest, projectId, variantIndex}) {
       dispatch(
         createRegionalAnalysis({
           ...profileRequest,
+          cutoffs: [profileRequest.cutoffsMinutes],
           destinationPointSetIds: destinationPointSets,
           name: nameInput.value,
+          percentiles: [profileRequest.travelTimePercentile],
           projectId,
           variantIndex
         })

--- a/lib/components/analysis/create-regional.tsx
+++ b/lib/components/analysis/create-regional.tsx
@@ -145,7 +145,7 @@ function CreateModal({onClose, profileRequest, projectId, variantIndex}) {
         await dispatch(
           createRegionalAnalysis({
             ...profileRequest,
-            cutoffs: [maxTripDurationMinutes],
+            cutoffsMinutes: [maxTripDurationMinutes],
             destinationPointSetIds: destinationPointSets,
             name: nameInput.value,
             percentiles: [travelTimePercentile],

--- a/lib/components/analysis/index.tsx
+++ b/lib/components/analysis/index.tsx
@@ -276,7 +276,7 @@ function ScenarioApplicationErrors({errors, ...p}) {
           <Heading size='sm'>
             {message('analysis.errorsInModification', {id: err.modificationId})}
           </Heading>
-          <List styleType='disc'>
+          <List styleType='disc' spacing={2}>
             {err.messages.map((msg, idx) => (
               <ListItem key={`message-${idx}`}>{msg}</ListItem>
             ))}

--- a/lib/components/analysis/index.tsx
+++ b/lib/components/analysis/index.tsx
@@ -270,7 +270,7 @@ function Results({
 function ScenarioApplicationErrors({errors, ...p}) {
   /** Render any errors that may have occurred applying the project */
   return (
-    <Stack spacing={P.md} {...p}>
+    <Stack spacing={P.md} {...p} maxHeight='200px' overflowY='scroll'>
       {errors.map((err, idx) => (
         <Stack key={idx}>
           <Heading size='sm'>

--- a/lib/components/analysis/regional-results.tsx
+++ b/lib/components/analysis/regional-results.tsx
@@ -243,7 +243,7 @@ function ComparisonDisplay({analysis, comparisonAnalysis}) {
   )
   const comparisonCutoffInput = useControlledInput({
     onChange: onChangeCutoff,
-    parse: parseInt,
+    parse: parseCutoff,
     value: comparisonCutoff
   })
 
@@ -253,7 +253,7 @@ function ComparisonDisplay({analysis, comparisonAnalysis}) {
   )
   const comparisonPercentileInput = useControlledInput({
     onChange: onChangePercentile,
-    parse: parseInt,
+    parse: parseCutoff,
     value: comparisonPercentile
   })
 

--- a/lib/components/analysis/regional.tsx
+++ b/lib/components/analysis/regional.tsx
@@ -2,7 +2,6 @@ import {Box, Select, Stack, Flex, useDisclosure} from '@chakra-ui/core'
 import {
   faChevronLeft,
   faDownload,
-  faMap,
   faTrash
 } from '@fortawesome/free-solid-svg-icons'
 import find from 'lodash/find'
@@ -82,13 +81,14 @@ export default function Regional(p) {
   })
 
   const activePointSet = useSelector(selectPointset)
+  const activePointSetId = get(activePointSet, '_id')
   const onChangeDestinationPointSet = useCallback(
     (v) => dispatch(setSearchParameter('destinationPointSetId', v)),
     [dispatch]
   )
   const destinationPointSetInput = useControlledInput({
     onChange: onChangeDestinationPointSet,
-    value: activePointSet._id
+    value: activePointSetId
   })
 
   async function _remove() {
@@ -104,7 +104,7 @@ export default function Regional(p) {
     e.preventDefault()
     const value = await dispatch(
       fetchAction({
-        url: `${API.Regional}/${analysis._id}/grid/tiff?cutoff=${cutoffInput.value}&percentile=${percentileInput.value}&destinationPointSetId=${activePointSet._id}`
+        url: `${API.Regional}/${analysis._id}/grid/tiff?cutoff=${cutoffInput.value}&percentile=${percentileInput.value}&destinationPointSetId=${activePointSetId}`
       })
     )
     window.open(get(value, 'url'))

--- a/lib/selectors/regional-comparison-cutoff.js
+++ b/lib/selectors/regional-comparison-cutoff.js
@@ -13,6 +13,8 @@ export default createSelector(
     const cutoffs = get(analysis, 'cutoffsMinutes') || []
     if (cutoffs.indexOf(comparison) >= 0) return comparison
     if (cutoffs.indexOf(cutoff) >= 0) return cutoff
-    return cutoffs[Math.floor(cutoffs.length / 2)]
+    return (
+      cutoffs[Math.floor(cutoffs.length / 2)] || get(analysis, 'cutoffMinutes')
+    )
   }
 )

--- a/lib/selectors/regional-comparison-percentile.js
+++ b/lib/selectors/regional-comparison-percentile.js
@@ -13,6 +13,9 @@ export default createSelector(
     const percentiles = get(analysis, 'travelTimePercentiles') || []
     if (percentiles.indexOf(comparison) >= 0) return comparison
     if (percentiles.indexOf(percentile) >= 0) return percentile
-    return percentiles[Math.floor(percentiles.length / 2)]
+    return (
+      percentiles[Math.floor(percentiles.length / 2)] ||
+      get(analysis, 'travelTimePercentile')
+    )
   }
 )

--- a/lib/selectors/regional-display-cutoff.js
+++ b/lib/selectors/regional-display-cutoff.js
@@ -9,6 +9,8 @@ export default createSelector(
   (analysis, cutoff) => {
     const cutoffs = get(analysis, 'cutoffsMinutes') || []
     if (cutoffs.indexOf(cutoff) >= 0) return cutoff
-    return cutoffs[Math.floor(cutoffs.length / 2)]
+    return (
+      cutoffs[Math.floor(cutoffs.length / 2)] || get(analysis, 'cutoffMinutes')
+    )
   }
 )

--- a/lib/selectors/regional-display-percentile.js
+++ b/lib/selectors/regional-display-percentile.js
@@ -9,6 +9,9 @@ export default createSelector(
   (analysis, percentile) => {
     const percentiles = get(analysis, 'travelTimePercentiles') || []
     if (percentiles.indexOf(percentile) >= 0) return percentile
-    return percentiles[Math.floor(percentiles.length / 2)]
+    return (
+      percentiles[Math.floor(percentiles.length / 2)] ||
+      get(analysis, 'travelTimePercentile')
+    )
   }
 )


### PR DESCRIPTION
# Fix 1

The new regional analysis code assumes the opportunity dataset still exists, but they may have been deleted. This should fix that problem.

## How to test

1. Successfully load a regional analysis that has had it's opportunity dataset deleted.

## Q: Should we disable deleting opportunity datasets? @abyrd @ansoncfit 

With the new regional analyses we only store the ids of the opportunity datasets. We retrieve the names of the datasets from the database. If you delete an opportunity dataset thats used for a new regional analysis, you can load the analysis and select by id, but it's quite confusing if there is no name.

# Fix 2

Fix loading and comparing older regional analysis. The way grids are selected would not work for comparison if a regional analysis did not have a cutoffs array or percentiles array. 

## How to test

1. Compare two old regional analyses and ensure they load.

# Fix 3

Creating a regional analysis with an older worker version would get a percentiles array. This PR also overrides the percentiles array and cutoffs array on creation.