### PR TITLE
When the Java API responds with a 401 or 403, log the user out

### DIFF
--- a/lib/components/activity-provider.tsx
+++ b/lib/components/activity-provider.tsx
@@ -10,14 +10,15 @@ import {ActivityContext, useActivitySync} from 'lib/hooks/use-activity'
  * API and to automatically log out the user, requiring them to log in again.
  */
 export default function ActivityProvider({children}) {
-  const res = useActivitySync()
+  const activity = useActivitySync()
   const router = useRouter()
 
   // Redirect if there is a 401 or 403 response to an activity request
-  const {error} = res.response
+  const {error} = activity.response
   useEffect(() => {
     if (
       error &&
+      error.response &&
       (error.response.status === 401 || error.response.status === 403)
     ) {
       router.push('/api/auth/logout')
@@ -25,6 +26,8 @@ export default function ActivityProvider({children}) {
   }, [error, router])
 
   return (
-    <ActivityContext.Provider value={res}>{children}</ActivityContext.Provider>
+    <ActivityContext.Provider value={activity}>
+      {children}
+    </ActivityContext.Provider>
   )
 }

--- a/lib/components/activity-provider.tsx
+++ b/lib/components/activity-provider.tsx
@@ -1,9 +1,30 @@
+import {useRouter} from 'next/router'
+import {useEffect} from 'react'
+
 import {ActivityContext, useActivitySync} from 'lib/hooks/use-activity'
 
+/**
+ * The Activity Provider wraps the entire application so that any component can call the `useActivity` hook to
+ * get the latest activity information. The activity API is requested on each page load and re-requested at a set
+ * interval. Therefore this provides an entry point to handle Unauthorized or Forbidden responses from the
+ * API and to automatically log out the user, requiring them to log in again.
+ */
 export default function ActivityProvider({children}) {
+  const res = useActivitySync()
+  const router = useRouter()
+
+  // Redirect if there is a 401 or 403 response to an activity request
+  const {error} = res.response
+  useEffect(() => {
+    if (
+      error &&
+      (error.response.status === 401 || error.response.status === 403)
+    ) {
+      router.push('/api/auth/logout')
+    }
+  }, [error, router])
+
   return (
-    <ActivityContext.Provider value={useActivitySync()}>
-      {children}
-    </ActivityContext.Provider>
+    <ActivityContext.Provider value={res}>{children}</ActivityContext.Provider>
   )
 }

--- a/lib/components/api-status-bar.tsx
+++ b/lib/components/api-status-bar.tsx
@@ -36,10 +36,19 @@ const NotOnline = () => (
   </BannerAlert>
 )
 
-const Unauthorized = () => (
+const NoUser = () => (
   <BannerAlert status='error' variant='solid'>
     <AlertIcon />
     <AlertTitle>You must be logged in to use Conveyal.</AlertTitle>
+  </BannerAlert>
+)
+
+const Unauthorized = () => (
+  <BannerAlert status='error' variant='solid'>
+    <AlertIcon />
+    <AlertTitle>
+      Unauthorized or expired access. Redirecting user to login again...
+    </AlertTitle>
   </BannerAlert>
 )
 
@@ -60,8 +69,12 @@ export default function APIStatusBar() {
   }, [isValidating])
 
   if (isOnline) {
-    if (!userResponse.isLoading && !userResponse.user) return <Unauthorized />
-    if (error) return <NoAPI />
+    if (!userResponse.isLoading && !userResponse.user) return <NoUser />
+    if (error) {
+      const status = error.response?.status
+      if (status === 401 || status === 403) return <Unauthorized />
+      return <NoAPI />
+    }
     if (isValidating && showIsValidating) return <IsValidating />
   } else if (error || showIsValidating) return <NotOnline />
   return null

--- a/lib/utils/safe-fetch.ts
+++ b/lib/utils/safe-fetch.ts
@@ -5,6 +5,7 @@ export interface ResponseError {
   data?: unknown
   error: Error
   problem: string
+  response?: Response
 }
 
 export interface ResponseOk<T> extends Response {
@@ -103,10 +104,10 @@ export async function safeFetch<T>(
       }
     } else {
       return {
-        ...res,
         error: new Error(await parseErrorMessageFromResponse(res)),
         ok: false,
-        problem: getProblemFromResponse(res)
+        problem: getProblemFromResponse(res),
+        response: res
       }
     }
   } catch (e: unknown) {

--- a/lib/with-auth.tsx
+++ b/lib/with-auth.tsx
@@ -30,7 +30,7 @@ const DevBar = () => (
       bg='red.500'
       height='1px'
       position='absolute'
-      width='100vw'
+      width='100%'
       zIndex={10000}
     />
   </>


### PR DESCRIPTION
This PR forces a log out if the Java API responds with a 401 or 403 response. We were experiencing cases where the id token expired at a different rate than the client session. This should help mitigate user's having issues with this.