### PR TITLE
Bugfix: use correct index when dragging stops

### DIFF
--- a/cypress/integration/modifications/add-trip-pattern.ts
+++ b/cypress/integration/modifications/add-trip-pattern.ts
@@ -130,13 +130,13 @@ describe('Add Trip Pattern', () => {
       const newCoord: L.LatLngTuple = [39.08, -84.5]
       const tempCoord: L.LatLngTuple = [39.09, -84.5]
 
-      cy.dragMarker('Stop 1', lastCoord, newCoord)
+      cy.dragMarker('Stop 2', lastCoord, newCoord)
       cy.findByText(/2 stops over 1.7/)
 
-      cy.dragMarker('Stop 1', newCoord, tempCoord)
+      cy.dragMarker('Stop 2', newCoord, tempCoord)
       cy.findByText(/2 stops over 2/)
 
-      cy.dragMarker('Stop 1', tempCoord, newCoord)
+      cy.dragMarker('Stop 2', tempCoord, newCoord)
       cy.findByText(/2 stops over 1.7/)
     })
 
@@ -159,7 +159,7 @@ describe('Add Trip Pattern', () => {
       const coord: L.LatLngTuple = [39.08, -84.49]
       const newCoord: L.LatLngTuple = [39.09, -84.49]
       cy.clickMapAtCoord(coord)
-      cy.dragMarker('Stop 1', coord, newCoord)
+      cy.dragMarker('Stop 2', coord, newCoord)
       cy.findByText(/3 stops over 2/)
     })
 
@@ -194,7 +194,7 @@ describe('Add Trip Pattern', () => {
         const even = i % 2 === 0
         const latInc = even ? step : 0
         const lonInc = even ? 0 : step
-        cy.dragMarker(`Stop ${i}`, [lat, lon], [lat + latInc, lon + lonInc])
+        cy.dragMarker(`Stop ${i + 1}`, [lat, lon], [lat + latInc, lon + lonInc])
         lat += step
         lon += step
       }

--- a/lib/components/modifications-map/transit-editor/index.tsx
+++ b/lib/components/modifications-map/transit-editor/index.tsx
@@ -97,19 +97,14 @@ function useNewStopIcon() {
 }
 
 // Get the modification segments. Always return an array
+const EMPTY_SEGMENTS = []
 const getSegments = (m: Modification): CL.ModificationSegment[] => [
-  ...(m.segments || [])
+  ...(m.segments || EMPTY_SEGMENTS)
 ]
 
 // Hook for getting the segments
 function useSegments(modification: Modification) {
-  const [segments, setSegments] = useState<CL.ModificationSegment[]>(
-    modification.segments || []
-  )
-  useEffect(() => {
-    setSegments(modification.segments || [])
-  }, [modification.segments])
-  return segments
+  return modification.segments || EMPTY_SEGMENTS
 }
 
 /**
@@ -146,6 +141,9 @@ export default function TransitEditor({
     [toast]
   )
 
+  /**
+   * Handles creating a new array so each usage below does not have to.
+   */
   const updateSegments = useCallback(
     (newSegments: CL.ModificationSegment[]) => {
       updateModification({segments: [...newSegments]})
@@ -304,7 +302,7 @@ export default function TransitEditor({
   )
 }
 
-const getLineWeightForZoom = (z) => (z < 11 ? 1 : z - 9)
+const getLineWeightForZoom = (z: number) => (z < 11 ? 1 : z - 9)
 function useLineWeight() {
   const zoom = useZoom()
   const [lineWeight, setLineWeight] = useState(() => getLineWeightForZoom(zoom))
@@ -402,7 +400,9 @@ function useStops(segments: CL.ModificationSegment[]) {
   return stops
 }
 
-const autoCreatedStopKey = (s) => `Auto-created Stop ${s.index}`
+// Use array index here instead of overall index
+const autoCreatedStopKey = (index: number) => `Auto-created Stop ${index + 1}`
+
 function AutoCreatedStops({onDragEnd, segments}) {
   const newStopIcon = useNewStopIcon()
   const stops = useStops(segments)
@@ -411,12 +411,12 @@ function AutoCreatedStops({onDragEnd, segments}) {
     <Pane zIndex={zIndex.autoCreatedStops}>
       {stops
         .filter((s) => s.autoCreated)
-        .map((stop) => (
+        .map((stop, index) => (
           <Marker
             position={stop}
             draggable
             icon={newStopIcon}
-            key={autoCreatedStopKey(stop)}
+            key={autoCreatedStopKey(index)}
             onClick={(event: L.LeafletMouseEvent) => {
               logDomEvent('AutoCreatedStop.onClick', event)
               DomEvent.stop(event)
@@ -428,7 +428,7 @@ function AutoCreatedStops({onDragEnd, segments}) {
               onDragEnd(stop.index, (event.target as L.Marker).getLatLng())
             }}
             opacity={0.5}
-            title={autoCreatedStopKey(stop)}
+            title={autoCreatedStopKey(index)}
           />
         ))}
     </Pane>
@@ -448,63 +448,62 @@ function useNewSnappedStopIcon() {
   return newSnappedStopIcon
 }
 
-const stopKey = (stop) => `Stop ${stop.index}`
+// Array index is used here because it refers to the nth Stop instead of overall index
+const stopKey = (index: number) => `Stop ${index + 1}`
+
 function Stops({deleteStop, onStopDragEnd, segments, updateSegments}) {
   const stops = useStops(segments)
   const newSnappedStopIcon = useNewSnappedStopIcon()
   const newStopIcon = useNewStopIcon()
   const zoom = useZoom()
 
-  const toggleStop = useCallback(
-    (stopIndex) => {
-      if (stopIndex < segments.length) {
-        segments[stopIndex] = {
-          ...segments[stopIndex],
-          stopAtStart: false,
-          fromStopId: null
-        }
+  function toggleStop(stopIndex: number, segments: CL.ModificationSegment[]) {
+    if (stopIndex < segments.length) {
+      segments[stopIndex] = {
+        ...segments[stopIndex],
+        stopAtStart: false,
+        fromStopId: null
       }
+    }
 
-      if (stopIndex > 0) {
-        segments[stopIndex - 1] = {
-          ...segments[stopIndex - 1],
-          stopAtEnd: false,
-          toStopId: null
-        }
+    if (stopIndex > 0) {
+      segments[stopIndex - 1] = {
+        ...segments[stopIndex - 1],
+        stopAtEnd: false,
+        toStopId: null
       }
-      updateSegments(segments)
-    },
-    [segments, updateSegments]
-  )
+    }
+    updateSegments(segments)
+  }
 
   return (
     <Pane zIndex={zIndex.stops}>
       {stops
         .filter((s) => !s.autoCreated)
-        .map((stop, stopIndex) => (
+        .map((stop, index) => (
           <Marker
             position={stop}
             icon={stop.stopId ? newSnappedStopIcon : newStopIcon}
             draggable
-            key={`${stopKey(stop)} ${zoom} ${stop.lng},${stop.lat}`}
-            title={stopKey(stop)}
+            key={`${stopKey(index)} ${zoom} ${stop.lng},${stop.lat}`}
+            title={stopKey(index)}
             ondragend={(event: L.DragEndEvent) => {
               logDomEvent('Stop.onDragEnd', event)
               DomEvent.stop(event)
-              onStopDragEnd(stopIndex, (event.target as L.Marker).getLatLng())
+              onStopDragEnd(stop.index, (event.target as L.Marker).getLatLng())
             }}
           >
             <Popup>
               <Stack>
-                <Heading size='sm'>{stopKey(stop)}</Heading>
+                <Heading size='sm'>{stopKey(index)}</Heading>
                 <Button
-                  onClick={() => toggleStop(stopIndex)}
+                  onClick={() => toggleStop(stop.index, segments)}
                   variantColor='blue'
                 >
                   {message('transitEditor.makeControlPoint')}
                 </Button>
                 <Button
-                  onClick={() => deleteStop(stopIndex)}
+                  onClick={() => deleteStop(stop.index)}
                   variantColor='red'
                 >
                   {message('transitEditor.deletePoint')}
@@ -547,7 +546,7 @@ type ControlPointsProps = {
   updateSegments: (segments: CL.ModificationSegment[]) => void
 }
 
-const controlPointKey = (cp) => `Control Point ${cp.index}`
+const controlPointKey = (index: number) => `Control Point ${index + 1}`
 function ControlPoints({
   deletePoint,
   onDragEnd,
@@ -558,46 +557,46 @@ function ControlPoints({
   const controlPointIcon = useControlPointIcon()
   const zoom = useZoom()
 
-  const togglePoint = useCallback(
-    (pointIndex: number) => {
-      if (pointIndex < segments.length) {
-        segments[pointIndex] = {
-          ...segments[pointIndex],
-          stopAtStart: true
-        }
+  function togglePoint(pointIndex: number, segments: CL.ModificationSegment[]) {
+    if (pointIndex < segments.length) {
+      segments[pointIndex] = {
+        ...segments[pointIndex],
+        stopAtStart: true
       }
+    }
 
-      if (pointIndex > 0) {
-        segments[pointIndex - 1] = {
-          ...segments[pointIndex - 1],
-          stopAtEnd: true
-        }
+    if (pointIndex > 0) {
+      segments[pointIndex - 1] = {
+        ...segments[pointIndex - 1],
+        stopAtEnd: true
       }
+    }
 
-      updateSegments(segments)
-    },
-    [segments, updateSegments]
-  )
+    updateSegments(segments)
+  }
 
   return (
     <Pane zIndex={zIndex.controlPoints}>
-      {controlPoints.map((cp) => (
+      {controlPoints.map((cp, index) => (
         <Marker
           position={cp}
           draggable
           icon={controlPointIcon}
-          key={`${controlPointKey(cp)} ${zoom} ${cp.lng} ${cp.lat}`}
+          key={`${controlPointKey(index)} ${zoom} ${cp.lng} ${cp.lat}`}
           onDragend={(event: L.DragEndEvent) => {
             logDomEvent('ControlPoint.onDragend', event)
             DomEvent.stop(event)
             onDragEnd(cp.index, (event.target as L.Marker).getLatLng())
           }}
-          title={controlPointKey(cp)}
+          title={controlPointKey(index)}
         >
           <Popup>
             <Stack>
-              <Heading size='sm'>{controlPointKey(cp)}</Heading>
-              <Button onClick={() => togglePoint(cp.index)} variantColor='blue'>
+              <Heading size='sm'>{controlPointKey(index)}</Heading>
+              <Button
+                onClick={() => togglePoint(cp.index, segments)}
+                variantColor='blue'
+              >
                 {message('transitEditor.makeStop')}
               </Button>
               <Button onClick={() => deletePoint(cp.index)} variantColor='red'>

--- a/lib/components/modifications-map/transit-editor/index.tsx
+++ b/lib/components/modifications-map/transit-editor/index.tsx
@@ -457,7 +457,7 @@ function Stops({deleteStop, onStopDragEnd, segments, updateSegments}) {
   const newStopIcon = useNewStopIcon()
   const zoom = useZoom()
 
-  function toggleStop(stopIndex: number, segments: CL.ModificationSegment[]) {
+  function toggleStop(stopIndex: number) {
     if (stopIndex < segments.length) {
       segments[stopIndex] = {
         ...segments[stopIndex],
@@ -497,7 +497,7 @@ function Stops({deleteStop, onStopDragEnd, segments, updateSegments}) {
               <Stack>
                 <Heading size='sm'>{stopKey(index)}</Heading>
                 <Button
-                  onClick={() => toggleStop(stop.index, segments)}
+                  onClick={() => toggleStop(stop.index)}
                   variantColor='blue'
                 >
                   {message('transitEditor.makeControlPoint')}
@@ -557,7 +557,7 @@ function ControlPoints({
   const controlPointIcon = useControlPointIcon()
   const zoom = useZoom()
 
-  function togglePoint(pointIndex: number, segments: CL.ModificationSegment[]) {
+  function togglePoint(pointIndex: number) {
     if (pointIndex < segments.length) {
       segments[pointIndex] = {
         ...segments[pointIndex],
@@ -593,10 +593,7 @@ function ControlPoints({
           <Popup>
             <Stack>
               <Heading size='sm'>{controlPointKey(index)}</Heading>
-              <Button
-                onClick={() => togglePoint(cp.index, segments)}
-                variantColor='blue'
-              >
+              <Button onClick={() => togglePoint(cp.index)} variantColor='blue'>
                 {message('transitEditor.makeStop')}
               </Button>
               <Button onClick={() => deletePoint(cp.index)} variantColor='red'>


### PR DESCRIPTION
Incorrect `stopIndex` was being passed to `onDragStop`. This adds a test with the examples from #1432 and fixes the problem by using the correct stop index. 

Other changes include using the specific array index for each point type for its key/title.

fixes #1432 