### PR TITLE
Add stale issue bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,19 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 365
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 14
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+  - blocking
+  - bug
+# Label to use when marking an issue as stale
+staleLabel: wontfix
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed in 14 days if no further activity occurs. 
+  Thank you for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
This PR adds a [bot](https://github.com/marketplace/stale) that comments on issues over a year old indicating the issue is "stale" and then closes the issue two weeks later if there is no further activity. It ignores issues with `bug` and `blocking` tags.

With over 100 issues in this repo I would like to do a general "purge". This assists with that.

Important to note, we can always reopen issues! 