### PR TITLE
Get R5 jar from Github Packages

### DIFF
--- a/.github/workflows/lint-jest-build.yml
+++ b/.github/workflows/lint-jest-build.yml
@@ -112,24 +112,31 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v2
+      - name: Set Up Node
+        uses: actions/setup-node@v2
         with:
           node-version: '12'
+      
       # Install / cache dependencies with Cypress to handle caching Cypress binary.
-      - uses: actions/checkout@v2
-      - uses: cypress-io/github-action@v2
+      - name: Check out analysis-ui
+        uses: actions/checkout@v2
+
+      - name: Install Cypress
+        uses: cypress-io/github-action@v2
         with:
           # just perform install
           runTests: false
 
       # Restore entire .next folder from previous job
-      - uses: actions/cache@v2
+      - name: Cache .next folder
+        uses: actions/cache@v2
         with:
           path: ${{ github.workspace }}/.next
           key: ${{ runner.os }}-${{ github.sha }}-nextjs
 
       # Restore maven dependencies (including those used by dependency:get) from previous runs
-      - uses: actions/cache@v2
+      - name: Cache local Maven repo
+        uses: actions/cache@v2
         with:
           path: ${{ github.workspace }}/.m2/repository
           key: ${{ runner.os }}-${{ github.sha }}-mavenrepo
@@ -140,14 +147,15 @@ jobs:
       # We replace the GITHUB_TOKEN environment variables with a custom generated token with wider scope.
       # The repository URL is defined in a minimal POM file because dependency:get allows adding repositories
       # on the command line, but dependency:copy does not and will fail to copy artifacts not from central.
-      - uses: actions/setup-java@v1
+      - name: Set up Java (and Maven settings.xml)
+        uses: actions/setup-java@v1
         with:
           java-version: 11
           server-id: r5ghpr
           server-username: GHPR_USER # name of env variable for server user
           server-password: GHPR_TOKEN # name of env variable for server password
 
-      - name: Get r5 jar from GHPR
+      - name: Fetch r5 jar from GH Packages
         run: |
           mvn dependency:copy -Dartifact=com.conveyal:r5:$r5version:jar:all -Dtransitive=false -DoutputDirectory=${{ github.workspace }}
         env:

--- a/.github/workflows/lint-jest-build.yml
+++ b/.github/workflows/lint-jest-build.yml
@@ -122,11 +122,17 @@ jobs:
           # just perform install
           runTests: false
 
-      # Restore entire .next folder from previous step
+      # Restore entire .next folder from previous job
       - uses: actions/cache@v2
         with:
           path: ${{ github.workspace }}/.next
           key: ${{ runner.os }}-${{ github.sha }}-nextjs
+
+      # Restore maven dependencies (including those used by dependency:get) from previous runs
+      - uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/.m2/repository
+          key: ${{ runner.os }}-${{ github.sha }}-mavenrepo
 
       # Fetch R5 .jar file from Github Packages
       # The setup-java action also creates a Maven settings.xml configured for Github packages.
@@ -141,7 +147,7 @@ jobs:
 
       - run: |
           mvn dependency:get -Dartifact=com.conveyal:r5:$R5_VERSION:jar:all -DremoteRepositories=r5-ghpr::::https://maven.pkg.github.com/conveyal/r5
-          mvn dependency:copy -Dartifact=com.conveyal:r5:${R5_VERSION}:jar:all -DoutputDirectory=${{ github.workspace }}
+          mvn dependency:copy -Dartifact=com.conveyal:r5:$R5_VERSION:jar:all -DoutputDirectory=${{ github.workspace }}
         env:
           GHPR_USER: ${{ secrets.GHPR_USER }}
           GHPR_TOKEN: ${{ secrets.GHPR_TOKEN }}
@@ -152,6 +158,7 @@ jobs:
         with:
           path: ~/.cache/Cypress
           key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package.json') }}
+
       # Install Cypress binary
       - run: npx cypress install
 

--- a/.github/workflows/lint-jest-build.yml
+++ b/.github/workflows/lint-jest-build.yml
@@ -3,8 +3,105 @@ name: 'Install, lint, unit test, build, run Cypress tests'
 on: [pull_request]
 
 jobs:
+  install:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '12'
+      - uses: actions/checkout@v2
+
+      # Install and cache the build
+      - uses: bahmutov/npm-install@v1
+        env:
+          # Setting to 0 skips installing the binary
+          CYPRESS_INSTALL_BINARY: 0
+
+      # Cache the entire working directory for subsequent steps
+      - uses: actions/cache@v2
+        with:
+          path: ./*
+          key: ${{ github.sha }}
+
+  typeCheck:
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '12'
+      - uses: actions/cache@v2
+        with:
+          path: ./*
+          key: ${{ github.sha }}
+
+      - run: yarn tsc
+
+  codeLinter:
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '12'
+      - uses: actions/cache@v2
+        with:
+          path: ./*
+          key: ${{ github.sha }}
+
+      - run: yarn lint
+      - run: yarn check-format
+
+  jestUnitTests:
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '12'
+      - uses: actions/cache@v2
+        with:
+          path: ./*
+          key: ${{ github.sha }}
+
+      - run: yarn jest
+        env:
+          CI: true
+
+  # Keep separate from
+  nextjsBuild:
+    runs-on: ubuntu-latest
+    needs: install
+    steps:
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '12'
+      - uses: actions/cache@v2
+        with:
+          path: ./*
+          key: ${{ github.sha }}
+
+      # Cache the next.js cache folder per os/dependency change
+      - uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/.next/cache
+          key: ${{ runner.os }}-nextjs-cache-${{ hashFiles('**/yarn.lock') }}
+
+      - run: yarn build
+        env:
+          NEXT_PUBLIC_BASEMAP_DISABLED: true
+          NEXT_PUBLIC_CYPRESS: true
+          NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
+
+      # Cache entire .next folder for subsequent steps
+      - uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/.next
+          key: ${{ runner.os }}-${{ github.sha }}-nextjs
+
   cypressIntegration:
     # needs: [codeLinter, jestUnitTests, nextjsBuild, typeCheck] # only run if these all pass
+    needs: install
     services:
       mongo:
         image: mongo

--- a/.github/workflows/lint-jest-build.yml
+++ b/.github/workflows/lint-jest-build.yml
@@ -100,7 +100,8 @@ jobs:
           key: ${{ runner.os }}-${{ github.sha }}-nextjs
 
   cypressIntegration:
-    needs: [codeLinter, jestUnitTests, nextjsBuild, typeCheck] # only run if these all pass
+    # needs: [codeLinter, jestUnitTests, nextjsBuild, typeCheck] # only run if these all pass
+    needs: install
     services:
       mongo:
         image: mongo
@@ -129,17 +130,21 @@ jobs:
 
       # Fetch R5 .jar file from Github Packages
       # The setup-java action also creates a Maven settings.xml configured for Github packages.
-      # However, each GH repo has its own Maven repo, so we may need separate credentials to access R5 repo.
+      # The GITHUB_TOKEN is scoped to only this repo, so does not allow access to R5 Github Packages.
+      # We replace the GITHUB_TOKEN environment variables with a custom generated token with wider scope.
       - uses: actions/setup-java@v1
         with:
           java-version: 11
+          server-id: r5-ghpr
+          server-username: GHPR_USER # name of env variable for server user
+          server-password: GHPR_TOKEN # name of env variable for server password
 
       - run: |
-          mvn dependency:get -Dartifact=com.conveyal:r5:$R5_VERSION:jar:all -DremoteRepositories=https://maven.pkg.github.com/conveyal/r5
+          mvn dependency:get -Dartifact=com.conveyal:r5:$R5_VERSION:jar:all -DremoteRepositories=r5-ghpr::::https://maven.pkg.github.com/conveyal/r5
           mvn dependency:copy -Dartifact=com.conveyal:r5:${R5_VERSION}:jar:all -DoutputDirectory=${{ github.workspace }}
         env:
-          GITHUB_ACTOR: ${{ secrets.GHPR_USER }}
-          GITHUB_TOKEN: ${{ secrets.GHPR_TOKEN }}
+          GHPR_USER: ${{ secrets.GHPR_USER }}
+          GHPR_TOKEN: ${{ secrets.GHPR_TOKEN }}
 
       - name: Cache Cypress
         id: cache-cypress

--- a/.github/workflows/lint-jest-build.yml
+++ b/.github/workflows/lint-jest-build.yml
@@ -107,7 +107,7 @@ jobs:
         ports:
           - 27017:27017
     env:
-      r5Version: v6.2-11-ge8b0fcf
+      R5_VERSION: v6.4
 
     runs-on: ubuntu-latest
     steps:
@@ -127,12 +127,18 @@ jobs:
           path: ${{ github.workspace }}/.next
           key: ${{ runner.os }}-${{ github.sha }}-nextjs
 
+      # Fetch R5 .jar file from Github Packages
+      # The setup-java action also creates a Maven settings.xml configured for Github packages.
+      # However, each GH repo has its own Maven repo, so we may need separate credentials to access R5 repo.
       - uses: actions/setup-java@v1
         with:
           java-version: 11
 
-      - name: Download Analysis Backend
-        run: curl https://r5-builds.s3-eu-west-1.amazonaws.com/${{ env.r5Version }}.jar --output ${{ github.workspace }}/${{ env.r5Version }}.jar
+      - run: |
+          mvn dependency:get -Dartifact=com.conveyal:r5:$R5_VERSION:jar:all -DremoteRepositories=https://maven.pkg.github.com/conveyal/r5
+          mvn dependency:copy -Dartifact=com.conveyal:r5:${R5_VERSION}:jar:all -DoutputDirectory=${{ github.workspace }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Cypress
         id: cache-cypress

--- a/.github/workflows/lint-jest-build.yml
+++ b/.github/workflows/lint-jest-build.yml
@@ -100,8 +100,7 @@ jobs:
           key: ${{ runner.os }}-${{ github.sha }}-nextjs
 
   cypressIntegration:
-    # needs: [codeLinter, jestUnitTests, nextjsBuild, typeCheck] # only run if these all pass
-    needs: install
+    needs: [codeLinter, jestUnitTests, nextjsBuild, typeCheck] # only run if these all pass
     services:
       mongo:
         image: mongo
@@ -116,7 +115,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '12'
-      
+
       # Install / cache dependencies with Cypress to handle caching Cypress binary.
       - name: Check out analysis-ui
         uses: actions/checkout@v2

--- a/.github/workflows/lint-jest-build.yml
+++ b/.github/workflows/lint-jest-build.yml
@@ -138,7 +138,7 @@ jobs:
           mvn dependency:get -Dartifact=com.conveyal:r5:$R5_VERSION:jar:all -DremoteRepositories=https://maven.pkg.github.com/conveyal/r5
           mvn dependency:copy -Dartifact=com.conveyal:r5:${R5_VERSION}:jar:all -DoutputDirectory=${{ github.workspace }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GHPR_TOKEN }}
 
       - name: Cache Cypress
         id: cache-cypress

--- a/.github/workflows/lint-jest-build.yml
+++ b/.github/workflows/lint-jest-build.yml
@@ -138,6 +138,7 @@ jobs:
           mvn dependency:get -Dartifact=com.conveyal:r5:$R5_VERSION:jar:all -DremoteRepositories=https://maven.pkg.github.com/conveyal/r5
           mvn dependency:copy -Dartifact=com.conveyal:r5:${R5_VERSION}:jar:all -DoutputDirectory=${{ github.workspace }}
         env:
+          GITHUB_ACTOR: ${{ secrets.GHPR_USER }}
           GITHUB_TOKEN: ${{ secrets.GHPR_TOKEN }}
 
       - name: Cache Cypress

--- a/.github/workflows/lint-jest-build.yml
+++ b/.github/workflows/lint-jest-build.yml
@@ -41,6 +41,8 @@ jobs:
       # The setup-java action also creates a Maven settings.xml configured for Github packages.
       # The GITHUB_TOKEN is scoped to only this repo, so does not allow access to R5 Github Packages.
       # We replace the GITHUB_TOKEN environment variables with a custom generated token with wider scope.
+      # The repository URL is defined in a minimal POM file because dependency:get allows adding repositories
+      # on the command line, but dependency:copy does not and will fail to copy artifacts not from central.
       - uses: actions/setup-java@v1
         with:
           java-version: 11
@@ -48,14 +50,12 @@ jobs:
           server-username: GHPR_USER # name of env variable for server user
           server-password: GHPR_TOKEN # name of env variable for server password
 
-      - run: |
-          mvn dependency:get $MVN_ARTIFACT $MVN_REPO 
-          mvn dependency:copy $MVN_ARTIFACT $MVN_REPO -DoutputDirectory=${{ github.workspace }}
+      - name: Get r5 jar from GHPR
+        run: |
+          mvn dependency:copy -Dartifact=com.conveyal:r5:$r5version:jar:all -Dtransitive=false -DoutputDirectory=${{ github.workspace }}
         env:
           GHPR_USER: ${{ secrets.GHPR_USER }}
           GHPR_TOKEN: ${{ secrets.GHPR_TOKEN }}
-          MVN_ARTIFACT: -Dartifact=com.conveyal:r5:${{ env.r5version }}:jar:all -Dtransitive=false
-          MVN_REPO: -DremoteRepositories=r5ghpr::::https://maven.pkg.github.com/conveyal/r5
 
       - name: Cache Cypress
         id: cache-cypress

--- a/.github/workflows/lint-jest-build.yml
+++ b/.github/workflows/lint-jest-build.yml
@@ -11,7 +11,7 @@ jobs:
         ports:
           - 27017:27017
     env:
-      R5_VERSION: v6.4
+      r5version: v6.4
 
     runs-on: ubuntu-latest
     steps:
@@ -44,16 +44,18 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: 11
-          server-id: r5-ghpr
+          server-id: r5ghpr
           server-username: GHPR_USER # name of env variable for server user
           server-password: GHPR_TOKEN # name of env variable for server password
 
       - run: |
-          mvn dependency:get -Dartifact=com.conveyal:r5:$R5_VERSION:jar:all -Dtransitive=false -DremoteRepositories=r5-ghpr::::https://maven.pkg.github.com/conveyal/r5
-          mvn dependency:copy -Dartifact=com.conveyal:r5:$R5_VERSION:jar:all -DoutputDirectory=${{ github.workspace }}
+          mvn dependency:get $MVN_ARTIFACT $MVN_REPO 
+          mvn dependency:copy $MVN_ARTIFACT $MVN_REPO -DoutputDirectory=${{ github.workspace }}
         env:
           GHPR_USER: ${{ secrets.GHPR_USER }}
           GHPR_TOKEN: ${{ secrets.GHPR_TOKEN }}
+          MVN_ARTIFACT: -Dartifact=com.conveyal:r5:${{ env.r5version }}:jar:all -Dtransitive=false
+          MVN_REPO: -DremoteRepositories=r5ghpr::::https://maven.pkg.github.com/conveyal/r5
 
       - name: Cache Cypress
         id: cache-cypress

--- a/.github/workflows/lint-jest-build.yml
+++ b/.github/workflows/lint-jest-build.yml
@@ -154,7 +154,7 @@ jobs:
 
       - name: Fetch r5 jar from GH Packages
         run: |
-          mvn dependency:copy -B -Dartifact=com.conveyal:r5:$r5version:jar:all -Dtransitive=false -DoutputDirectory=${{ github.workspace }}/analysis-ui
+          mvn dependency:copy -B -Dartifact=com.conveyal:r5:$r5version:jar:all -Dtransitive=false -DoutputDirectory=${{ github.workspace }}
         env:
           GHPR_USER: ${{ secrets.GHPR_USER }}
           GHPR_TOKEN: ${{ secrets.GHPR_TOKEN }}

--- a/.github/workflows/lint-jest-build.yml
+++ b/.github/workflows/lint-jest-build.yml
@@ -154,7 +154,7 @@ jobs:
 
       - name: Fetch r5 jar from GH Packages
         run: |
-          mvn dependency:copy -Dartifact=com.conveyal:r5:$r5version:jar:all -Dtransitive=false -DoutputDirectory=${{ github.workspace }}/analysis-ui
+          mvn dependency:copy -B -Dartifact=com.conveyal:r5:$r5version:jar:all -Dtransitive=false -DoutputDirectory=${{ github.workspace }}/analysis-ui
         env:
           GHPR_USER: ${{ secrets.GHPR_USER }}
           GHPR_TOKEN: ${{ secrets.GHPR_TOKEN }}

--- a/.github/workflows/lint-jest-build.yml
+++ b/.github/workflows/lint-jest-build.yml
@@ -3,105 +3,8 @@ name: 'Install, lint, unit test, build, run Cypress tests'
 on: [pull_request]
 
 jobs:
-  install:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '12'
-      - uses: actions/checkout@v2
-
-      # Install and cache the build
-      - uses: bahmutov/npm-install@v1
-        env:
-          # Setting to 0 skips installing the binary
-          CYPRESS_INSTALL_BINARY: 0
-
-      # Cache the entire working directory for subsequent steps
-      - uses: actions/cache@v2
-        with:
-          path: ./*
-          key: ${{ github.sha }}
-
-  typeCheck:
-    runs-on: ubuntu-latest
-    needs: install
-    steps:
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '12'
-      - uses: actions/cache@v2
-        with:
-          path: ./*
-          key: ${{ github.sha }}
-
-      - run: yarn tsc
-
-  codeLinter:
-    runs-on: ubuntu-latest
-    needs: install
-    steps:
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '12'
-      - uses: actions/cache@v2
-        with:
-          path: ./*
-          key: ${{ github.sha }}
-
-      - run: yarn lint
-      - run: yarn check-format
-
-  jestUnitTests:
-    runs-on: ubuntu-latest
-    needs: install
-    steps:
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '12'
-      - uses: actions/cache@v2
-        with:
-          path: ./*
-          key: ${{ github.sha }}
-
-      - run: yarn jest
-        env:
-          CI: true
-
-  # Keep separate from
-  nextjsBuild:
-    runs-on: ubuntu-latest
-    needs: install
-    steps:
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '12'
-      - uses: actions/cache@v2
-        with:
-          path: ./*
-          key: ${{ github.sha }}
-
-      # Cache the next.js cache folder per os/dependency change
-      - uses: actions/cache@v2
-        with:
-          path: ${{ github.workspace }}/.next/cache
-          key: ${{ runner.os }}-nextjs-cache-${{ hashFiles('**/yarn.lock') }}
-
-      - run: yarn build
-        env:
-          NEXT_PUBLIC_BASEMAP_DISABLED: true
-          NEXT_PUBLIC_CYPRESS: true
-          NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
-
-      # Cache entire .next folder for subsequent steps
-      - uses: actions/cache@v2
-        with:
-          path: ${{ github.workspace }}/.next
-          key: ${{ runner.os }}-${{ github.sha }}-nextjs
-
   cypressIntegration:
     # needs: [codeLinter, jestUnitTests, nextjsBuild, typeCheck] # only run if these all pass
-    needs: install
     services:
       mongo:
         image: mongo
@@ -146,7 +49,7 @@ jobs:
           server-password: GHPR_TOKEN # name of env variable for server password
 
       - run: |
-          mvn dependency:get -Dartifact=com.conveyal:r5:$R5_VERSION:jar:all -DremoteRepositories=r5-ghpr::::https://maven.pkg.github.com/conveyal/r5
+          mvn dependency:get -Dartifact=com.conveyal:r5:$R5_VERSION:jar:all -Dtransitive=false -DremoteRepositories=r5-ghpr::::https://maven.pkg.github.com/conveyal/r5
           mvn dependency:copy -Dartifact=com.conveyal:r5:$R5_VERSION:jar:all -DoutputDirectory=${{ github.workspace }}
         env:
           GHPR_USER: ${{ secrets.GHPR_USER }}

--- a/.github/workflows/lint-jest-build.yml
+++ b/.github/workflows/lint-jest-build.yml
@@ -17,7 +17,7 @@ jobs:
           # Setting to 0 skips installing the binary
           CYPRESS_INSTALL_BINARY: 0
 
-      # Cache the entire working directory for subsequent steps
+      # Cache the entire working directory for subsequent jobs
       - uses: actions/cache@v2
         with:
           path: ./*
@@ -68,7 +68,6 @@ jobs:
         env:
           CI: true
 
-  # Keep separate from
   nextjsBuild:
     runs-on: ubuntu-latest
     needs: install
@@ -93,7 +92,7 @@ jobs:
           NEXT_PUBLIC_CYPRESS: true
           NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
 
-      # Cache entire .next folder for subsequent steps
+      # Cache entire .next folder for subsequent jobs
       - uses: actions/cache@v2
         with:
           path: ${{ github.workspace }}/.next
@@ -126,15 +125,14 @@ jobs:
           # just perform install
           runTests: false
 
-      # Restore entire .next folder from previous job
-      - name: Cache .next folder
+      - name: Restore .next folder from nextjsBuild
         uses: actions/cache@v2
         with:
           path: ${{ github.workspace }}/.next
           key: ${{ runner.os }}-${{ github.sha }}-nextjs
 
       # Restore maven dependencies (including those used by dependency:get) from previous runs
-      - name: Cache local Maven repo
+      - name: Restore local Maven repo
         uses: actions/cache@v2
         with:
           path: ${{ github.workspace }}/.m2/repository
@@ -156,7 +154,7 @@ jobs:
 
       - name: Fetch r5 jar from GH Packages
         run: |
-          mvn dependency:copy -Dartifact=com.conveyal:r5:$r5version:jar:all -Dtransitive=false -DoutputDirectory=${{ github.workspace }}
+          mvn dependency:copy -Dartifact=com.conveyal:r5:$r5version:jar:all -Dtransitive=false -DoutputDirectory=${{ github.workspace }}/analysis-ui
         env:
           GHPR_USER: ${{ secrets.GHPR_USER }}
           GHPR_TOKEN: ${{ secrets.GHPR_TOKEN }}

--- a/analysis.properties
+++ b/analysis.properties
@@ -1,6 +1,7 @@
 # When offline is true, authentication and other services are not used.
 # This is only partially true - regional results will still be saved on S3.
 offline=true
+immediate-shutdown=false
 
 # Auth0 authentication configuration. The values will be ignored when configuration option offline=true.
 auth0-client-id=X
@@ -10,8 +11,8 @@ auth0-secret=Y
 # Access group for administrators
 admin-access-group=OFFLINE
 
-# The host and port of the remote Mongo server (if any). Comment out for local Mongo instance.
-# database-uri=mongodb://127.0.0.1:27017
+# The host and port of the Mongo server.
+database-uri=mongodb://127.0.0.1:27017
 
 # The name of the database in the Mongo instance.
 database-name=analysis

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,17 @@
+<!-- This Maven POM file is not used for building analysis-ui itself. -->
+<!-- It only specifies the repo where we will find jars used in testing. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.conveyal</groupId>
+  <artifactId>analysis-ui</artifactId>
+  <version>0.0</version>
+  <packaging>pom</packaging>
+  <repositories>
+    <repository>
+      <id>r5ghpr</id>
+      <name>Github Packages R5 Repo</name>
+      <url>https://maven.pkg.github.com/conveyal/r5</url>
+    </repository>
+  </repositories>
+</project>


### PR DESCRIPTION
## Purpose

This PR grabs the specified version of R5 from Github Packages and runs the Cypress tests against it.

Recently we set up Github Packages, which provides one Maven-style repo per Github repo. This allows our other projects to use development builds of R5 as dependencies without going through an external Maven repo; using the Central repo introduces a lot of extra lag time and effort (artifact signing, slow connections etc.)

Previously we were uploading shadow jars (jar containing all dependencies) on every commit of R5 to a particular bucket on S3. With Github Packages configured, the copies on S3 seem redundant, so we stopped uploading those jars to S3 and this mechanism is now deprecated (used only for fetching old worker versions).

## Background

This is now working but turned out to be tricker than expected. I'll summarize some information unearthed while working on this for future reference.

In Github Actions, the setup-java action is used to install the JVM. Its documentation explains that it also creates a Maven settings.xml file supplying credentials for Github Packages (which are substituted in from environment variables). In Maven the credentials are supplied in settings.xml and associated with a repository ID, but the repository url is attached to that ID in the project's POM file. 

It is important but not very well documented that every Github repo has its own sandboxed Maven repository in Packages, at its own unique base URL. This is different than traditional Maven repos which contain artifacts from many different projects, often from large numbers of different organizations. The GITHUB_TOKEN supplied to actions does not have permissions to read any other project's Maven repo. Therefore you have to generate a _personal_ access token (PAT) and supply it to the actions via repository secrets. Even then you must also supply one or more separate GHPR repo URLs since every Github repo has its own separate Maven repo URL. Using the PAT is somewhat of a hack since these tokens are personal - they act as a user rather than a repo or organization. Enough people are complaining about this that hopefully they'll eventually add a checkbox to allow the GITHUB_TOKEN read access to the whole organization's GH Packages Maven repos.

This whole system is somewhat bizarre since the whole purpose of Maven repos  is to make multiple different artifacts available for use by each other as dependencies. My sense from forums is that there's a lot of demand for organization-wide GHPR repos, and they're just keeping them sandboxed until they work out all the security implications.

Once the permissions and URLs are sorted out, you then need to piece together the command to fetch the jar, which is not obvious. The `mvn dependency:get` plugin action ("mojo") will fetch an artifact from a remote repo into the local repo. This command allows you to specify the remote repo on the command line, but stores the files in a Maven internal cache in a hidden directory under the home directory which we ideally shouldn't access directly.

The `mvn dependency:copy` plugin can apparently then be used to copy the artifact from the local repository to a specified directory, but I could never get this to work. It always says this artifact is not available on Maven Central. This non-availability is recorded in the local cache. Even though the jar file you're trying to copy has been placed in that same cache by `dependency:get`, it came from a non-Central repo so Maven pretends it doesn't exist. Unlike `dependency:get`, `dependency:copy` does not accept repository URLs or IDs on the command line, so you apparently have to make a basic POM file to inform Maven you accept artifacts from Packages instead of Central. Once you have this POM in place you don't even need the `dependency:get` (which is mostly useful because it avoids making a POM). The `dependency:copy` will fetch the jar into the local cache as needed, then copy it to your specified directory. 

Taking all that into account, we get a reasonably compact few lines to fetch the jar. 

## Future 

It's good to know how to achieve this and have the tests working on current dev builds of R5. However it's way too tricky for my taste, and it's still using shadow jars which are themselves a hack. What we should really be doing is either A) eliminate the shadow jar inside Github Packages and package r5 and all its dependencies in a zip, stashing those zips somewhere outside Github Packages, or B) asking Maven to download the non-shadow r5 jar and all transitive dependencies as individual files, and cacheing the whole local maven repo in ~/.m2 between CI runs.