### PR TITLE
Update Cypress test to reflect new feed naming

### DIFF
--- a/cypress/fixtures/regions/scratch.json
+++ b/cypress/fixtures/regions/scratch.json
@@ -4,7 +4,7 @@
   "PBFfile": "regions/nky/streets.osm.pbf",
   "GTFSfile": "regions/nky/TANK-GTFS.zip",
   "corruptGTFSfile": "regions/nky/null-GTFS.zip",
-  "feedAgencyName": "Transit Authority of Northern Kentucky",
+  "feedAgencyName": "Transit Authority of Northern Kentucky: 2019-10-31 to 2020-08-27",
   "sampleRouteName": "Southbank Shuttle",
   "searchTerm": "covington",
   "foundName": "Covington, Kentucky, United States",


### PR DESCRIPTION
https://github.com/conveyal/r5/pull/715 adds start/end dates to feed names shown when viewing bundles