### PR TITLE
Limit transfers to 1 character (single digit)

### DIFF
--- a/lib/components/analysis/__tests__/__snapshots__/profile-request-editor.js.snap
+++ b/lib/components/analysis/__tests__/__snapshots__/profile-request-editor.js.snap
@@ -66,7 +66,6 @@ exports[`Components > Analysis > Profile Request Editor should render correctly 
       maxLength={1}
       onChange={[Function]}
       size="md"
-      type="number"
       value={3}
       variant="outline"
     />

--- a/lib/components/analysis/__tests__/__snapshots__/profile-request-editor.js.snap
+++ b/lib/components/analysis/__tests__/__snapshots__/profile-request-editor.js.snap
@@ -63,6 +63,7 @@ exports[`Components > Analysis > Profile Request Editor should render correctly 
       isFullWidth={true}
       isInvalid={false}
       isValid={true}
+      maxLength={1}
       onChange={[Function]}
       size="md"
       type="number"

--- a/lib/components/analysis/profile-request-editor.tsx
+++ b/lib/components/analysis/profile-request-editor.tsx
@@ -254,7 +254,7 @@ export default function ProfileRequestEditor({
         <FormLabel htmlFor={maxTransfersInput.id}>
           {message('analysis.transfers')}
         </FormLabel>
-        <Input {...maxTransfersInput} type='number' maxLength={1} />
+        <Input {...maxTransfersInput} maxLength={1} />
       </FormControl>
 
       {hasTransit && toTime >= TenPM && (

--- a/lib/components/analysis/profile-request-editor.tsx
+++ b/lib/components/analysis/profile-request-editor.tsx
@@ -254,7 +254,7 @@ export default function ProfileRequestEditor({
         <FormLabel htmlFor={maxTransfersInput.id}>
           {message('analysis.transfers')}
         </FormLabel>
-        <Input {...maxTransfersInput} type='number' />
+        <Input {...maxTransfersInput} type='number' maxLength={1} />
       </FormControl>
 
       {hasTransit && toTime >= TenPM && (


### PR DESCRIPTION
The `maxLength` attribute limits the total number of characters allowed to be typed into the input. A min/max number limit only helps with the form validation.