### PR TITLE
Clock drift compensation and property name changes

### DIFF
--- a/lib/components/task-list.tsx
+++ b/lib/components/task-list.tsx
@@ -6,6 +6,7 @@ import {
   Stack,
   StackDivider
 } from '@chakra-ui/react'
+import dateSubtract from 'date-fns/sub'
 import formatDistanceToNow from 'date-fns/formatDistanceToNow'
 import {useEffect, useState} from 'react'
 
@@ -39,16 +40,10 @@ function getColor(task: CL.Task): string {
 function getTime(task: CL.Task): string {
   switch (task.state) {
     case 'ACTIVE':
-      return task.timeBegan != null
-        ? secondsToHhMmSsString(
-            Math.floor((Date.now() - task.timeBegan) / 1_000)
-          )
-        : ''
+      return secondsToHhMmSsString(Math.floor((Date.now() - task.startTime) / 1_000))
     case 'DONE':
     case 'ERROR':
-      return task.timeCompleted != null
-        ? formatDistanceToNow(task.timeCompleted, {addSuffix: true})
-        : ''
+      return formatDistanceToNow(dateSubtract(Date.now(), {seconds: task.secondsComplete}), {addSuffix: true})
   }
 }
 
@@ -80,12 +75,12 @@ function getLinkParams(workProduct: CL.TaskWorkProduct) {
     case 'BUNDLE':
       return {
         bundleId: workProduct.id,
-        regionId: workProduct.region
+        regionId: workProduct.regionId
       }
     case 'REGIONAL_ANALYSIS':
       return {
         regionalAnalysisId: workProduct.id,
-        regionId: workProduct.region
+        regionId: workProduct.regionId
       }
   }
 }

--- a/lib/components/task-list.tsx
+++ b/lib/components/task-list.tsx
@@ -40,10 +40,15 @@ function getColor(task: CL.Task): string {
 function getTime(task: CL.Task): string {
   switch (task.state) {
     case 'ACTIVE':
-      return secondsToHhMmSsString(Math.floor((Date.now() - task.startTime) / 1_000))
+      return secondsToHhMmSsString(
+        Math.floor((Date.now() - task.startTime) / 1_000)
+      )
     case 'DONE':
     case 'ERROR':
-      return formatDistanceToNow(dateSubtract(Date.now(), {seconds: task.secondsComplete}), {addSuffix: true})
+      return formatDistanceToNow(
+        dateSubtract(Date.now(), {seconds: task.secondsComplete}),
+        {addSuffix: true}
+      )
   }
 }
 

--- a/lib/hooks/use-activity.ts
+++ b/lib/hooks/use-activity.ts
@@ -106,13 +106,12 @@ const taskReducer: Reducer<State, Actions> = (state, action) => {
           previousData: action.data,
           // TODO: filter out active tasks that no longer exist on the backend in case of an error.
           tasks: unionById(action.data.taskProgress, state.tasks)
-                  .filter(
-                    (t) => !state.hiddenTaskIds.includes(t.id)
-                  )
-                  .map(t => {
-                      if (t.state != 'ACTIVE' || t.startTime) return t;
-                      else return { ...t, startTime: Date.now() - (t.secondsActive * 1_000) }
-                  }),
+            .filter((t) => !state.hiddenTaskIds.includes(t.id))
+            .map((t) => {
+              if (t.state != 'ACTIVE' || t.startTime) return t
+              else
+                return {...t, startTime: Date.now() - t.secondsActive * 1_000}
+            }),
           // Speed up the refresh interval when the data has changed
           refreshInterval: FAST_REFRESH_INTERVAL_MS
         })

--- a/lib/hooks/use-activity.ts
+++ b/lib/hooks/use-activity.ts
@@ -105,9 +105,14 @@ const taskReducer: Reducer<State, Actions> = (state, action) => {
           ...state,
           previousData: action.data,
           // TODO: filter out active tasks that no longer exist on the backend in case of an error.
-          tasks: unionById(action.data.taskProgress, state.tasks).filter(
-            (t) => !state.hiddenTaskIds.includes(t.id)
-          ),
+          tasks: unionById(action.data.taskProgress, state.tasks)
+                  .filter(
+                    (t) => !state.hiddenTaskIds.includes(t.id)
+                  )
+                  .map(t => {
+                      if (t.state != 'ACTIVE' || t.startTime) return t;
+                      else return { ...t, startTime: Date.now() - (t.secondsActive * 1_000) }
+                  }),
           // Speed up the refresh interval when the data has changed
           refreshInterval: FAST_REFRESH_INTERVAL_MS
         })

--- a/lib/mocks/tasks.ts
+++ b/lib/mocks/tasks.ts
@@ -3,8 +3,8 @@ const activeTask: CL.Task = {
   id: '1',
   percentComplete: 50,
   state: 'ACTIVE',
-  timeBegan: Date.now() - 60_000,
-  timeCompleted: -1,
+  secondsActive: 60,
+  secondsComplete: 0,
   title: 'Active task'
 }
 
@@ -13,11 +13,12 @@ const erroredTask: CL.Task = {
   detail: 'Error message from a task',
   id: '2',
   state: 'ERROR',
-  timeCompleted: Date.now(),
+  secondsActive: 30,
+  secondsComplete: 0,
   title: 'Errored Task',
   workProduct: {
     id: 'bundleId',
-    region: 'regionId',
+    regionId: 'regionId',
     type: 'BUNDLE'
   }
 }

--- a/types/conveyal.d.ts
+++ b/types/conveyal.d.ts
@@ -227,7 +227,7 @@ declare namespace CL {
 
   export type TaskWorkProduct = {
     id: string
-    region: string
+    regionId: string
     type: 'BUNDLE' | 'REGIONAL_ANALYSIS'
   }
 
@@ -236,8 +236,9 @@ declare namespace CL {
     id: string
     percentComplete: number
     state: TaskState
-    timeBegan?: number
-    timeCompleted?: number
+    startTime?: number
+    secondsActive: number
+    secondsComplete: number
     title: string
     workProduct?: TaskWorkProduct
   }


### PR DESCRIPTION
As discussed recently, we have no guarantee that the server's clock is in sync with the client machine's clock. Especially since we're tracking tasks that may take significantly less than a minute, using absolute times reported by the server risks displaying durations that are negative or start well above zero. 

This PR derives a startTime field known to be accurate on the client machine from relative durations reported on the API. I may be breaking some conventions in the way I did this, feel free to push additional changes. This just serves as an example of the idea.

This PR is relative to`status-reporting` but branches off before the recent merge from `dev`, which seems to have broken a filename selector.