### PR TITLE
Remove double tool tips

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -116,9 +116,7 @@ Cypress.Commands.add('navTo', (menuItemTitle) => {
   // and wait until at least part of the page is loaded.
   const page = navToPages[title]
   // click the menu item
-  cy.get('#sidebar', unlog)
-    .findByRole('button', {name: RegExp(title, 'i')})
-    .click(unlog)
+  cy.get('#sidebar', unlog).findByLabelText(RegExp(title, 'i')).click(unlog)
   // Ensure the pathname has updated to the correct path
   cy.location('pathname', unlog).should('match', page.path, unlog)
   // check that page loads at least some content

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -116,7 +116,7 @@ Cypress.Commands.add('navTo', (menuItemTitle) => {
   // and wait until at least part of the page is loaded.
   const page = navToPages[title]
   // click the menu item
-  cy.get('#sidebar', unlog).findByLabelText(RegExp(title, 'i')).click(unlog)
+  cy.get('#sidebar', unlog).findButton(RegExp(title, 'i')).click(unlog)
   // Ensure the pathname has updated to the correct path
   cy.location('pathname', unlog).should('match', page.path, unlog)
   // check that page loads at least some content

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -116,7 +116,9 @@ Cypress.Commands.add('navTo', (menuItemTitle) => {
   // and wait until at least part of the page is loaded.
   const page = navToPages[title]
   // click the menu item
-  cy.get('#sidebar', unlog).findButton(RegExp(title, 'i')).click(unlog)
+  cy.get('#sidebar', unlog).within(() => {
+    cy.findButton(RegExp(title, 'i')).click(unlog)
+  })
   // Ensure the pathname has updated to the correct path
   cy.location('pathname', unlog).should('match', page.path, unlog)
   // check that page loads at least some content

--- a/lib/components/sidebar.tsx
+++ b/lib/components/sidebar.tsx
@@ -98,7 +98,7 @@ const ItemLink = memo<ItemLinkProps>(({children, label, to, params = {}}) => {
   return (
     <Tip isDisabled={isActive} label={label} placement='right'>
       <div>
-        <NavItemContents {...navItemProps} role='button'>
+        <NavItemContents {...navItemProps} aria-label={label} role='button'>
           {children}
         </NavItemContents>
       </div>

--- a/lib/components/sidebar.tsx
+++ b/lib/components/sidebar.tsx
@@ -98,7 +98,7 @@ const ItemLink = memo<ItemLinkProps>(({children, label, to, params = {}}) => {
   return (
     <Tip isDisabled={isActive} label={label} placement='right'>
       <div>
-        <NavItemContents {...navItemProps} role='button' title={label}>
+        <NavItemContents {...navItemProps} role='button'>
           {children}
         </NavItemContents>
       </div>


### PR DESCRIPTION
Our tooltip provides a label. The html title tag can be removed which shows up slower. `aria-label` is still there for screen reading (if that would ever be necessary other than for test tools).

closes #1516 