### PR TITLE
Don't import within integration tests

### DIFF
--- a/cypress/integration/local/opportunities.js
+++ b/cypress/integration/local/opportunities.js
@@ -1,4 +1,6 @@
-import {generateName} from '../../support'
+function generateName(type, name) {
+  return `${Cypress.env('dataPrefix')}${type}_${name}_${Date.now()}`
+}
 
 // How long should it take to create an OD
 const timeout = 60000

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -27,7 +27,3 @@ before('Optionally wipe configured state', () => {
     }
   })
 })
-
-export function generateName(type, name) {
-  return `${Cypress.env('dataPrefix')}${type}_${name}_${Date.now()}`
-}


### PR DESCRIPTION
It appears that integration tests will fail (sometimes) when importing from external files. The OD test is the only one that was importing and it fails with an odd Cypress related error. This inlines that import and should fix that error. 