### PR TITLE
Ignore stops without coordinates

### DIFF
--- a/lib/utils/get-stop-near-point.ts
+++ b/lib/utils/get-stop-near-point.ts
@@ -19,16 +19,21 @@ export default function getStopNearPoint(
   let closestStopDistance = Infinity
   let closestStop: null | GTFS.Stop = null
   for (const stop of allStops) {
-    const stopDistance = turfDistance(
-      clickPoint,
-      turfPoint([stop.stop_lon, stop.stop_lat])
-    )
     if (
-      stopDistance < maxDistanceKilometers &&
-      stopDistance < closestStopDistance
+      stop.stop_lat &&
+      stop.stop_lon
     ) {
-      closestStopDistance = stopDistance
-      closestStop = stop
+      const stopDistance = turfDistance(
+        clickPoint,
+        turfPoint([stop.stop_lon, stop.stop_lat])
+      )
+      if (
+        stopDistance < maxDistanceKilometers &&
+        stopDistance < closestStopDistance
+      ) {
+        closestStopDistance = stopDistance
+        closestStop = stop
+      }
     }
   }
 

--- a/lib/utils/get-stop-near-point.ts
+++ b/lib/utils/get-stop-near-point.ts
@@ -19,10 +19,7 @@ export default function getStopNearPoint(
   let closestStopDistance = Infinity
   let closestStop: null | GTFS.Stop = null
   for (const stop of allStops) {
-    if (
-      stop.stop_lat &&
-      stop.stop_lon
-    ) {
+    if (stop.stop_lat && stop.stop_lon) {
       const stopDistance = turfDistance(
         clickPoint,
         turfPoint([stop.stop_lon, stop.stop_lat])


### PR DESCRIPTION
Addresses #1497 in alignment editing. Are we aware of other places where missing stop_lat/stop_lon values will trigger errors?

## How to test

1. Create an add-trip modification for a bundle with a recent MBTA feed. Ensure the alignment can be drawn successfully, specifically that clicking on the map adds a stop and does not trigger a console error.
