### PR TITLE
Increase JVM heap when testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "migrate": "migrate --store=./db/migrations-store.js --env=.env.local",
     "start": "next start",
-    "start-backend": "java -Xmx5G -cp *.jar com.conveyal.analysis.BackendMain > /dev/null",
+    "start-backend": "java -Xmx4G -cp *.jar com.conveyal.analysis.BackendMain > /dev/null",
     "pretest": "yarn",
     "test": "yarn tsc && yarn lint && yarn jest",
     "test-debug": "node --inspect-brk node_modules/.bin/jest --runInBand"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "migrate": "migrate --store=./db/migrations-store.js --env=.env.local",
     "start": "next start",
-    "start-backend": "java -cp *.jar com.conveyal.analysis.BackendMain > /dev/null",
+    "start-backend": "java -Xmx5G -cp *.jar com.conveyal.analysis.BackendMain > /dev/null",
     "pretest": "yarn",
     "test": "yarn tsc && yarn lint && yarn jest",
     "test-debug": "node --inspect-brk node_modules/.bin/jest --runInBand"


### PR DESCRIPTION
## Description
I noticed slow or highly variable run times when running Cypress tests in the new branch of R5 that runs these tests. In staging and production, we usually give the backend a maximum JVM heap size of many GB. But `yarn start-backend` is using the default max, which is 1/4 of total memory. It's possible that the heap is getting cluttered and the GC thread is using a lot of CPU, slowing down the tests.

The GH Actions documentation at https://docs.github.com/en/actions/reference/specifications-for-github-hosted-runners says that Linux runners have 7GB of memory. The JVM heap defaults to 1/4 of that, 1.75 GB. I'm increasing significantly see if tests complete more quickly.

## How to test
Just observe the Action runs with this change and see if they're faster.