### PR TITLE
Fix r5 version warning

### DIFF
--- a/lib/modules/r5-version/components/selector.tsx
+++ b/lib/modules/r5-version/components/selector.tsx
@@ -26,7 +26,7 @@ const _isValidNewOption = (newOption) => {
 }
 
 const _promptTextCreator = (label) =>
-  message('r5Version.customWarningVersion', {
+  message('r5Version.customVersionWarning', {
     version: label
   })
 


### PR DESCRIPTION
## How to test

1. Type a custom version in the selector
2. Ensure a warning message appears
