### PR TITLE
Refactor geocoder to work without react-select

### DIFF
--- a/cypress/integration/0-regions.ts
+++ b/cypress/integration/0-regions.ts
@@ -9,7 +9,7 @@ const getEast = () => cy.findByLabelText(/East bound/)
 const getWest = () => cy.findByLabelText(/West bound/)
 const getCreate = () => cy.findButton(/Set up a new region/)
 const getSave = () => cy.findButton(/Save changes/)
-const getSearch = () => cy.get('#geocoder')
+const getSearch = () => cy.findByTitle(/Search map/)
 
 /**
  * Scratch region
@@ -17,7 +17,7 @@ const getSearch = () => cy.get('#geocoder')
 const regionData = {
   description: 'Cypress stratch testing region',
   searchTerm: 'covington kentucky',
-  foundName: 'Covington, Kentucky, United States',
+  foundName: /^Covington$/,
   north: 39.1199,
   south: 38.9268,
   east: -84.3592,
@@ -102,19 +102,26 @@ describe('Regions', () => {
     const testLocations = [
       {
         searchTerm: 'cincinnati ohio usa',
-        findText: /^Cincinnati, Ohio/,
+        findText: /^Cincinnati$/,
         coord: [39.1, -84.5]
       },
       {
         searchTerm: 'tulsa oklahoma usa',
-        findText: /^Tulsa, Oklahoma/,
+        findText: /^Tulsa$/,
         coord: [36.1, -95.9]
       }
     ]
     const maxOffset = 10000 // meters
     testLocations.forEach((r) => {
-      getSearch().focus().clear().type(r.searchTerm)
-      cy.findByText(r.findText).click()
+      getSearch().click()
+
+      cy.findByPlaceholderText(/Search map/)
+        .click()
+        .focus()
+        .clear()
+        .type(r.searchTerm)
+
+      cy.findAllByText(r.findText).first().click()
       cy.mapCenteredOn(r.coord as L.LatLngTuple, maxOffset)
     })
 
@@ -124,8 +131,16 @@ describe('Regions', () => {
     getName().type(regionName)
     getDesc().type(regionData.description)
     // search for region by name
-    getSearch().focus().clear().type(regionData.searchTerm)
-    cy.findByText(regionData.foundName).click()
+    getSearch().click()
+
+    cy.findByPlaceholderText(/Search map/)
+      .click()
+      .focus()
+      .clear()
+      .type(regionData.searchTerm)
+
+    cy.findAllByText(regionData.foundName).first().click()
+
     cy.mapCenteredOn(regionData.center, 10000)
     // Enter exact coordinates
     getNorth()

--- a/lib/components/map/geocoder.tsx
+++ b/lib/components/map/geocoder.tsx
@@ -148,7 +148,12 @@ export default function GeocoderPopper({
         {({onClose}) => (
           <>
             <PopoverTrigger>
-              <Button colorScheme='blue' shadow='xl' isDisabled={isDisabled}>
+              <Button
+                colorScheme='blue'
+                isDisabled={isDisabled}
+                shadow='lg'
+                title='Search map'
+              >
                 <SearchIcon />
               </Button>
             </PopoverTrigger>

--- a/lib/components/map/geocoder.tsx
+++ b/lib/components/map/geocoder.tsx
@@ -1,74 +1,173 @@
+import {
+  Box,
+  Button,
+  Input,
+  InputGroup,
+  InputLeftElement,
+  InputRightElement,
+  Popover,
+  PopoverBody,
+  PopoverContent,
+  PopoverTrigger,
+  Portal,
+  PortalManager,
+  Spinner,
+  Stack,
+  Text
+} from '@chakra-ui/react'
 import lonlat from '@conveyal/lonlat'
-import type {LatLngBoundsExpression} from 'leaflet'
-import fpGet from 'lodash/fp/get'
-import {CSSProperties, useCallback} from 'react'
-import Select from 'react-select/async'
+import type {LatLngBoundsExpression, Map} from 'leaflet'
+import {RefObject, useEffect, useRef, useState} from 'react'
+import {useLeaflet} from 'react-leaflet'
 
+import {POPOVER_Z} from 'lib/constants/z-index'
 import mapboxSearch, {MapboxFeature} from 'lib/utils/mapbox-search'
 
-import {selectStyles} from '../select'
+import {SearchIcon} from '../icons'
 
-const geocoderStyle: CSSProperties = {
-  position: 'absolute',
-  top: '10px',
-  left: '10px',
-  width: '296px',
-  zIndex: 1000
-}
-
-const getPlaceName = fpGet('place_name')
-const getId = fpGet('id')
+type OnResultsFn = (r: MapboxFeature, map: Map) => void
 
 type GeocoderProps = {
   isDisabled?: boolean
-  map: void | L.Map
+  onChange?: OnResultsFn
 }
 
-export default function Geocoder({isDisabled, map}: GeocoderProps) {
-  const panToResult = useCallback(
-    (r: MapboxFeature) => {
-      if (r && map) {
-        if (r.bbox) {
-          const [west, south, east, north] = r.bbox
-          const bounds: LatLngBoundsExpression = [
-            [south, west],
-            [north, east]
-          ]
-          map.fitBounds(bounds)
-        } else {
-          map.setView([r.center[1], r.center[0]], 19)
-        }
-        map.fire('geocode', r)
-      }
-    },
-    [map]
-  )
+const panToResult: OnResultsFn = (r, map) => {
+  if (r && map) {
+    if (r.bbox) {
+      const [west, south, east, north] = r.bbox
+      const bounds: LatLngBoundsExpression = [
+        [south, west],
+        [north, east]
+      ]
+      map.fitBounds(bounds)
+    } else {
+      map.setView([r.center[1], r.center[0]], 19)
+    }
+    map.fire('geocode', r)
+  }
+}
 
-  const searchWithProximity = useCallback(
-    (t: string, callback) => {
+const subText = (m: MapboxFeature) => {
+  const firstComma = m.place_name.indexOf(',')
+  if (firstComma > 0) {
+    return m.place_name.substr(firstComma + 2)
+  } else {
+    return m.place_name
+  }
+}
+
+export function GeocoderSearch({
+  inputRef,
+  onChange
+}: {
+  inputRef: RefObject<HTMLInputElement>
+  onChange: OnResultsFn
+}) {
+  const {map} = useLeaflet()
+  const [isLoading, setIsLoading] = useState(false)
+  const [search, setSearch] = useState('')
+  const [results, setResults] = useState<MapboxFeature[]>([])
+  const center = map?.getCenter()
+  const proximityStr = center ? lonlat.toString(center) : ''
+
+  useEffect(() => {
+    if (search && search.length > 3) {
+      setIsLoading(true)
       mapboxSearch(
-        t,
+        search,
         {
-          proximity: map ? lonlat.toString(map.getCenter()) : ''
+          proximity: proximityStr
         },
-        callback
+        (results) => {
+          setIsLoading(false)
+          setResults(results)
+        }
       )
-    },
-    [map]
-  )
+    }
+  }, [proximityStr, search])
 
   return (
-    <div style={geocoderStyle}>
-      <Select
-        inputId='geocoder'
-        isDisabled={isDisabled}
-        getOptionLabel={getPlaceName}
-        getOptionValue={getId}
-        loadOptions={searchWithProximity}
-        onChange={panToResult}
-        placeholder='Search map...'
-        styles={selectStyles}
-      />
-    </div>
+    <Stack spacing={0}>
+      <InputGroup>
+        <InputLeftElement mt={1}>
+          <SearchIcon />
+        </InputLeftElement>
+        <Input
+          onChange={(e) => setSearch(e.currentTarget.value)}
+          placeholder='Search map'
+          ref={inputRef}
+          size='lg'
+          value={search}
+          variant='flushed'
+        />
+        <InputRightElement>{isLoading && <Spinner />}</InputRightElement>
+      </InputGroup>
+      {results.map((r) => (
+        <Box
+          key={r.id}
+          cursor='pointer'
+          onClick={() => onChange(r, map)}
+          px={3}
+          py={2}
+          _hover={{
+            bg: 'blue.500',
+            color: 'white'
+          }}
+          rounded={0}
+          fontSize='lg'
+          textAlign='left'
+          title={r.place_name}
+        >
+          <Text
+            fontWeight='bold'
+            overflowX='hidden'
+            textOverflow='ellipsis'
+            whiteSpace='nowrap'
+          >
+            {r.place_name.split(',')[0]}
+          </Text>
+          <Text overflowX='hidden' textOverflow='ellipsis' whiteSpace='nowrap'>
+            {subText(r)}
+          </Text>
+        </Box>
+      ))}
+    </Stack>
+  )
+}
+
+export default function GeocoderPopper({
+  isDisabled,
+  onChange = panToResult
+}: GeocoderProps) {
+  const initialFocusRef = useRef()
+
+  return (
+    <PortalManager zIndex={POPOVER_Z}>
+      <Popover initialFocusRef={initialFocusRef} isLazy placement='left'>
+        {({onClose}) => (
+          <>
+            <PopoverTrigger>
+              <Button colorScheme='blue' shadow='xl' isDisabled={isDisabled}>
+                <SearchIcon />
+              </Button>
+            </PopoverTrigger>
+            <Portal>
+              <PopoverContent shadow='lg'>
+                <PopoverBody p={0}>
+                  <GeocoderSearch
+                    inputRef={initialFocusRef}
+                    onChange={(r, map) => {
+                      onChange(r, map)
+                      onClose()
+                    }}
+                  />
+                </PopoverBody>
+              </PopoverContent>
+            </Portal>
+          </>
+        )}
+      </Popover>
+    </PortalManager>
   )
 }

--- a/lib/components/map/index.tsx
+++ b/lib/components/map/index.tsx
@@ -1,13 +1,15 @@
+import {Button, Stack, useColorModeValue} from '@chakra-ui/react'
 import set from 'lodash/set'
 import dynamic from 'next/dynamic'
 import {useEffect, useRef, useState} from 'react'
 import {
   AttributionControl,
   Map as LeafletMap,
-  Viewport,
-  ZoomControl
+  useLeaflet,
+  Viewport
 } from 'react-leaflet'
 import {useSelector} from 'react-redux'
+import MapControl from 'react-leaflet-control'
 
 import useRouteChanging from 'lib/hooks/use-route-changing'
 import selectModificationSaveInProgress from 'lib/selectors/modification-save-in-progress'
@@ -15,7 +17,7 @@ import selectRegionBounds from 'lib/selectors/region-bounds'
 import {getParsedItem, stringifyAndSet} from 'lib/utils/local-storage'
 
 import Geocoder from './geocoder'
-import {useColorModeValue} from '@chakra-ui/color-mode'
+import {AddIcon, MinusIcon} from '../icons'
 
 const MapboxGLLayer = dynamic(() => import('./mapbox-gl'))
 
@@ -31,6 +33,38 @@ const lightStyle =
   process.env.NEXT_PUBLIC_MAPBOX_STYLE ?? 'conveyal/cjwu7oipd0bf41cqqv15huoim'
 const darkStyle = 'conveyal/cklwkj6g529qi17nydq56jn9k'
 const getStyle = (style: string) => `mapbox://styles/${style}`
+
+function Controls({isDisabled}) {
+  const {map} = useLeaflet()
+
+  return (
+    <MapControl position='topright'>
+      <Stack>
+        <Stack spacing={0}>
+          <Button
+            colorScheme='blue'
+            isDisabled={isDisabled}
+            onClick={() => map.zoomIn()}
+            roundedBottom={0}
+            shadow='lg'
+          >
+            <AddIcon />
+          </Button>
+          <Button
+            colorScheme='blue'
+            isDisabled={isDisabled}
+            onClick={() => map.zoomOut()}
+            roundedTop={0}
+            shadow='lg'
+          >
+            <MinusIcon />
+          </Button>
+        </Stack>
+        <Geocoder isDisabled={isDisabled} />
+      </Stack>
+    </MapControl>
+  )
+}
 
 export default function Map({children, setLeafletContext}) {
   const style = useColorModeValue(lightStyle, darkStyle)
@@ -108,15 +142,11 @@ export default function Map({children, setLeafletContext}) {
         )}
 
         <AttributionControl position='bottomright' prefix={false} />
-        <ZoomControl position='topright' />
+
+        <Controls isDisabled={routeChanging || saveInProgress} />
 
         {!routeChanging && children ? children : null}
       </LeafletMap>
-
-      <Geocoder
-        isDisabled={routeChanging || saveInProgress}
-        map={leafletMapRef.current?.leafletElement}
-      />
     </>
   )
 }

--- a/lib/utils/mapbox-search.ts
+++ b/lib/utils/mapbox-search.ts
@@ -1,5 +1,4 @@
 import throttle from 'lodash/throttle'
-import get from 'lodash/get'
 import {stringify} from 'querystring'
 
 import {MB_TOKEN} from 'lib/constants'
@@ -10,12 +9,20 @@ const PATH = '/geocoding/v5/mapbox.places'
 const getURL = (s: string, q: string) =>
   `${BASE_URL}${PATH}/${encodeURIComponent(s)}.json?${q}`
 
+type Context = {
+  id: string
+  text: string
+}
+
 /**
  * Mapbox adds properties to a normal featuer.
  * https://docs.mapbox.com/api/search/#geocoding-response-object
  */
 export interface MapboxFeature extends GeoJSON.Feature {
   center: [number, number] // lon/lat
+  context: Context[]
+  place_name: string
+  text: string
 }
 
 type SearchCallback = (features: MapboxFeature[]) => void
@@ -28,7 +35,7 @@ export default throttle(function mapboxSearch(
   options = {},
   cb: SearchCallback
 ) {
-  if (get(s, 'length') < 3) return cb([])
+  if (s == null || s.length < 3) return cb([])
 
   const querystring = stringify({
     access_token: MB_TOKEN,


### PR DESCRIPTION
Additionally, this allows us to put the geocoder manually onto the page to more directly control what occurs on a geocoder select. For example, on the Analysis Page we most likely want the marker location to be updated.

<img width="380" alt="Screen Shot 2021-03-08 at 16 16 42" src="https://user-images.githubusercontent.com/776780/110389140-155bf400-8032-11eb-8fd1-537e662211ea.png">
