### PR TITLE
Disable recording to speed up cypress tests

### DIFF
--- a/.github/workflows/lint-jest-build.yml
+++ b/.github/workflows/lint-jest-build.yml
@@ -120,11 +120,11 @@ jobs:
         run: curl https://r5-builds.s3-eu-west-1.amazonaws.com/${{ matrix.backend }}.jar --output ${{ github.workspace }}/${{ matrix.backend }}.jar
 
       - uses: cypress-io/github-action@v2
-        env:
-          # pass the Dashboard record key as an environment variable
-          # CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-          # pass GitHub token to allow accurately detecting a build vs a re-run build
-          # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # env:
+        # pass the Dashboard record key as an environment variable
+        # CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+        # pass GitHub token to allow accurately detecting a build vs a re-run build
+        # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           install: false
           # record: true

--- a/.github/workflows/lint-jest-build.yml
+++ b/.github/workflows/lint-jest-build.yml
@@ -122,12 +122,12 @@ jobs:
       - uses: cypress-io/github-action@v2
         env:
           # pass the Dashboard record key as an environment variable
-          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+          # CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           # pass GitHub token to allow accurately detecting a build vs a re-run build
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           install: false
-          record: true
+          # record: true
           start: yarn action # runs frontend and java server together
           wait-on: 'http://localhost:3000'
           wait-on-timeout: 60

--- a/cypress.json
+++ b/cypress.json
@@ -14,7 +14,7 @@
     "authZeroDomain": "",
     "region": "scratch",
     "dataPrefix": "CYP_",
-    "resetDataBeforeEachRun": true
+    "resetDataBeforeEachRun": false
   },
   "projectId": "cvhnxt"
 }

--- a/cypress.json
+++ b/cypress.json
@@ -5,6 +5,7 @@
   "defaultCommandTimeout": 8000,
   "pageLoadTimeout": 120000,
   "retries": 1,
+  "video": false,
   "env": {
     "accessGroup": "testing",
     "username": "testing@conveyal.com",
@@ -13,7 +14,7 @@
     "authZeroDomain": "",
     "region": "scratch",
     "dataPrefix": "CYP_",
-    "resetDataBeforeEachRun": false
+    "resetDataBeforeEachRun": true
   },
   "projectId": "cvhnxt"
 }

--- a/cypress/integration/0-regions.js
+++ b/cypress/integration/0-regions.js
@@ -109,8 +109,8 @@ describe('Region setup', function () {
     // Create the region
     cy.get('@create').click()
     cy.navComplete()
-    // should redirect to bundle upload
-    cy.location('pathname', {timeout: 10000}).should('match', /regions\/.{24}$/)
+    // should redirect to a region with no bundles
+    cy.location('pathname').should('match', /regions\/.{24}$/)
     cy.contains('Upload a new Network Bundle')
     // Region is listed in main regions menu
     cy.navTo('Regions')

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -19,8 +19,8 @@ before('Optionally wipe configured state', () => {
         if ('regionId' in storedVals) {
           cy.visit(`/regions/${storedVals.regionId}`)
           cy.navTo('Region Settings')
-          cy.findByText(/Delete this region/i).click()
-          cy.findByText(/Confirm: Delete this region/).click()
+          cy.findByRole('button', {name: /Delete this region/i}).click()
+          cy.findByRole('button', {name: /Confirm: Delete this region/}).click()
         }
       })
       cy.writeFile(pseudoFixture, '{}')

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "@typescript-eslint/parser": "^3.9.0",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^26.0.1",
-    "cypress": "^5.1.0",
+    "cypress": "^5.2.0",
     "cypress-file-upload": "^4.1.1",
     "cypress-image-snapshot": "^3.1.1",
     "cypress-wait-until": "^1.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5060,10 +5060,10 @@ cypress-wait-until@^1.7.1:
   resolved "https://registry.yarnpkg.com/cypress-wait-until/-/cypress-wait-until-1.7.1.tgz#3789cd18affdbb848e3cfc1f918353c7ba1de6f8"
   integrity sha512-8DL5IsBTbAxBjfYgCzdbohPq/bY+IKc63fxtso1C8RWhLnQkZbVESyaclNr76jyxfId6uyzX8+Xnt0ZwaXNtkA==
 
-cypress@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-5.1.0.tgz#979e9ff3e0acd792eefd365bf104046479a9643b"
-  integrity sha512-craPRO+Viu4268s7eBvX5VJW8aBYcAQT+EwEccQSMY+eH1ZPwnxIgyDlmMWvxLVX9SkWxOlZbEycPyzanQScBQ==
+cypress@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-5.2.0.tgz#6902efd90703242a2539f0623c6e1118aff01f95"
+  integrity sha512-9S2spcrpIXrQ+CQIKHsjRoLQyRc2ehB06clJXPXXp1zyOL/uZMM3Qc20ipNki4CcNwY0nBTQZffPbRpODeGYQg==
   dependencies:
     "@cypress/listr-verbose-renderer" "^0.4.1"
     "@cypress/request" "^2.88.5"


### PR DESCRIPTION
Turns out we overused the free tier for Cypress. This PR updates Cypress to 5.2 and disables recording (which speeds up the tests in the Github Actions themselves).