### PR TITLE
Add inputs for older r5 versions

### DIFF
--- a/lib/components/analysis/create-regional.tsx
+++ b/lib/components/analysis/create-regional.tsx
@@ -182,6 +182,8 @@ function CreateModal({onClose, profileRequest, projectId, variantIndex}) {
     nameInput.isInvalid ||
     cutoffsInput.isInvalid ||
     percentilesInput.isInvalid ||
+    cutoffInput.isInvalid ||
+    percentileInput.isInvalid ||
     destinationPointSets.length < 1
 
   return (

--- a/lib/components/analysis/create-regional.tsx
+++ b/lib/components/analysis/create-regional.tsx
@@ -55,6 +55,8 @@ const createTestArray = (min, max) => (sorted) =>
 
 const testCutoffs = createTestArray(5, 120)
 const testPercentiles = createTestArray(1, 99)
+const testCutoff = (c) => c >= 5 && c <= 120
+const testPercentile = (p) => p >= 1 && p <= 99
 
 const disabledLabel = 'Fetch results with the current settings to enable button'
 
@@ -129,6 +131,18 @@ function CreateModal({onClose, profileRequest, projectId, variantIndex}) {
     value: get(profileRequest, 'percentiles', defaultPercentiles)
   })
 
+  const cutoffInput = useInput({
+    parse: parseInt,
+    test: testCutoff,
+    value: maxTripDurationMinutes
+  })
+
+  const percentileInput = useInput({
+    parse: parseInt,
+    test: testPercentile,
+    value: travelTimePercentile
+  })
+
   async function create() {
     setIsCreating(true)
     try {
@@ -148,10 +162,10 @@ function CreateModal({onClose, profileRequest, projectId, variantIndex}) {
         await dispatch(
           createRegionalAnalysis({
             ...profileRequest,
-            cutoffsMinutes: [maxTripDurationMinutes],
+            cutoffsMinutes: [cutoffInput.value],
             destinationPointSetIds: destinationPointSets,
             name: nameInput.value,
-            percentiles: [travelTimePercentile],
+            percentiles: [percentileInput.value],
             projectId,
             variantIndex
           })
@@ -228,7 +242,7 @@ function CreateModal({onClose, profileRequest, projectId, variantIndex}) {
             </FormControl>
           </Stack>
 
-          {workerVersionHandlesMultipleDimensions && (
+          {workerVersionHandlesMultipleDimensions ? (
             <Stack spacing={4}>
               <FormControl
                 isDisabled={isCreating}
@@ -261,6 +275,28 @@ function CreateModal({onClose, profileRequest, projectId, variantIndex}) {
                       : percentilesInput.value
                   }
                 />
+                <FormHelperText>From 1 to 99.</FormHelperText>
+              </FormControl>
+            </Stack>
+          ) : (
+            <Stack spacing={4}>
+              <FormControl
+                isDisabled={isCreating}
+                isRequired
+                isInvalid={cutoffInput.isInvalid}
+              >
+                <FormLabel htmlFor={cutoffInput.id}>Cutoff minute</FormLabel>
+                <Input {...cutoffInput} />
+                <FormHelperText>From 5 to 120.</FormHelperText>
+              </FormControl>
+
+              <FormControl
+                isDisabled={isCreating}
+                isRequired
+                isInvalid={percentileInput.isInvalid}
+              >
+                <FormLabel htmlFor={percentileInput.id}>Percentile</FormLabel>
+                <Input {...percentileInput} />
                 <FormHelperText>From 1 to 99.</FormHelperText>
               </FormControl>
             </Stack>

--- a/lib/components/analysis/create-regional.tsx
+++ b/lib/components/analysis/create-regional.tsx
@@ -53,10 +53,11 @@ const createTestArray = (min, max) => (sorted) =>
   sorted[0] >= min &&
   sorted[sorted.length - 1] <= max
 
+const onlyDigits = (s) => /^\d+$/.test(s)
 const testCutoffs = createTestArray(5, 120)
 const testPercentiles = createTestArray(1, 99)
-const testCutoff = (c) => c >= 5 && c <= 120
-const testPercentile = (p) => p >= 1 && p <= 99
+const testCutoff = (c, o) => onlyDigits(o) && c >= 5 && c <= 120
+const testPercentile = (p, o) => onlyDigits(o) && p >= 1 && p <= 99
 
 const disabledLabel = 'Fetch results with the current settings to enable button'
 
@@ -162,10 +163,10 @@ function CreateModal({onClose, profileRequest, projectId, variantIndex}) {
         await dispatch(
           createRegionalAnalysis({
             ...profileRequest,
-            cutoffsMinutes: [cutoffInput.value],
+            cutoffsMinutes: [parseInt(cutoffInput.value)],
             destinationPointSetIds: destinationPointSets,
             name: nameInput.value,
-            percentiles: [percentileInput.value],
+            percentiles: [parseInt(percentileInput.value)],
             projectId,
             variantIndex
           })


### PR DESCRIPTION
PR #1287 removed the ability to select a travel time percentile for regional analysis. This PR adds the ability to edit the cutoff and percentile for older versions of r5 in the create regional analysis screen.