### PR TITLE
Remove region settings link from the sidebar

### DIFF
--- a/cypress/index.d.ts
+++ b/cypress/index.d.ts
@@ -31,7 +31,6 @@ declare namespace Cypress {
     | 'projects'
     | 'regions'
     | 'regional analyses'
-    | 'region settings'
 
   export type ProjectScenario = {
     project?: string

--- a/cypress/integration/0-regions.ts
+++ b/cypress/integration/0-regions.ts
@@ -81,7 +81,7 @@ function deleteOldScratchRegions() {
     .then((regions) => {
       if (regions.length > 0) {
         cy.wrap(regions[0]).click()
-        cy.navTo('region settings')
+        cy.findButton(/Edit region settings/).click()
         deleteThisRegion()
         deleteOldScratchRegions()
       }
@@ -157,7 +157,7 @@ describe('Regions', () => {
     cy.navComplete()
     cy.location('pathname').should('match', /regions\/.{24}$/)
     // region settings are saved correctly
-    cy.navTo('region settings')
+    cy.findButton(/Edit region settings/).click()
     // check setting values
     getName().should('have.value', regionName)
     getDesc().should('have.value', regionData.description)
@@ -181,7 +181,7 @@ describe('Regions', () => {
     cy.navTo('regions')
     cy.findButton(newName).click()
     cy.navComplete()
-    cy.navTo('region settings') // will go to bundle page otherwise
+    cy.findButton(/Edit region settings/).click() // will go to bundle page otherwise
     getDesc().should('have.value', newDescription)
     getName().should('have.value', newName)
 

--- a/cypress/models/region.ts
+++ b/cypress/models/region.ts
@@ -31,7 +31,8 @@ export default class Region extends Model {
   }
 
   _delete() {
-    cy.navTo('region settings')
+    cy.navTo('projects')
+    cy.findButton(/Edit region settings/).click()
     // Delete region
     cy.findByText(/Delete this region/).click()
     cy.findByText(/Confirm: Delete this region/).click()

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -73,10 +73,6 @@ const navToPages = {
     lookFor: /Set up a new region/i,
     path: /\//
   },
-  'region settings': {
-    lookFor: /Delete this region/i,
-    path: /\/regions\/[a-z0-9]+\/edit/
-  },
   projects: {
     lookFor: /Create new Project|Upload a .* Bundle/i,
     path: /\/regions\/[a-z0-9]+/

--- a/lib/components/sidebar.tsx
+++ b/lib/components/sidebar.tsx
@@ -6,7 +6,6 @@ import {
   faDatabase,
   faGlobe,
   faLayerGroup,
-  faMap,
   faPencilAlt,
   faQuestionCircle,
   faServer,
@@ -136,12 +135,6 @@ export default function Sidebar() {
         <ItemLink icon={faGlobe} label={message('nav.regions')} to='regions' />
         {queryParams.regionId && queryParams.regionId !== CREATING_ID && (
           <>
-            <ItemLink
-              icon={faMap}
-              label={message('nav.regionSettings')}
-              to='regionSettings'
-              params={regionOnly}
-            />
             <ItemLink
               icon={faCubes}
               label={message('nav.projects')}


### PR DESCRIPTION
Region settings is not frequently accessed and therefore does not need to be in the sidebar.  This change removes it. The page is still accessible from the gear icon at the top of the "Projects" page.

Fixes #1406 