### PR TITLE
Fix Regional Analysis Link

### DIFF
--- a/lib/components/running-analysis.tsx
+++ b/lib/components/running-analysis.tsx
@@ -7,7 +7,7 @@ import Bolts from './worker-bolts'
 
 // Round everything above a million
 const toSI = format('.4~s')
-const roundToSI = (n) => (n < 1000000 ? n : toSI(n))
+const roundToSI = (n: number) => (n < 1000000 ? n : toSI(n))
 
 export default function RunningAnalysis({job, ...p}) {
   const complete = job.complete
@@ -18,9 +18,11 @@ export default function RunningAnalysis({job, ...p}) {
       <Flex align='flex-start' justify='space-between'>
         <Heading size='sm'>
           <ALink
-            analysisId={job.jobId}
-            regionId={job.regionalAnalysis.regionId}
             to='regionalAnalyses'
+            query={{
+              analysisId: job.jobId,
+              regionId: job.regionalAnalysis.regionId
+            }}
           >
             {job.regionalAnalysis.name}
           </ALink>


### PR DESCRIPTION
Error was introduced when we refactored the `ALink` component. Note: if the file was TypeScript originally it would've caught the error.

fixes #1514 