### PR TITLE
Wrap ckmeans usage in try/catch to prevent error

### DIFF
--- a/lib/actions/analysis/parse-times-data.ts
+++ b/lib/actions/analysis/parse-times-data.ts
@@ -6,9 +6,9 @@ const TIMES_GRID_TYPE = 'ACCESSGR'
 /**
  * Parse a grid header created by a GridResultWriter
  */
-export function parseGridHeader(ab: ArrayBuffer) {
+export function parseGridHeader(ab: ArrayBuffer): CL.AccessGridHeader {
   const headerData = new Int8Array(ab, 0, TIMES_GRID_TYPE.length)
-  const headerType = String.fromCharCode.apply(null, headerData)
+  const headerType: string = String.fromCharCode.apply(null, headerData)
   if (headerType !== TIMES_GRID_TYPE) {
     throw new Error(
       `Retrieved grid header ${headerType} !== ${TIMES_GRID_TYPE}. Please check your data.`
@@ -42,7 +42,7 @@ export function parseGridHeader(ab: ArrayBuffer) {
 /**
  * Parse the ArrayBuffer from a `*_times.dat` file for a point in a network.
  */
-export function parseTimesData(ab: ArrayBuffer) {
+export function parseTimesData(ab: ArrayBuffer): CL.AccessGrid {
   const header = parseGridHeader(ab)
   const gridSize = header.width * header.height
 
@@ -68,7 +68,7 @@ export function parseTimesData(ab: ArrayBuffer) {
     (HEADER_LENGTH + header.width * header.height * header.depth) *
       Int32Array.BYTES_PER_ELEMENT
   )
-  const metadata = decodeMetadata(rawMetadata)
+  const metadata: Record<string, unknown> = decodeMetadata(rawMetadata)
 
   function contains(x: number, y: number, z: number) {
     return (

--- a/lib/actions/analysis/regional.ts
+++ b/lib/actions/analysis/regional.ts
@@ -103,15 +103,19 @@ export const loadRegionalAnalysisGrid = (
         `${REGIONAL_URL}/${analysis._id}/grid/grid?cutoff=${cutoff}&percentile=${percentile}&destinationPointSetId=${pointSetId}`
       )
     )
-    // Parse the headers and create a usable grid.
-    const grid = createGrid(rawGrid)
-    // Assign the regional analysis _id and display parameters
-    grid.analysisId = analysis._id
-    grid.cutoff = cutoff || get(analysis, 'cutoffMinutes')
-    grid.percentile = percentile || get(analysis, 'travelTimePercentile')
-    grid.pointSetId = pointSetId
+
     // Pass into the store
-    dispatch(setRegionalAnalysisGrid(grid))
+    dispatch(
+      setRegionalAnalysisGrid({
+        // Parse the headers and create a usable grid.
+        ...createGrid(rawGrid),
+        // Assign the regional analysis _id and display parameters
+        analysisId: analysis._id,
+        cutoff: cutoff || get(analysis, 'cutoffMinutes'),
+        percentile: percentile || get(analysis, 'travelTimePercentile'),
+        pointSetId
+      })
+    )
   }
 }
 

--- a/lib/components/analysis/__tests__/__snapshots__/regional-results.js.snap
+++ b/lib/components/analysis/__tests__/__snapshots__/regional-results.js.snap
@@ -704,7 +704,7 @@ exports[`RegionalResults snapshot(mount) 1`] = `
                             }
                             colors={
                               Array [
-                                Object {
+                                Rgb {
                                   "b": 255,
                                   "g": 255,
                                   "opacity": 0,
@@ -4322,7 +4322,7 @@ exports[`RegionalResults with comparison snapshot(mount) 1`] = `
                                   "opacity": 0.42,
                                   "r": 252,
                                 },
-                                Object {
+                                Rgb {
                                   "b": 255,
                                   "g": 255,
                                   "opacity": 0,

--- a/lib/components/analysis/regional-results.tsx
+++ b/lib/components/analysis/regional-results.tsx
@@ -199,17 +199,22 @@ export default function RegionalResults({analysis}) {
           )}
 
           {displayGrid && displayScale ? (
-            displayScale.breaks.length > 0 ? (
+            displayScale.error ? (
+              <Alert roundedBottom='md' status='warning'>
+                <AlertIcon />
+                Data not suitable for generating a color scale.
+              </Alert>
+            ) : displayScale.breaks.length === 0 ? (
+              <Alert roundedBottom='md' status='warning'>
+                <AlertIcon />
+                There is no data to show.
+              </Alert>
+            ) : (
               <Legend
                 breaks={displayScale.breaks}
                 min={displayGrid.min}
                 colors={displayScale.colorRange}
               />
-            ) : (
-              <Alert roundedBottom='md' status='warning'>
-                <AlertIcon />
-                There is no data to show.
-              </Alert>
             )
           ) : (
             <Text p={4}>Loading grids...</Text>

--- a/lib/components/map/regional.js
+++ b/lib/components/map/regional.js
@@ -13,9 +13,9 @@ import Gridualizer from './gridualizer'
 let key = 0
 export default React.memo(function Regional() {
   const grid = useSelector(selectDisplayGrid)
-  const {colorizer} = useSelector(selectDisplayScale) || {}
+  const {error, colorizer} = useSelector(selectDisplayScale) || {}
 
-  if (!grid || !colorizer) return null
+  if (!grid || !colorizer || error) return null
 
   // Function is cheap. It just wraps draw tile with the necessary parts
   const drawTile = createDrawTile({colorizer, grid})

--- a/lib/selectors/regional-display-grid.ts
+++ b/lib/selectors/regional-display-grid.ts
@@ -7,7 +7,7 @@ export default createSelector(
   selectGrid.active,
   selectGrid.comparison,
   selectComparisonId,
-  (activeGrid, comparisonGrid, comparisonId) => {
+  (activeGrid, comparisonGrid, comparisonId: string) => {
     if (comparisonId) {
       if (activeGrid && comparisonGrid) {
         return subtract(activeGrid, comparisonGrid)
@@ -21,7 +21,7 @@ export default createSelector(
 /**
  * Non-destructively subtract grid B from grid A
  */
-function subtract(a, b) {
+function subtract(a: CL.RegionalGrid, b: CL.RegionalGrid): CL.RegionalGrid {
   const gridsDoNotAlign =
     a.west !== b.west ||
     a.north !== b.north ||

--- a/lib/selectors/regional-display-scale.ts
+++ b/lib/selectors/regional-display-scale.ts
@@ -1,4 +1,4 @@
-import {color as parseColor} from 'd3-color'
+import {color as parseColor, rgb, RGBColor} from 'd3-color'
 import {schemeBlues, schemeReds} from 'd3-scale-chromatic'
 import get from 'lodash/get'
 import {ckmeans, sample} from 'simple-statistics'
@@ -18,7 +18,7 @@ const TOTAL_BREAKS = 5
 const OPACITY = 0.42
 
 // Convert to rgba colors
-function toRGBA(c) {
+function toRGBA(c: string) {
   const rgb = parseColor(c).rgb()
   rgb.opacity = OPACITY
   return rgb
@@ -29,20 +29,20 @@ const schemeBlueDarken = schemeBlues[TOTAL_BREAKS + 1].slice(1)
 const schemeRedDarken = schemeReds[TOTAL_BREAKS + 1].slice(1).reverse()
 
 // Color ranges. Add a transparent point for 0s
-const zeroColor = {r: 255, g: 255, b: 255, opacity: 0}
+const zeroColor = rgb(255, 255, 255, 0)
 const colorRangePositive = schemeBlueDarken.map(toRGBA)
 const colorRangeNegative = schemeRedDarken.map(toRGBA)
 
 // Choropleth style colorizer for writing to Canvas. Canvas takes an RGBA array
 // for colors with the A being in the range of 0-255.
-function createColorizer(breaks, colorRange) {
+function createColorizer(breaks: number[], colorRange: RGBColor[]) {
   const colors = colorRange.map((c) => [
     c.r,
     c.g,
     c.b,
     Math.floor(c.opacity * 255)
   ])
-  return (v) => {
+  return (v: number) => {
     const floored = Math.floor(v)
     for (let i = 0; i < breaks.length; i++) {
       if (floored <= breaks[i]) return colors[i]
@@ -51,9 +51,9 @@ function createColorizer(breaks, colorRange) {
   }
 }
 
-const negate = (b) => -b
+const negate = (b: number) => -b
 
-export default createSelector(selectDisplayGrid, (grid) => {
+export default createSelector(selectDisplayGrid, (grid?: CL.RegionalGrid) => {
   if (!grid || get(grid, 'data.length') < 1) return null
   if (grid.min === grid.max) {
     return {
@@ -63,12 +63,12 @@ export default createSelector(selectDisplayGrid, (grid) => {
     }
   }
 
-  // CKMeans throws an error when clusters requested > total values
+  // CKMeans throws an error when clusters requested > total values.
   try {
     // All values are positive
     if (grid.min >= 0) {
       const values = selectRandomGridValues(grid)
-      const clusters = ckmeans(values, colorRangePositive.length)
+      const clusters: number[][] = ckmeans(values, colorRangePositive.length)
       const breaks = [0, ...findBreaks(clusters)]
       const colorRange = [zeroColor, ...colorRangePositive]
 
@@ -87,7 +87,7 @@ export default createSelector(selectDisplayGrid, (grid) => {
     // All values are negative
     if (grid.max <= 0) {
       const values = selectRandomGridValues(grid)
-      const clusters = ckmeans(values, colorRangeNegative.length)
+      const clusters: number[][] = ckmeans(values, colorRangeNegative.length)
       const breaks = [...findBreaks(clusters), 0]
       const colorRange = [...colorRangeNegative, zeroColor]
       return {
@@ -102,7 +102,7 @@ export default createSelector(selectDisplayGrid, (grid) => {
       // Sample only the positive numbers
       const positiveValues = selectRandomGridValues(grid, (v) => v > 0)
       // Add an additional break because the cluster around 0 is transparent
-      const positiveClusters = ckmeans(
+      const positiveClusters: number[][] = ckmeans(
         positiveValues,
         colorRangePositive.length + 1
       )
@@ -191,13 +191,16 @@ export default createSelector(selectDisplayGrid, (grid) => {
 
 // Filtering out the zeros seems to give more nuanced breaks. There are a huge
 // amount of zeros.
-const filterZero = (v) => v !== 0
+const filterZero = (v: number) => v !== 0
 
 /**
  * Randomly sample filtered grid values.
  */
-function selectRandomGridValues(grid, filter = filterZero) {
-  const filtered = grid.data.filter(filter)
+function selectRandomGridValues(
+  grid: CL.RegionalGrid,
+  filter = filterZero
+): number[] {
+  const filtered: number[] = Array.from(grid.data.filter(filter))
   if (filtered.length <= MAX_SAMPLE_SIZE) return filtered
 
   // Seed with the grid dimensions to sample the same points on similar grids
@@ -207,10 +210,10 @@ function selectRandomGridValues(grid, filter = filterZero) {
     grid.width,
     grid.height
   ])
-  return sample(filtered, MAX_SAMPLE_SIZE, () => generator.random())
+  return sample<number>(filtered, MAX_SAMPLE_SIZE, () => generator.random())
 }
 
 // Find the maximum values in each cluster
-function findBreaks(clusters) {
+function findBreaks(clusters: number[][]) {
   return clusters.map((c) => c[c.length - 1])
 }

--- a/lib/selectors/regional-grid.ts
+++ b/lib/selectors/regional-grid.ts
@@ -10,7 +10,13 @@ import selectDisplayCutoff from './regional-display-cutoff'
 import selectDisplayPercentile from './regional-display-percentile'
 import selectDisplayPointSet from './regional-display-destination-pointset'
 
-const findGrid = (grids, analysisId, cutoff, percentile, pointSet) =>
+const findGrid = (
+  grids: CL.RegionalGrid[],
+  analysisId: string,
+  cutoff: number,
+  percentile: number,
+  pointSet: string
+) =>
   grids.find(
     (g) =>
       g.analysisId === analysisId &&

--- a/lib/utils/create-grid.ts
+++ b/lib/utils/create-grid.ts
@@ -2,7 +2,7 @@
  * Create a Grid from an ArrayBuffer retrieved from the server or S3. Binary
  * data that uses a common header format used across Conveyal libraries.
  */
-export default function create(data: ArrayBuffer) {
+export default function create(data: ArrayBuffer): CL.ParsedGrid {
   const array = new Int32Array(data, 4 * 5)
   const header = new Int32Array(data)
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,8 @@
     "@turf/line-slice": "^5.1.5",
     "@turf/nearest-point-on-line": "^6.0.2",
     "@turf/point-to-line-distance": "^6.0.0",
+    "@types/d3-color": "^2.0.1",
+    "@types/d3-scale-chromatic": "^2.0.0",
     "@zeit/next-mdx": "^1.2.0",
     "classnames": "^2.2.6",
     "compare-versions": "^3.6.0",

--- a/types/conveyal.d.ts
+++ b/types/conveyal.d.ts
@@ -135,4 +135,47 @@ declare namespace CL {
     segments: ModificationSegment[]
     segmentSpeeds: SegmentSpeeds
   }
+
+  /**
+   * Access Grids
+   */
+
+  export type GridHeader = {
+    zoom: number
+    west: number
+    north: number
+    width: number
+    height: number
+  }
+
+  export type AccessGridHeader = GridHeader & {
+    depth: number
+    version: number
+  }
+
+  export type AccessGridMetadata = Record<string, unknown>
+
+  export type AccessGrid = AccessGridHeader &
+    AccessGridMetadata & {
+      data: Int32Array
+      errors: unknown[]
+      warnings: any
+      contains(x: number, y: number, z: number): boolean
+      get(x: number, y: number, z: number): number
+    }
+
+  export type ParsedGrid = GridHeader & {
+    data: Int32Array
+    min: number
+    max: number
+    contains(x: number, y: number): boolean
+    getValue(x: number, y: number): number
+  }
+
+  export type RegionalGrid = ParsedGrid & {
+    analysisId: string
+    cutoff: number
+    percentile: number
+    pointSetId: string
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2160,6 +2160,11 @@
   dependencies:
     cypress "*"
 
+"@types/d3-color@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/d3-color/-/d3-color-2.0.1.tgz#570ea7f8b853461301804efa52bd790a640a26db"
+  integrity sha512-u7LTCL7RnaavFSmob2rIAJLNwu50i6gFwY9cHFr80BrQURYQBRkJ+Yv47nA3Fm7FeRhdWTiVTeqvSeOuMAOzBQ==
+
 "@types/d3-format@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/d3-format/-/d3-format-2.0.0.tgz#607d261cb268f0a027f100575491031539a40ee6"
@@ -2169,6 +2174,11 @@
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/@types/d3-path/-/d3-path-1.0.9.tgz#73526b150d14cd96e701597cbf346cfd1fd4a58c"
   integrity sha512-NaIeSIBiFgSC6IGUBjZWcscUJEq7vpVu7KthHN8eieTV9d9MqkSOZLH4chq1PmcKy06PNe3axLeKmRIyxJ+PZQ==
+
+"@types/d3-scale-chromatic@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/d3-scale-chromatic/-/d3-scale-chromatic-2.0.0.tgz#8d4a6f07cbbf2a9f2a4bec9c9476c27ed76a96ea"
+  integrity sha512-Y62+2clOwZoKua84Ha0xU77w7lePiaBoTjXugT4l8Rd5LAk+Mn/ZDtrgs087a+B5uJ3jYUHHtKw5nuEzp0WBHw==
 
 "@types/d3-scale@^3.2.2":
   version "3.2.2"


### PR DESCRIPTION
If the total data values are less than the breaks generated, an ugly uncaught exception will occur. This wraps that exception in a try/catch and shows an error message instead.

## Note
I couldn't reproduce the error locally. And therefore was unable to create a Cypress test for this. If someone knows how to reproduce, please let me know.

Addresses #1153 