### PR TITLE
Set updatedAt / createdAt to match r5 models

### DIFF
--- a/lib/db/authenticated-collection.ts
+++ b/lib/db/authenticated-collection.ts
@@ -80,8 +80,10 @@ export default class AuthenticatedCollection {
       _id: new ObjectID().toString(),
       accessGroup: this.accessGroup,
       nonce: new ObjectID().toString(),
+      createdAt: new Date(),
       createdBy: this.user.email,
-      updatedBy: this.user.email
+      updatedBy: this.user.email,
+      updatedAt: new Date()
     })
   }
 
@@ -144,7 +146,8 @@ export default class AuthenticatedCollection {
         $set: {
           ...omitImmutable(newValues),
           nonce: new ObjectID().toString(),
-          updatedBy: this.user.email
+          updatedBy: this.user.email,
+          updatedAt: new Date()
         }
       },
       {


### PR DESCRIPTION
`updatedAt` specifically was accidentally being overwritten with a `number` when updates occurred from the frontend. 