### PR TITLE
Return updated document in db PUTs

### DIFF
--- a/cypress/integration/6-analysis.ts
+++ b/cypress/integration/6-analysis.ts
@@ -240,7 +240,7 @@ describe('Analysis', () => {
   })
 
   describe('presets', () => {
-    it.only('CRUD a preset', function () {
+    it('CRUD a preset', function () {
       region.setupAnalysis()
 
       const name = Cypress.env('dataPrefix') + 'preset'

--- a/cypress/integration/6-analysis.ts
+++ b/cypress/integration/6-analysis.ts
@@ -240,8 +240,11 @@ describe('Analysis', () => {
   })
 
   describe('presets', () => {
-    it('CRUD a preset', function () {
+    it.only('CRUD a preset', function () {
+      region.setupAnalysis()
+
       const name = Cypress.env('dataPrefix') + 'preset'
+      const editedName = Cypress.env('dataPrefix') + 'edited preset name'
       // Preset select does not exist without first creating a preset
       cy.getPrimaryAnalysisSettings()
         .findByRole('button', {name: /Save/})
@@ -266,6 +269,10 @@ describe('Analysis', () => {
       cy.findByRole('button', {name: /Save/}).click()
       cy.findByRole('dialog').should('not.exist')
       cy.findByText(/Saved changes to preset/)
+      cy.getPrimaryAnalysisSettings()
+        .findAllByLabelText(/Active preset/)
+        .click({force: true})
+        .type(`${editedName}{enter}`)
 
       // Delete the preset
       cy.getPrimaryAnalysisSettings()

--- a/lib/components/presets.tsx
+++ b/lib/components/presets.tsx
@@ -40,19 +40,24 @@ const getId = fpGet('_id')
 const getOptionLabel = fpGet('name')
 
 // For input validation
-const hasName = (n) => n && n.length > 0
+const hasName = (n?: string) => n?.length > 0
 
 /**
  * Presets contain many more parameters than we use in the UI. Only check the ones from there.
  */
-function findPreset(settings, presets = []) {
+function findPreset(
+  settings: Record<string, unknown>,
+  presets: CL.Preset[] = []
+) {
   return presets.find(
     ({profileRequest}) =>
       Object.keys(profileRequest).find((k) => {
-        if (typeof profileRequest[k] === 'number') {
-          return !isWithinTolerance(profileRequest[k], settings[k])
+        const v = profileRequest[k]
+        const s = settings[k]
+        if (typeof v === 'number' && typeof s === 'number') {
+          return !isWithinTolerance(v, s)
         }
-        return !isEqual(profileRequest[k], settings[k])
+        return !isEqual(v, s)
       }) == null
   )
 }
@@ -62,7 +67,7 @@ type Props = {
   currentSettings: Record<string, unknown>
   isDisabled: boolean
   isComparison?: boolean
-  onChange: (any) => void
+  onChange: (preset: Record<string, unknown>) => void
   regionId: string
 }
 
@@ -85,7 +90,7 @@ export default memo<Props>(function PresetChooser({
   const createPresetAction = useDisclosure()
   const editPresetAction = useDisclosure()
   const removeAction = useDisclosure()
-  const [selectedPreset, setSelectedPreset] = useState()
+  const [selectedPreset, setSelectedPreset] = useState<CL.Preset>()
 
   // ID to differentiate between primary and comparison
   const id = 'select-preset-' + isComparison
@@ -193,13 +198,13 @@ export default memo<Props>(function PresetChooser({
             options={presets as any}
             onChange={_selectPreset}
             placeholder='Select a preset'
-            value={selectedPreset}
+            value={selectedPreset as any}
           />
         ) : (
           <Alert status='info'>Save presets to be used later.</Alert>
         )}
       </div>
-      {presetsCollection.response.error && (
+      {presetsCollection.error && (
         <FormErrorMessage>Error loading presets.</FormErrorMessage>
       )}
 

--- a/lib/db/authenticated-collection.ts
+++ b/lib/db/authenticated-collection.ts
@@ -131,6 +131,9 @@ export default class AuthenticatedCollection {
           nonce: new ObjectID().toString(),
           updatedBy: this.user.email
         }
+      },
+      {
+        returnOriginal: false // return the updated document
       }
     )
   }

--- a/lib/hooks/use-collection.ts
+++ b/lib/hooks/use-collection.ts
@@ -19,6 +19,7 @@ interface UseCollection extends ConfigInterface {
 type UseCollectionResponse<T> = {
   create: (properties: T) => Promise<SafeResponse>
   data: T[]
+  error?: Error
   remove: (_id: string) => Promise<SafeResponse>
   response: responseInterface<T[], ResponseError>
   update: (_id: string, newProperties: Partial<T>) => Promise<SafeResponse>
@@ -108,6 +109,7 @@ export function createUseCollection<T extends CL.IModel>(
     return {
       create,
       data: response.data,
+      error: response.error?.error,
       remove,
       response,
       update


### PR DESCRIPTION
The original document is returned by default, this change adds the `returnOriginal: false` option to db PUTs in the JavaScript API. 

Fixes #1472 
