### PR TITLE
Add a 0th column header

### DIFF
--- a/lib/components/analysis/download-menu.tsx
+++ b/lib/components/analysis/download-menu.tsx
@@ -50,9 +50,9 @@ export default function DownloadMenu({
 
   function downloadOpportunitiesCSV() {
     const header =
-      Array(120)
+      Array(121)
         .fill(0)
-        .map((_, i) => i + 1)
+        .map((_, i) => i)
         .join(',') + '\n'
     const csvContent = getPercentileCurves(store.getState(), isComparison)
       .map((row) => row.join(','))


### PR DESCRIPTION
Access to opportunities CSVs that can be downloaded in the single point analysis mode had a `0`th column but the header started at `1`. This fixes that by adding a 0th header.