### PR TITLE
Fix the logout link

### DIFF
--- a/lib/constants/index.ts
+++ b/lib/constants/index.ts
@@ -63,9 +63,9 @@ export const Pages = {
   analysis: '/regions/[regionId]/analysis',
   regionalAnalyses: '/regions/[regionId]/regional',
   regionalAnalysis: '/regions/[regionId]/regional/[analysisId]',
-  login: '/api/login',
-  logout: '/api/logout',
-  authCallback: '/api/callback',
+  login: '/api/auth/login',
+  logout: '/api/auth/logout',
+  authCallback: '/api/auth/callback',
   resources: '/regions/[regionId]/resources',
   resourceUpload: '/regions/[regionId]/resources/upload',
   resourceEdit: '/regions/[regionId]/resources/[resourceId]'


### PR DESCRIPTION
When we updated the Auth0 libraries last week the logout link changed to `/api/auth/logout` but I forgot to update it.