### PR TITLE
Remove react-datetime

### DIFF
--- a/lib/components/analysis/__tests__/__snapshots__/profile-request-editor.js.snap
+++ b/lib/components/analysis/__tests__/__snapshots__/profile-request-editor.js.snap
@@ -10,34 +10,23 @@ exports[`Components > Analysis > Profile Request Editor should render correctly 
     isInvalid={false}
   >
     <FormLabel
-      htmlFor="serviceDate"
+      htmlFor="00000000-0000-0000-0000-000000000000"
     >
       Date
     </FormLabel>
-    <DateTime
-      className=""
-      closeOnSelect={true}
-      closeOnTab={true}
-      dateFormat="YYYY-MM-DD"
-      defaultValue=""
-      input={true}
-      inputProps={
-        Object {
-          "disabled": false,
-        }
-      }
-      onBlur={[Function]}
+    <Input
+      as="input"
+      errorBorderColor="red.500"
+      focusBorderColor="blue.500"
+      id="00000000-0000-0000-0000-000000000000"
+      isFullWidth={true}
+      isInvalid={false}
+      isValid={true}
       onChange={[Function]}
-      onFocus={[Function]}
-      onNavigateBack={[Function]}
-      onNavigateForward={[Function]}
-      onViewModeChange={[Function]}
-      renderInput={[Function]}
-      strictParsing={true}
-      timeConstraints={Object {}}
-      timeFormat={false}
-      utc={true}
+      size="md"
+      type="date"
       value="2016-01-16"
+      variant="outline"
     />
   </FormControl>
   <Memo(TimePicker)

--- a/lib/components/analysis/profile-request-editor.tsx
+++ b/lib/components/analysis/profile-request-editor.tsx
@@ -12,18 +12,12 @@ import {
   SimpleGrid
 } from '@chakra-ui/core'
 import get from 'lodash/get'
-import {forwardRef, useState, useCallback} from 'react'
-import DateTime from 'react-datetime'
+import {forwardRef, useCallback} from 'react'
 
 import useInput from 'lib/hooks/use-controlled-input'
 import message from 'lib/message'
 
 import TimePicker from '../time-picker'
-
-// DateTime does not have a `renderInput`
-const DateTimeWithRender = DateTime as any
-
-const DATE_FORMAT = 'YYYY-MM-DD'
 
 const bold = (b) => `<strong>${b}</strong>`
 
@@ -104,17 +98,20 @@ export default function ProfileRequestEditor({
     setProfileRequest({fromTime: parseInt(fromTime)})
   const setToTime = (toTime) => setProfileRequest({toTime: parseInt(toTime)})
 
-  const [dateIsValid, setDateIsValid] = useState(true)
-  function setDate(date) {
-    if (!date || !date.isValid || !date.isValid()) {
-      return setDateIsValid(false)
-    }
-    setDateIsValid(true)
-    setProfileRequest({date: date.format(DATE_FORMAT)})
-  }
+  const {fromTime, toTime} = profileRequest
+  const bundleOutOfDate = bundleIsOutOfDate(
+    bundle,
+    profileRequest.date,
+    project
+  )
 
-  const {date, fromTime, toTime} = profileRequest
-  const bundleOutOfDate = bundleIsOutOfDate(bundle, date, project)
+  const setDate = useCallback((date) => setProfileRequest({date}), [
+    setProfileRequest
+  ])
+  const dateInput = useInput({
+    onChange: setDate,
+    value: profileRequest.date
+  })
 
   const setWalkSpeed = useCallback(
     (walkSpeed) => setProfileRequest({walkSpeed: walkSpeed / 3.6}), // km/h to m/s
@@ -194,20 +191,15 @@ export default function ProfileRequestEditor({
         <>
           <FormControl
             isDisabled={disabled}
-            isInvalid={bundleOutOfDate || !dateIsValid}
+            isInvalid={bundleOutOfDate || dateInput.isInvalid}
           >
-            <FormLabel htmlFor='serviceDate'>
+            <FormLabel htmlFor={dateInput.id}>
               {message('analysis.date')}
             </FormLabel>
-            <DateTimeWithRender
-              closeOnSelect
-              dateFormat={DATE_FORMAT}
-              inputProps={{disabled}}
-              onChange={setDate}
-              renderInput={(p) => <Input {...p} id='serviceDate' />}
-              timeFormat={false}
-              utc // because new Date('2016-12-12') yields a date at midnight UTC
-              value={date}
+            <Input
+              {...dateInput}
+              isInvalid={!!bundleOutOfDate || dateInput.isInvalid}
+              type='date'
             />
           </FormControl>
 

--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
     "npm-run-all": "^4.1.5",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
-    "react-datetime": "^2.16.3",
     "react-dom": "^16.13.1",
     "react-ga": "^3.1.2",
     "react-leaflet": "^2.7.0",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -9,7 +9,6 @@ import ChakraTheme from '../lib/chakra'
 import ErrorModal from '../lib/components/error-modal'
 import LogRocket from '../lib/logrocket'
 
-import 'react-datetime/css/react-datetime.css'
 import 'simplebar/dist/simplebar.css'
 import '../styles.css'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4899,15 +4899,6 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-create-react-class@^15.5.2:
-  version "15.6.3"
-  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.3.tgz#2d73237fb3f970ae6ebe011a9e66f46dbca80036"
-  integrity sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==
-  dependencies:
-    fbjs "^0.8.9"
-    loose-envify "^1.3.1"
-    object-assign "^4.1.1"
-
 create-react-context@^0.2.2:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.3.tgz#9ec140a6914a22ef04b8b09b7771de89567cb6f3"
@@ -6556,7 +6547,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
-fbjs@^0.8.0, fbjs@^0.8.9:
+fbjs@^0.8.0:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
@@ -9480,7 +9471,7 @@ logrocket@^1.0.7:
   resolved "https://registry.yarnpkg.com/logrocket/-/logrocket-1.0.9.tgz#0b4cab2535e0dcdf3c802eb604b109662a403d38"
   integrity sha512-dsZh4zPRtZlPqmI3n4Sgkh5DeWo+rRh4NZhRm6BH9F3Jfv1WFDutISr1a5bQJb9rITvBbRgw3zTVeWjU71qyBg==
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -10797,11 +10788,6 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-assign@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-3.0.0.tgz#9bedd5ca0897949bca47e7ff408062d549f587f2"
-  integrity sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=
-
 object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
@@ -12028,7 +12014,7 @@ prop-types-exact@1.2.0, prop-types-exact@^1.2.0:
     object.assign "^4.1.0"
     reflect.ownkeys "^0.2.0"
 
-prop-types@15.7.2, prop-types@^15.5.10, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@15.7.2, prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -12302,16 +12288,6 @@ react-clientside-effect@^1.2.2:
   dependencies:
     "@babel/runtime" "^7.0.0"
 
-react-datetime@^2.16.3:
-  version "2.16.3"
-  resolved "https://registry.yarnpkg.com/react-datetime/-/react-datetime-2.16.3.tgz#7f9ac7d4014a939c11c761d0c22d1fb506cb505e"
-  integrity sha512-amWfb5iGEiyqjLmqCLlPpu2oN415jK8wX1qoTq7qn6EYiU7qQgbNHglww014PT4O/3G5eo/3kbJu/M/IxxTyGw==
-  dependencies:
-    create-react-class "^15.5.2"
-    object-assign "^3.0.0"
-    prop-types "^15.5.7"
-    react-onclickoutside "^6.5.0"
-
 react-dom@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
@@ -12387,11 +12363,6 @@ react-modal@^3.11.2:
     prop-types "^15.5.10"
     react-lifecycles-compat "^3.0.0"
     warning "^4.0.3"
-
-react-onclickoutside@^6.5.0:
-  version "6.9.0"
-  resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.9.0.tgz#a54bc317ae8cf6131a5d78acea55a11067f37a1f"
-  integrity sha512-8ltIY3bC7oGhj2nPAvWOGi+xGFybPNhJM0V1H8hY/whNcXgmDeaeoCMPPd8VatrpTsUWjb/vGzrmu6SrXVty3A==
 
 react-redux@v7.2.0:
   version "7.2.0"


### PR DESCRIPTION
It's a very out of date dependency that uses Bootstrap CSS. Most modern browsers implement their own date input. This PR removes the dependency and replaces it with the native date input.
