### PR TITLE
Add ZenDesk chat widget

### DIFF
--- a/lib/components/sidebar.tsx
+++ b/lib/components/sidebar.tsx
@@ -5,9 +5,9 @@ import {
   faCubes,
   faDatabase,
   faGlobe,
+  faInfoCircle,
   faLayerGroup,
   faPencilAlt,
-  faQuestionCircle,
   faServer,
   faSignOutAlt,
   faTh,
@@ -197,9 +197,9 @@ export default function Sidebar() {
           />
         )}
         <ExternalLink
-          icon={faQuestionCircle}
+          icon={faInfoCircle}
           label={message('nav.help')}
-          href='http://docs.conveyal.com'
+          href='https://docs.conveyal.com'
         />
         <OnlineIndicator />
       </div>

--- a/lib/user.ts
+++ b/lib/user.ts
@@ -19,6 +19,7 @@ export interface IUser {
 declare global {
   interface Window {
     __user?: IUser
+    zE: any
   }
 }
 
@@ -53,6 +54,16 @@ export function storeUser(user: IUser): void {
     accessGroup: user.accessGroup,
     email: user.email
   })
+
+  // Identify the user for ZenDesk
+  if (window.zE) {
+    window.zE(() => {
+      window.zE.identify({
+        emai: user.email,
+        organization: user.accessGroup
+      })
+    })
+  }
 
   // Store the user on window, requiring a new session on each tab/page
   window.__user = user

--- a/lib/user.ts
+++ b/lib/user.ts
@@ -59,7 +59,8 @@ export function storeUser(user: IUser): void {
   if (window.zE) {
     window.zE(() => {
       window.zE.identify({
-        emai: user.email,
+        name: user.email,
+        email: user.email,
         organization: user.accessGroup
       })
     })

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -26,6 +26,14 @@ const Analytics = () => (
   </>
 )
 
+const ZenDeskWidget = () =>
+  process.env.ZENDESK_KEY != null && (
+    <script
+      id='ze-snippet'
+      src={`https://static.zdassets.com/ekr/snippet.js?key=${process.env.ZENDESK_KEY}`}
+    />
+  )
+
 export default class extends Document {
   render() {
     return (
@@ -39,6 +47,7 @@ export default class extends Document {
           <link rel='shortcut icon' href={LOGO_URL} type='image/x-icon' />
           <Stylesheets />
           <Analytics />
+          <ZenDeskWidget />
         </Head>
         <body>
           <Main />


### PR DESCRIPTION
Add's the snippet from ZenDesk for the chat/support widget. If no "agents" are online (which will be the usual case), it will allow users to directly submit support requests from inside the application.

This PR also identifies all logged in users with the widget so that user's will not have to input their email addresses for us to know who submitted the request/chat.