### PR TITLE
[Dependabot] Change update interval to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
     reviewers:
       - 'trevorgerhardt'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
     target-branch: 'dev'
     # Increase the version requirements for package.json
     # only when required


### PR DESCRIPTION
Too much noise right now. Would still like to get update notifications regularly, just not that often.