### PR TITLE
Show errors in create modal

### DIFF
--- a/cypress/integration/clear-data.ts
+++ b/cypress/integration/clear-data.ts
@@ -1,6 +1,6 @@
 import {clearTemporaryData} from './utils'
 
-describe.skip('Clear all test data', () => {
+describe('Clear all test data', () => {
   before(() => {
     clearTemporaryData()
   })

--- a/lib/components/analysis/create-regional.tsx
+++ b/lib/components/analysis/create-regional.tsx
@@ -36,8 +36,7 @@ import {routeTo} from 'lib/router'
 import selectCurrentRegionId from 'lib/selectors/current-region-id'
 import selectMaxTripDurationMinutes from 'lib/selectors/max-trip-duration-minutes'
 import selectTravelTimePercentile from 'lib/selectors/travel-time-percentile'
-import {safeFetch} from 'lib/utils/safe-fetch'
-import {getUser} from 'lib/user'
+import authenticatedFetch from 'lib/utils/auth-fetch'
 
 import Select from '../select'
 
@@ -69,16 +68,9 @@ const testPercentile = (p, o) => onlyDigits(o) && p >= 1 && p <= 99
 const disabledLabel = 'Fetch results with the current settings to enable button'
 
 function createRegionalAnalysis(options: Record<string, unknown>) {
-  return safeFetch(API.Regional, {
+  return authenticatedFetch(API.Regional, {
     method: 'POST',
-    mode: 'cors',
-    body: JSON.stringify(options),
-    headers: {
-      Accept: 'application/json',
-      'Content-Type': 'application/json;charset=UTF-8',
-      Authorization: `bearer ${getUser().idToken}`,
-      'X-Conveyal-Access-Group': getUser().adminTempAccessGroup
-    }
+    body: JSON.stringify(options)
   })
 }
 

--- a/lib/components/analysis/create-regional.tsx
+++ b/lib/components/analysis/create-regional.tsx
@@ -14,10 +14,8 @@ import {
   FormHelperText,
   Stack,
   Alert,
-  CloseButton,
   AlertIcon,
-  AlertDescription,
-  AlertTitle
+  AlertDescription
 } from '@chakra-ui/core'
 import fpGet from 'lodash/fp/get'
 import get from 'lodash/get'

--- a/lib/components/analysis/create-regional.tsx
+++ b/lib/components/analysis/create-regional.tsx
@@ -12,7 +12,12 @@ import {
   ModalOverlay,
   useDisclosure,
   FormHelperText,
-  Stack
+  Stack,
+  Alert,
+  CloseButton,
+  AlertIcon,
+  AlertDescription,
+  AlertTitle
 } from '@chakra-ui/core'
 import fpGet from 'lodash/fp/get'
 import get from 'lodash/get'
@@ -95,6 +100,7 @@ export default function CreateRegional({
 
 function CreateModal({onClose, profileRequest, projectId, variantIndex}) {
   const dispatch = useDispatch()
+  const [error, setError] = useState<string | null>('Test error message')
   const [isCreating, setIsCreating] = useState(false)
   const opportunityDatasets = useSelector(selectOpportunityDatasets)
   const selectedOpportunityDataset = useSelector(activeOpportunityDataset)
@@ -177,7 +183,11 @@ function CreateModal({onClose, profileRequest, projectId, variantIndex}) {
       const {as, href} = routeTo('regionalAnalyses', {regionId})
       router.push(href, as)
     } catch (e) {
+      console.error(e)
       setIsCreating(false)
+      if (e instanceof Error) {
+        setError(e.message)
+      }
     }
   }
 
@@ -202,6 +212,14 @@ function CreateModal({onClose, profileRequest, projectId, variantIndex}) {
         <ModalCloseButton />
         <ModalBody>
           <Stack mb={4} spacing={4}>
+            {error && (
+              <Alert status='error'>
+                <AlertIcon />
+                <AlertDescription>
+                  Error creating regional analysis. {error}
+                </AlertDescription>
+              </Alert>
+            )}
             <FormControl
               isDisabled={isCreating}
               mb={4}

--- a/lib/components/analysis/create-regional.tsx
+++ b/lib/components/analysis/create-regional.tsx
@@ -98,7 +98,7 @@ export default function CreateRegional({
 
 function CreateModal({onClose, profileRequest, projectId, variantIndex}) {
   const dispatch = useDispatch()
-  const [error, setError] = useState<string | null>('Test error message')
+  const [error, setError] = useState<string | null>(null)
   const [isCreating, setIsCreating] = useState(false)
   const opportunityDatasets = useSelector(selectOpportunityDatasets)
   const selectedOpportunityDataset = useSelector(activeOpportunityDataset)

--- a/lib/selectors/current-regional-analysis-id.js
+++ b/lib/selectors/current-regional-analysis-id.js
@@ -1,2 +1,4 @@
 import get from 'lodash/get'
-export default (state) => get(state, 'queryString.analysisId')
+export default function selectCurrentRegionalAnalysisId(state) {
+  return get(state, 'queryString.analysisId')
+}

--- a/lib/selectors/regional-analyses.js
+++ b/lib/selectors/regional-analyses.js
@@ -1,2 +1,4 @@
 import get from 'lodash/get'
-export default (state) => get(state, 'regionalAnalyses.analyses', [])
+export default function selectRegionalAnalyses(state) {
+  return get(state, 'regionalAnalyses.analyses', [])
+}

--- a/lib/user.ts
+++ b/lib/user.ts
@@ -35,7 +35,7 @@ export const UserContext = createContext(null)
 
 // Helper functions to hide storage details
 // Store on `window` so that each new tab/window needs to check the session
-export function getUser(serverSideUser?: IUser): IUser | void {
+export function getUser(serverSideUser?: IUser): undefined | IUser {
   if (isDisabled) return localUser
   if (isServer) return serverSideUser
   return window.__user || serverSideUser

--- a/lib/utils/auth-fetch.ts
+++ b/lib/utils/auth-fetch.ts
@@ -1,0 +1,26 @@
+import {getUser} from '../user'
+
+import {safeFetch} from './safe-fetch'
+
+/**
+ * Fetch wrapper that includes authentication. Defaults to JSON.
+ */
+export default function authFetch(url: string, options?: RequestInit) {
+  const user = getUser()
+  const headers = {
+    Accept: 'application/json',
+    'Content-Type': 'application/json;charset=UTF-8',
+    Authorization: `bearer ${user.idToken}`
+  }
+  if (user.adminTempAccessGroup)
+    headers['X-Conveyal-Access-Group'] = user.adminTempAccessGroup
+
+  return safeFetch(url, {
+    mode: 'cors',
+    ...options,
+    headers: {
+      ...headers,
+      ...options?.headers
+    }
+  })
+}


### PR DESCRIPTION
If an error occurs while creating a regional analysis, log it to the console and show it in an `Alert` box. The dispatched fetch was causing errors to be handled in a variety of ways, so I moved it to use a `safeFetch` to handle errors in the same way. (`safeFetch` should never throw an error)