### PR TITLE
Add custom origins regional analysis test

### DIFF
--- a/cypress/fixtures/regions/nky/hospitals.csv
+++ b/cypress/fixtures/regions/nky/hospitals.csv
@@ -1,0 +1,4 @@
+lon,lat,name
+-84.518361,39.07198,St Elizabeth Covington Hospital
+-84.563353,39.01394,St Elizabeth Medical Center Edgewood
+-84.467161,39.078317,St Elizabeth Fort Thomas Hospital

--- a/cypress/index.d.ts
+++ b/cypress/index.d.ts
@@ -82,7 +82,12 @@ declare namespace Cypress {
      * @param name
      * @param filePath
      */
-    createOpportunityDataset(name: string, filePath: string): Chainable<string>
+    createOpportunityDataset(
+      name: string,
+      filePath: string,
+      isFreeform?: boolean,
+      idField?: string
+    ): Chainable<string>
 
     /**
      * Create a new regional analysis.

--- a/cypress/integration/2-opportunities.ts
+++ b/cypress/integration/2-opportunities.ts
@@ -17,7 +17,7 @@ describe('Opportunity Datasets', function () {
 
   beforeEach(() => region.navTo('spatial datasets'))
 
-  const importedWithGrid = region.getOpportunityDataset(
+  const importedWithGrid = region.getSpatialDataset(
     'Grid Import',
     scratchRegion.opportunities.grid.file
   )

--- a/cypress/integration/6-analysis.ts
+++ b/cypress/integration/6-analysis.ts
@@ -73,7 +73,7 @@ describe('Analysis', () => {
 
   // tests basic single point analysis at specified locations
   it('runs, giving reasonable results', function () {
-    region.defaultOpportunityDataset.select()
+    region.defaultSpatialDataset.select()
     // move marker and align map for snapshot
     for (const key in scratchRegion.locations) {
       const location: L.LatLngTuple = scratchRegion.locations[key]
@@ -97,7 +97,7 @@ describe('Analysis', () => {
       cy.findByLabelText(/Max LTS/).select('4')
     })
 
-    region.defaultOpportunityDataset.select()
+    region.defaultSpatialDataset.select()
     cy.fetchResults()
 
     getOpportunityCount().isWithin(results.bikeOnly)
@@ -134,7 +134,7 @@ describe('Analysis', () => {
     cy.setOrigin(location)
     cy.fetchResults()
 
-    region.defaultOpportunityDataset.select()
+    region.defaultSpatialDataset.select()
     getOpportunityCount().isWithin(results.customBounds)
   })
 
@@ -149,7 +149,7 @@ describe('Analysis', () => {
     })
 
     cy.setOrigin(location)
-    region.defaultOpportunityDataset.select()
+    region.defaultSpatialDataset.select()
     cy.fetchResults()
 
     getOpportunityCount().isWithin(results['6:00-8:00'], 10)
@@ -178,7 +178,7 @@ describe('Analysis', () => {
     const location = scratchRegion.locations.center as L.LatLngTuple
     cy.setOrigin(location)
 
-    region.defaultOpportunityDataset.select()
+    region.defaultSpatialDataset.select()
     cy.fetchResults()
 
     cy.get('svg#results-chart')
@@ -231,7 +231,7 @@ describe('Analysis', () => {
 
     cy.fetchResults()
     cy.findByText(/Select an opportunity dataset to see accessibility/)
-    region.defaultOpportunityDataset.select()
+    region.defaultSpatialDataset.select()
 
     // Logistic function should cause "out of sync" after dataset selected
     cy.findByText(/Results are out of sync with settings/)

--- a/cypress/integration/example.ts
+++ b/cypress/integration/example.ts
@@ -19,7 +19,7 @@ describe('Example Modification Test', () => {
   )
 
   // Create a new opportunity dataset
-  const opportunityData = newRegion.getOpportunityDataset(
+  const opportunityData = newRegion.getSpatialDataset(
     'Example OD',
     'regions/nky/people.grid'
   )

--- a/cypress/integration/regional/basic.ts
+++ b/cypress/integration/regional/basic.ts
@@ -4,24 +4,15 @@ describe('Regional', () => {
   const region = getDefaultRegion()
 
   describe('Create Modal', () => {
-    before(() => {
+    it('should show total origins', () => {
       region.initializeAnalysisDefaults()
       region.fetchAccessibilityComparison(region.center)
       cy.getPrimaryAnalysisSettings().within(() => {
         cy.findButton(/Regional analysis/).click()
       })
-    })
-
-    it('should show total origins', () => {
       cy.findByText(/Analysis will run for 11,644 origin points/)
+      cy.findButton(/Cancel/).click()
     })
-
-    it(
-      'should show error if opportunity datasets selected are not the same size'
-    )
-    it(
-      'should show error if a freeform pointset and other opportunity datasets are selected'
-    )
   })
 
   describe('Results', () => {

--- a/cypress/integration/regional/basic.ts
+++ b/cypress/integration/regional/basic.ts
@@ -2,65 +2,91 @@ import {getDefaultRegion, scratchRegion} from '../utils'
 
 describe('Regional', () => {
   const region = getDefaultRegion()
-  const regionalAnalysis = region.getRegionalAnalysis('Basic Regional Test', {
-    settings: {
-      bounds: scratchRegion.customRegionSubset
-    }
-  })
 
-  // For faster testing results, comment out the below
-  after(() => regionalAnalysis.delete())
-
-  beforeEach(() => {
-    cy.findByText(/Access to/i)
-      .parent()
-      .as('legend')
-  })
-
-  it('verifies regional analysis results', function () {
-    cy.get('@legend').should('not.contain', 'Loading grids')
-    // compare to self with different time cutoff and check the legend again
-    cy.findByLabelText(/Compare to/).type(`${regionalAnalysis.name}{enter}`, {
-      force: true
+  describe('Create Modal', () => {
+    before(() => {
+      region.initializeAnalysisDefaults()
+      region.fetchAccessibilityComparison(region.center)
+      cy.getPrimaryAnalysisSettings().within(() => {
+        cy.findButton(/Regional analysis/).click()
+      })
     })
-    // TODO make these select elements easier to identify
-    cy.findByText(/Compare to/)
-      .parent()
-      .parent()
-      .findByRole('option', {name: '45 minutes'})
-      .parent()
-      .select('60 minutes')
-    cy.get('@legend').should('not.contain', 'Loading grids')
-    // test aggreation area upload
-    cy.findByText(/upload new aggregation area/i).click()
-    cy.findByRole('button', {name: 'Upload'}).as('upload').should('be.disabled')
-    cy.findByLabelText(/Aggregation area name/i).type('cities')
-    cy.findByLabelText(/Select aggregation area files/i)
-      .attachFile({
-        filePath: scratchRegion.aggregationAreas.files[0],
-        encoding: 'base64'
+
+    it('should show total origins', () => {
+      cy.findByText(/Analysis will run for 11,644 origin points/)
+    })
+
+    it(
+      'should show error if opportunity datasets selected are not the same size'
+    )
+    it(
+      'should show error if a freeform pointset and other opportunity datasets are selected'
+    )
+  })
+
+  describe('Results', () => {
+    const regionalAnalysis = region.getRegionalAnalysis('Basic Regional Test', {
+      settings: {
+        bounds: scratchRegion.customRegionSubset
+      }
+    })
+
+    // For faster testing results, comment out the below
+    after(() => regionalAnalysis.delete())
+
+    beforeEach(() => {
+      cy.findByText(/Access to/i)
+        .parent()
+        .as('legend')
+    })
+
+    it('verifies regional analysis results', function () {
+      cy.get('@legend').should('not.contain', 'Loading grids')
+      // compare to self with different time cutoff and check the legend again
+      cy.findByLabelText(/Compare to/).type(`${regionalAnalysis.name}{enter}`, {
+        force: true
       })
-      .attachFile({
-        filePath: scratchRegion.aggregationAreas.files[1],
-        encoding: 'base64'
-      })
-      .attachFile({
-        filePath: scratchRegion.aggregationAreas.files[2],
-        encoding: 'base64'
-      })
-      .attachFile({
-        filePath: scratchRegion.aggregationAreas.files[3],
-        encoding: 'base64'
-      })
-    cy.findByLabelText(/Union/).uncheck({force: true})
-    cy.findByLabelText(/Shapefile attribute to use as aggregation area name/i)
-      .clear()
-      .type(scratchRegion.aggregationAreas.nameField)
-    cy.get('@upload').scrollIntoView().click()
-    cy.contains(/Upload complete/, {timeout: 30000}).should('be.visible')
-    // TODO label dissociated from input
-    //cy.findByLabelText(/Aggregate results to/i)
-    //  .type(this.region.aggregationAreas.sampleName+'{enter}')
+      // TODO make these select elements easier to identify
+      cy.findByText(/Compare to/)
+        .parent()
+        .parent()
+        .findByRole('option', {name: '45 minutes'})
+        .parent()
+        .select('60 minutes')
+      cy.get('@legend').should('not.contain', 'Loading grids')
+      // test aggreation area upload
+      cy.findByText(/upload new aggregation area/i).click()
+      cy.findByRole('button', {name: 'Upload'})
+        .as('upload')
+        .should('be.disabled')
+      cy.findByLabelText(/Aggregation area name/i).type('cities')
+      cy.findByLabelText(/Select aggregation area files/i)
+        .attachFile({
+          filePath: scratchRegion.aggregationAreas.files[0],
+          encoding: 'base64'
+        })
+        .attachFile({
+          filePath: scratchRegion.aggregationAreas.files[1],
+          encoding: 'base64'
+        })
+        .attachFile({
+          filePath: scratchRegion.aggregationAreas.files[2],
+          encoding: 'base64'
+        })
+        .attachFile({
+          filePath: scratchRegion.aggregationAreas.files[3],
+          encoding: 'base64'
+        })
+      cy.findByLabelText(/Union/).uncheck({force: true})
+      cy.findByLabelText(/Shapefile attribute to use as aggregation area name/i)
+        .clear()
+        .type(scratchRegion.aggregationAreas.nameField)
+      cy.get('@upload').scrollIntoView().click()
+      cy.contains(/Upload complete/, {timeout: 30000}).should('be.visible')
+      // TODO label dissociated from input
+      //cy.findByLabelText(/Aggregate results to/i)
+      //  .type(this.region.aggregationAreas.sampleName+'{enter}')
+    })
   })
 
   it('test starting and deleting a running analysis')

--- a/cypress/integration/regional/origins.ts
+++ b/cypress/integration/regional/origins.ts
@@ -1,0 +1,24 @@
+import {getDefaultRegion} from '../utils'
+
+/**
+ * Select custom origin point sets.
+ */
+describe('Regional > Custom Origins', () => {
+  const region = getDefaultRegion()
+  const hospitals = region.getFreeformDataset(
+    'Hospitals',
+    'regions/nky/hospitals.csv',
+    'name'
+  )
+  const customOriginAnalysis = region.getRegionalAnalysis('Custom Origin', {
+    originPointSet: hospitals.name
+  })
+
+  it('should run a regional analysis with custom origins', () => {
+    customOriginAnalysis.navTo()
+    cy.findButton(/Export data/).click()
+    cy.findByText(/GeoTIFF/).should('be.disabled')
+    cy.findByText(/Access CSV/).should('be.enabled')
+    // .click() Disabled. Will crash Cypress for now.
+  })
+})

--- a/cypress/integration/utils.ts
+++ b/cypress/integration/utils.ts
@@ -69,7 +69,7 @@ export function getDefaultRegion(): Region {
   )
 
   // Create a default opportunity dataset
-  defaultRegion.getOpportunityDataset(
+  defaultRegion.getSpatialDataset(
     scratchRegion.opportunities.grid.name,
     scratchRegion.opportunities.grid.file
   )

--- a/cypress/models/freeform-dataset.ts
+++ b/cypress/models/freeform-dataset.ts
@@ -1,0 +1,19 @@
+import SpatialDataset from './spatial-data'
+
+export default class FreeformDataset extends SpatialDataset {
+  idField: string
+
+  constructor(
+    parentName: string,
+    name: string,
+    filePath: string,
+    idField = 'id'
+  ) {
+    super(parentName, name, filePath)
+    this.idField = idField
+  }
+
+  _create() {
+    cy.createOpportunityDataset(this.name, this.filePath, true, this.idField)
+  }
+}

--- a/cypress/models/model.ts
+++ b/cypress/models/model.ts
@@ -1,7 +1,7 @@
 type ModelType =
   | 'bundle'
   | 'modification'
-  | 'opportunityDataset'
+  | 'spatialDataset'
   | 'project'
   | 'region'
   | 'regionalAnalysis'

--- a/cypress/models/region.ts
+++ b/cypress/models/region.ts
@@ -7,7 +7,6 @@ import Model from './model'
 import SpatialDataset from './spatial-data'
 import Project from './project'
 import RegionalAnalysis, {RegionalAnalysisOptions} from './regional-analysis'
-import {findDOMNode} from 'react-dom'
 
 type ProjectAnalysisSettings = {
   project?: Project

--- a/cypress/models/regional-analysis.ts
+++ b/cypress/models/regional-analysis.ts
@@ -7,6 +7,7 @@ export type RegionalAnalysisOptions = {
   scenario?: string
   settings?: Record<string, unknown>
   opportunityDatasets?: string[]
+  originPointSet?: string
   cutoffs?: number[]
   percentiles?: number[]
 }

--- a/cypress/models/spatial-data.ts
+++ b/cypress/models/spatial-data.ts
@@ -1,11 +1,15 @@
 import Model from './model'
 
-export default class OpportunityData extends Model {
+export default class SpatialDataset extends Model {
   filePath: string
 
   constructor(parentName: string, name: string, filePath: string) {
-    super(parentName, name, 'opportunityDataset')
+    super(parentName, name, 'spatialDataset')
     this.filePath = filePath
+  }
+
+  _create() {
+    cy.createOpportunityDataset(this.name, this.filePath)
   }
 
   _delete() {
@@ -22,7 +26,7 @@ export default class OpportunityData extends Model {
     cy.navComplete()
     cy.location('href').then((href) => {
       if (!href.match(/.*DatasetId=\w{24}$/)) {
-        cy.createOpportunityDataset(this.name, this.filePath)
+        this._create()
       }
     })
     cy.location('href')

--- a/cypress/support/analysis.ts
+++ b/cypress/support/analysis.ts
@@ -134,6 +134,7 @@ Cypress.Commands.add(
     opportunityDatasets: string[],
     options?: {
       cutoffs?: number[]
+      originPointSet?: string
       percentiles?: number[]
       timeout?: number
     }
@@ -143,6 +144,12 @@ Cypress.Commands.add(
       .click()
 
     cy.findByLabelText(/Regional analysis name/).type(name, {delay: 0})
+
+    if (options?.originPointSet) {
+      cy.findByLabelText(/Origin points/)
+        .click({force: true})
+        .type(`${options.originPointSet}{enter}`)
+    }
 
     opportunityDatasets.forEach((od) => {
       cy.findByLabelText(/Opportunity dataset\(s\)/)

--- a/cypress/support/opportunities.ts
+++ b/cypress/support/opportunities.ts
@@ -1,6 +1,11 @@
 Cypress.Commands.add(
   'createOpportunityDataset',
-  function (name: string, filePath: string): Cypress.Chainable<string> {
+  function (
+    name: string,
+    filePath: string,
+    isFreeform = false,
+    idField = 'id'
+  ): Cypress.Chainable<string> {
     Cypress.log({
       displayName: 'creating',
       message: 'opportunities'
@@ -15,8 +20,17 @@ Cypress.Commands.add(
     })
 
     if (filePath.endsWith('csv')) {
-      cy.findByLabelText(/Latitude/).type('lat')
-      cy.findByLabelText(/Longitude/).type('lon')
+      cy.findByLabelText(/Latitude/)
+        .clear()
+        .type('lat')
+      cy.findByLabelText(/Longitude/)
+        .clear()
+        .type('lon')
+    }
+
+    if (isFreeform) {
+      cy.findByLabelText(/Enable free form/).click({force: true})
+      cy.findByLabelText(/ID field/).type(idField)
     }
 
     cy.findButton(/Upload a new spatial dataset/).click()

--- a/lib/components/analysis/regional.tsx
+++ b/lib/components/analysis/regional.tsx
@@ -243,7 +243,12 @@ export default function Regional(p) {
               &nbsp;&nbsp;Export data
             </MenuButton>
             <MenuList>
-              <MenuItem onClick={_downloadProjectGIS}>GeoTIFF</MenuItem>
+              <MenuItem
+                isDisabled={analysis.request.originPointSetKey != null}
+                onClick={_downloadProjectGIS}
+              >
+                GeoTIFF
+              </MenuItem>
               <MenuItem onClick={_downloadRequestJSON}>
                 Scenario and modification JSON
               </MenuItem>
@@ -266,7 +271,7 @@ export default function Regional(p) {
         projectId={analysis.projectId}
       />
 
-      {isComplete && (
+      {isComplete && analysis?.request?.originPointSetKey == null && (
         <RegionalResults
           analysis={analysis}
           analysisId={analysis._id}

--- a/lib/selectors/comparison-analyses.js
+++ b/lib/selectors/comparison-analyses.js
@@ -12,12 +12,13 @@ export default createSelector(
     regionalAnalyses
       // don't compare incomparable analyses
       .filter(
-        ({_id, zoom, width, height, north, west}) =>
-          activeJobs.findIndex((job) => job.jobId === _id) === -1 &&
-          zoom === analysis.zoom &&
-          width === analysis.width &&
-          height === analysis.height &&
-          north === analysis.north &&
-          west === analysis.west
+        (c) =>
+          activeJobs.findIndex((job) => job.jobId === c._id) === -1 &&
+          c.request.originPointSetKey == null &&
+          c.zoom === analysis.zoom &&
+          c.width === analysis.width &&
+          c.height === analysis.height &&
+          c.north === analysis.north &&
+          c.west === analysis.west
       )
 )

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "@wojtekmaj/enzyme-adapter-react-17": "^0.4.1",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^26.6.1",
-    "cypress": "^6.2.0",
+    "cypress": "^6.5.0",
     "cypress-file-upload": "^4.1.1",
     "cypress-image-snapshot": "^4.0.0",
     "cypress-wait-until": "^1.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2341,6 +2341,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.10.tgz#5958a82e41863cfc71f2307b3748e3491ba03785"
   integrity sha512-J32dgx2hw8vXrSbu4ZlVhn1Nm3GbeCFNw2FWL8S5QKucHGY0cyNwjdQdO+KMBZ4wpmC7KhLCiNsdk1RFRIYUQQ==
 
+"@types/node@12.12.50":
+  version "12.12.50"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.50.tgz#e9b2e85fafc15f2a8aa8fdd41091b983da5fd6ee"
+  integrity sha512-5ImO01Fb8YsEOYpV+aeyGYztcYcjGsBvN4D7G5r1ef2cuQOpymjWNQi5V0rKHE6PC2ru3HkoUr/Br2/8GUA84w==
+
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
@@ -4200,7 +4205,7 @@ cypress-wait-until@^1.7.1:
   resolved "https://registry.yarnpkg.com/cypress-wait-until/-/cypress-wait-until-1.7.1.tgz#3789cd18affdbb848e3cfc1f918353c7ba1de6f8"
   integrity sha512-8DL5IsBTbAxBjfYgCzdbohPq/bY+IKc63fxtso1C8RWhLnQkZbVESyaclNr76jyxfId6uyzX8+Xnt0ZwaXNtkA==
 
-cypress@*, cypress@^6.2.0:
+cypress@*:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-6.2.0.tgz#1a8a7dd5bd08db3064551a9f12072963cc9337bf"
   integrity sha512-m/rkcogYM9MTy8rbsZgyS5wT2L/J+B5V2bY2ztkDNMyqhk/oZgUF4KTWVLzkW2I+scg0iAddca95tLlt7XnAtw==
@@ -4234,6 +4239,52 @@ cypress@*, cypress@^6.2.0:
     log-symbols "^4.0.0"
     minimist "^1.2.5"
     moment "^2.27.0"
+    ospath "^1.2.2"
+    pretty-bytes "^5.4.1"
+    ramda "~0.26.1"
+    request-progress "^3.0.0"
+    supports-color "^7.2.0"
+    tmp "~0.2.1"
+    untildify "^4.0.0"
+    url "^0.11.0"
+    yauzl "^2.10.0"
+
+cypress@^6.5.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-6.5.0.tgz#d853d7a8f915f894249a8788294bfba077278c17"
+  integrity sha512-ol/yTAqHrQQpYBjxLlRSvZf4DOb9AhaQNVlwdOZgJcBHZOOa52/p/6/p3PPcvzjWGOMG6Yq0z4G+jrbWyk/9Dg==
+  dependencies:
+    "@cypress/listr-verbose-renderer" "^0.4.1"
+    "@cypress/request" "^2.88.5"
+    "@cypress/xvfb" "^1.2.4"
+    "@types/node" "12.12.50"
+    "@types/sinonjs__fake-timers" "^6.0.1"
+    "@types/sizzle" "^2.3.2"
+    arch "^2.1.2"
+    blob-util "2.0.2"
+    bluebird "^3.7.2"
+    cachedir "^2.3.0"
+    chalk "^4.1.0"
+    check-more-types "^2.24.0"
+    cli-table3 "~0.6.0"
+    commander "^5.1.0"
+    common-tags "^1.8.0"
+    dayjs "^1.9.3"
+    debug "4.3.2"
+    eventemitter2 "^6.4.2"
+    execa "^4.0.2"
+    executable "^4.1.1"
+    extract-zip "^1.7.0"
+    fs-extra "^9.0.1"
+    getos "^3.2.1"
+    is-ci "^2.0.0"
+    is-installed-globally "^0.3.2"
+    lazy-ass "^1.6.0"
+    listr "^0.14.3"
+    lodash "^4.17.19"
+    log-symbols "^4.0.0"
+    minimist "^1.2.5"
+    moment "^2.29.1"
     ospath "^1.2.2"
     pretty-bytes "^5.4.1"
     ramda "~0.26.1"
@@ -4345,10 +4396,22 @@ dateformat@^3.0.3:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
+dayjs@^1.9.3:
+  version "1.10.4"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.10.4.tgz#8e544a9b8683f61783f570980a8a80eaf54ab1e2"
+  integrity sha512-RI/Hh4kqRc1UKLOAf/T5zdMMX5DQIlDxwUe3wSyMMnEbGunnpENCdbUgM+dW7kXidZqCttBrmw7BhN4TMddkCw==
+
 debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
+  dependencies:
+    ms "2.1.2"
+
+debug@4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
+  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
   dependencies:
     ms "2.1.2"
 
@@ -7866,7 +7929,7 @@ mkdirp@^0.5.1, mkdirp@^0.5.4:
   dependencies:
     minimist "^1.2.5"
 
-moment@^2.27.0:
+moment@^2.27.0, moment@^2.29.1:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==


### PR DESCRIPTION
- Add a Cypress test that creates a regional analysis with a freeform origin point set.
- Prevents errors from displaying when viewing a regional analysis that uses a freeform origin point set. 