### PR TITLE
Fix project back links

### DIFF
--- a/cypress/integration/regional/basic.ts
+++ b/cypress/integration/regional/basic.ts
@@ -78,6 +78,12 @@ describe('Regional', () => {
       //cy.findByLabelText(/Aggregate results to/i)
       //  .type(this.region.aggregationAreas.sampleName+'{enter}')
     })
+
+    it('links to projects correctly', () => {
+      regionalAnalysis.navTo()
+      cy.findByText(region.defaultProject.name).click()
+      cy.findButton(/Create a modification/)
+    })
   })
 
   it('test starting and deleting a running analysis')

--- a/lib/components/analysis/__tests__/__snapshots__/profile-request-display.js.snap
+++ b/lib/components/analysis/__tests__/__snapshots__/profile-request-display.js.snap
@@ -282,18 +282,18 @@ exports[`Component ProfileRequestDisplay snapshot(mount) 1`] = `
                               <ALink
                                 projectId="1"
                                 regionId="1"
-                                to="project"
+                                to="modifications"
                               >
                                 <InternalLink
                                   projectId="1"
                                   regionId="1"
-                                  to="project"
+                                  to="modifications"
                                 >
                                   <Link
-                                    as="/regions/1/projects/1"
+                                    as="/regions/1/projects/1/modifications"
                                     href={
                                       Object {
-                                        "pathname": "/regions/[regionId]/projects/[projectId]",
+                                        "pathname": "/regions/[regionId]/projects/[projectId]/modifications",
                                         "query": Object {},
                                       }
                                     }
@@ -307,7 +307,7 @@ exports[`Component ProfileRequestDisplay snapshot(mount) 1`] = `
                                       }
                                       className=""
                                       color="blue.500"
-                                      href="/regions/1/projects/1"
+                                      href="/regions/1/projects/1/modifications"
                                       onClick={[Function]}
                                       onMouseEnter={[Function]}
                                     >
@@ -333,7 +333,7 @@ exports[`Component ProfileRequestDisplay snapshot(mount) 1`] = `
                                         className=""
                                         color="blue.500"
                                         cursor="pointer"
-                                        href="/regions/1/projects/1"
+                                        href="/regions/1/projects/1/modifications"
                                         onClick={[Function]}
                                         onMouseEnter={[Function]}
                                         outline="none"
@@ -342,7 +342,7 @@ exports[`Component ProfileRequestDisplay snapshot(mount) 1`] = `
                                       >
                                         <a
                                           className=" css-17d37xz"
-                                          href="/regions/1/projects/1"
+                                          href="/regions/1/projects/1/modifications"
                                           onClick={[Function]}
                                           onMouseEnter={[Function]}
                                         >
@@ -359,7 +359,7 @@ exports[`Component ProfileRequestDisplay snapshot(mount) 1`] = `
                                 <div>
                                   <a
                                     class=" css-17d37xz"
-                                    href="/regions/1/projects/1"
+                                    href="/regions/1/projects/1/modifications"
                                   >
                                     Mock Project
                                   </a>

--- a/lib/components/analysis/__tests__/__snapshots__/regional-results.js.snap
+++ b/lib/components/analysis/__tests__/__snapshots__/regional-results.js.snap
@@ -2804,18 +2804,18 @@ exports[`RegionalResults with comparison snapshot(mount) 1`] = `
                                                 <ALink
                                                   projectId="1"
                                                   regionId="1"
-                                                  to="project"
+                                                  to="modifications"
                                                 >
                                                   <InternalLink
                                                     projectId="1"
                                                     regionId="1"
-                                                    to="project"
+                                                    to="modifications"
                                                   >
                                                     <Link
-                                                      as="/regions/1/projects/1"
+                                                      as="/regions/1/projects/1/modifications"
                                                       href={
                                                         Object {
-                                                          "pathname": "/regions/[regionId]/projects/[projectId]",
+                                                          "pathname": "/regions/[regionId]/projects/[projectId]/modifications",
                                                           "query": Object {},
                                                         }
                                                       }
@@ -2829,7 +2829,7 @@ exports[`RegionalResults with comparison snapshot(mount) 1`] = `
                                                         }
                                                         className=""
                                                         color="blue.500"
-                                                        href="/regions/1/projects/1"
+                                                        href="/regions/1/projects/1/modifications"
                                                         onClick={[Function]}
                                                         onMouseEnter={[Function]}
                                                       >
@@ -2855,7 +2855,7 @@ exports[`RegionalResults with comparison snapshot(mount) 1`] = `
                                                           className=""
                                                           color="blue.500"
                                                           cursor="pointer"
-                                                          href="/regions/1/projects/1"
+                                                          href="/regions/1/projects/1/modifications"
                                                           onClick={[Function]}
                                                           onMouseEnter={[Function]}
                                                           outline="none"
@@ -2864,7 +2864,7 @@ exports[`RegionalResults with comparison snapshot(mount) 1`] = `
                                                         >
                                                           <a
                                                             className=" css-17d37xz"
-                                                            href="/regions/1/projects/1"
+                                                            href="/regions/1/projects/1/modifications"
                                                             onClick={[Function]}
                                                             onMouseEnter={[Function]}
                                                           >
@@ -2881,7 +2881,7 @@ exports[`RegionalResults with comparison snapshot(mount) 1`] = `
                                                   <div>
                                                     <a
                                                       class=" css-17d37xz"
-                                                      href="/regions/1/projects/1"
+                                                      href="/regions/1/projects/1/modifications"
                                                     >
                                                       Mock Project
                                                     </a>

--- a/lib/components/analysis/profile-request-display.tsx
+++ b/lib/components/analysis/profile-request-display.tsx
@@ -101,7 +101,7 @@ export default function ProfileRequestDisplay({
                 <Tip label={PROJECT_CHANGE_NOTE}>
                   <div>
                     <ALink
-                      to='project'
+                      to='modifications'
                       projectId={project._id}
                       regionId={project.regionId}
                     >

--- a/pages/regions/[regionId]/projects/[projectId]/index.tsx
+++ b/pages/regions/[regionId]/projects/[projectId]/index.tsx
@@ -42,7 +42,7 @@ const ModificationsPage: any = withInitialFetch(
         dispatch(loadProject(projectId)),
         dispatch(loadModifications(projectId))
       ])
-      const project = results[1]
+      const project = results[0]
       const bundle = await dispatch(loadBundle(project.bundleId))
       return {
         bundle,


### PR DESCRIPTION
They were linking to `/regions/[regionId]/projects/[projectId]` which was breaking. This fixes that page from breaking and also changes the link to `/regions/[regionId]/projects/[projectId]/modifications`.