### PR TITLE
Change stale tag to "stale", update comment text

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -9,11 +9,11 @@ exemptLabels:
   - blocking
   - bug
 # Label to use when marking an issue as stale
-staleLabel: wontfix
+staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
-  This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed in 14 days if no further activity occurs. 
-  Thank you for your contributions.
+  This issue has not had any activity for over one year, so it has been marked as stale. 
+  It will be closed in 14 days if no further activity occurs.
+  If you would like to keep this issue open, please comment giving an update and confirming its relevance.
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: false


### PR DESCRIPTION
The original tag "wontfix" sounds like an intentional decision/judgement from the developers.
Tagging them "stale" is more objective and descriptive when understanding later why they were closed.
Also updated the automatic comments to be less generic and better match our processes.
