### PR TITLE
Log paths for debugging

### DIFF
--- a/lib/actions/analysis/index.ts
+++ b/lib/actions/analysis/index.ts
@@ -244,6 +244,10 @@ export const handleSurface = (error, responses) => {
   const comparisonSurface =
     responses.length > 1 ? responseToSurface(responses[1].value) : undefined
 
+  // Log parsed responses for debugging
+  console.log('Surface', surface)
+  if (comparisonSurface) console.log('Comparison surface', comparisonSurface)
+
   return [
     setScenarioApplicationErrors(null),
     setScenarioApplicationWarnings([


### PR DESCRIPTION
Logs entire parsed response, which contains `pathSummaries` when enabled.

Addresses #1391 