### PR TITLE
Fix horizontal scrolling and status page logo

### DIFF
--- a/lib/components/banner-alert.tsx
+++ b/lib/components/banner-alert.tsx
@@ -7,8 +7,7 @@ export default function BannerAlert({children, ...p}: AlertProps) {
     <Alert
       alignItems='center'
       justifyContent='center'
-      maxWidth='100%'
-      width='100vw'
+      width='100%'
       zIndex={POPOVER_Z}
       {...p}
     >

--- a/pages/status.tsx
+++ b/pages/status.tsx
@@ -25,7 +25,7 @@ export default function Status() {
       <Stack spacing={10} width='50rem'>
         <Flex justify='space-between'>
           <Heading size='2xl'>Status</Heading>
-          <Image display='inline-block' size='45px' src='/logo.svg' />
+          <Image display='inline-block' boxSize={45} src='/logo.svg' />
         </Flex>
         <ALink to='regions'>← Back to the application</ALink>
         <Divider />


### PR DESCRIPTION
- Horizontal scroll bar was still appearing after the last attempt to fix it, this change removes the use of `vw` entirely.
- Uses the correct `boxSize` attribute for the logo on the status page (not `size`)