### PR TITLE
Increase modification auto-save debounce from 10 to 30 seconds

### DIFF
--- a/lib/components/modification/editor.tsx
+++ b/lib/components/modification/editor.tsx
@@ -44,8 +44,8 @@ import JSONEditor from './json-editor'
 import ModificationType from './type'
 import Variants from './variants'
 
-// Debounce the update function for five seconds
-const DEBOUNCE_MS = 10 * 1000
+// Debounce the update function for thirty seconds
+const DEBOUNCE_MS = 30_000
 
 // Shortened version
 const hasOwnProperty = (o, p) => Object.prototype.hasOwnProperty.call(o, p)


### PR DESCRIPTION
It was noticed on slow connections that the debounce occurred frequently enough to disrupt a normal workflow. This triples the normal auto-save interval while maintaining the save functionality (auto-save on an interval and when leaving the page).
